### PR TITLE
[WIP] power_distribution: place outlet_banks; assign to boxes

### DIFF
--- a/script/power_distribution/calculate_line_lengths.rb
+++ b/script/power_distribution/calculate_line_lengths.rb
@@ -62,8 +62,21 @@ def ethernet_cable_lengths(graph:, boxes:)
   cable_lengths
 end
 
+def ac_power_cable_lengths(graph:, boxes:)
+  cable_lengths = []
+
+  boxes.each do |box|
+    length = min_distance_between_vertices_in_feet(graph, box.vertex.id, box.outlet_bank.vertex.id)
+    length += AC_POWER_WIGGLE_FEET
+
+    cable_lengths << length
+  end
+
+  cable_lengths
+end
+
 def bucket_cable_lengths(cable_lengths)
-  buckets = [5, 10, 15, 20, 25, 30]
+  buckets = [5, 10, 15, 20, 25, 30, 35, 40, 45, 50]
 
   bucketed_cables = buckets.map { |i| [i, 0] }.to_h
 

--- a/script/power_distribution/constants.rb
+++ b/script/power_distribution/constants.rb
@@ -5,3 +5,16 @@ MAX_CHANNELS_PER_CONTROLLER = 8
 EXPECTED_TOTAL_CONTROLLER_COUNT = 49
 PANEL_TYPE_LIT = 'lit'
 PANEL_TYPE_SOLID = 'solid'
+
+AC_POWER_OUTLET_BANKS = 4
+# At each vertex, there's a bank of 20 outlets. Each pair of outlets
+# is on one circuit, so we need to ensure there's no more than one
+# junction box per circuit.
+AC_POWER_OUTLET_BANK_VERTICES = [25, 26, 69, 75]
+
+# Power outlet banks aren't actually at vertices. They're off to either side
+# (port or starboard) of the generator and ice lounge. So, call that 6 feet
+# offset from the vertex we've assigned it to. Past that, add another 6 feet
+# as wiggle room. We can always cut these cables down to length later, and
+# extra length is not the end of the world.
+AC_POWER_WIGGLE_FEET = 12

--- a/script/power_distribution/junction_box.rb
+++ b/script/power_distribution/junction_box.rb
@@ -8,6 +8,7 @@ class JunctionBox
       JunctionBoxCircuit.new(id: "#{id}-#{i}", junction_box: self)
     end
     @controllers = []
+    @outlet_bank = nil
   end
 
   def calculate_id
@@ -58,7 +59,7 @@ class JunctionBox
     controllers.push(controller)
   end
 
-  attr_accessor :controllers, :circuits, :vertex, :id
+  attr_accessor :outlet_bank, :controllers, :circuits, :vertex, :id
 end
 
 class JunctionBoxCircuit

--- a/script/power_distribution/outlet_bank.rb
+++ b/script/power_distribution/outlet_bank.rb
@@ -1,0 +1,122 @@
+require 'csv'
+
+require './calculate_line_lengths'
+require './junction_box'
+
+# OutletBank is a bank of 110V AC power outlets coming from the generator.
+# Each pair of outlets is on a shared 15A fuse.
+class OutletBank
+  NUMBER_OF_CIRCUITS = 10
+
+  def initialize(vertex:)
+    @vertex = vertex
+    @id = vertex.id
+
+    @circuits = (0..NUMBER_OF_CIRCUITS).map do |i|
+      OutletBankCircuit.new(id: "C#{self.id}-#{i}", outlet_bank: self)
+    end
+  end
+
+  def decorated_id
+    "O#{@id}"
+  end
+
+  def has_any_available_circuits?
+    circuits.any? { |c| c.outlets.none? { |outlet| outlet.assigned? } }
+  end
+
+  def assign_junction_box_to_open_circuit(junction_box:)
+    if !has_any_available_circuits?
+      raise "no available circuits; logic error"
+    end
+
+    circuits.select { |c| c.outlets.none? { |outlet| outlet.assigned? } }.first.outlets.first.assign_junction_box(junction_box: junction_box)
+  end
+
+  def self.load_outlet_banks(vertices:)
+    bank = {}
+    AC_POWER_OUTLET_BANK_VERTICES.map do |v|
+      outlet_bank_vertex = vertices.find { |vertex_id, vertex| vertex_id == v }[1]
+
+      bank[v] = OutletBank.new(vertex: outlet_bank_vertex)
+    end
+    bank
+  end
+
+  def self.assign_junction_boxes_to_outlet_banks(graph:, outlet_banks:, junction_boxes:)
+    junction_boxes.each do |_, boxes|
+      # Multiple boxes may be at each vertex depending upon nearby power needs.
+      boxes.each do |box|
+        shortest_eligible_distance_to_box_from_outlet_bank = 999999
+        nearest_eligible_outlet_bank = nil
+
+        outlet_banks.each do |_, outlet_bank|
+          min_distance = min_distance_between_vertices_in_feet(graph, outlet_bank.vertex.id, box.vertex.id)
+
+          if min_distance < shortest_eligible_distance_to_box_from_outlet_bank && outlet_bank.has_any_available_circuits?
+            shortest_eligible_distance_to_box_from_outlet_bank = min_distance
+            nearest_eligible_outlet_bank = outlet_bank
+          end
+        end
+
+        if nearest_eligible_outlet_bank.nil?
+          raise "no eligible outlet banks; logic error"
+        end
+
+        nearest_eligible_outlet_bank.assign_junction_box_to_open_circuit(junction_box: box)
+      end
+    end
+  end
+  
+  # TODO: reflect when we need an extension cord too
+  def cable_distance_to_junction_box()
+  end
+
+  attr_accessor :id, :vertex, :circuits
+
+  private
+
+end
+
+class OutletBankCircuit
+  MAX_CURRENT_AMPS = 15
+  NUMBER_OF_OUTLETS = 2
+
+  def initialize(id:, outlet_bank:)
+    @id = id
+    @outlet_bank = outlet_bank
+
+    @outlets = (0..NUMBER_OF_OUTLETS).map do |i|
+      Outlet.new(id: "OU#{id}-#{i}", outlet_bank_circuit: self)
+    end
+  end
+
+  attr_accessor :id, :outlet_bank, :outlets
+
+  def outlet_bank_id
+    outlet_bank.id
+  end
+end
+
+class Outlet
+  def initialize(id:, outlet_bank_circuit:)
+    @id = id
+    @outlet_bank_circuit = outlet_bank_circuit
+    @junction_box = nil
+  end
+
+  def assigned?
+    junction_box != nil
+  end
+
+  def assign_junction_box(junction_box:)
+    if assigned? || self.outlet_bank_circuit.outlets.any? { |outlet| outlet.assigned? }
+      raise 'circuit/outlet already assigned'
+    end
+
+    self.junction_box = junction_box
+    junction_box.outlet_bank = self.outlet_bank_circuit.outlet_bank
+  end
+
+  attr_accessor :id, :outlet_bank_circuit, :junction_box
+end

--- a/script/power_distribution/place_junction_boxes.rb
+++ b/script/power_distribution/place_junction_boxes.rb
@@ -9,6 +9,7 @@ require './panel'
 require './junction_box'
 require './calculate_line_lengths'
 require './controller'
+require './outlet_bank'
 
 # Place junction boxes such that:
 #   - Each edge and panel is assigned to circuits within a single box
@@ -370,21 +371,33 @@ graph.edges.each_value do |edge|
   end
 end
 
+outlet_banks = OutletBank.load_outlet_banks(vertices: vertices)
+OutletBank.assign_junction_boxes_to_outlet_banks(graph: graph, outlet_banks: outlet_banks, junction_boxes: boxes)
+
 power_cable_lengths = bucket_cable_lengths(power_cable_lengths(boxes: boxes.values.flatten, graph: graph))
 power_cable_lengths.delete_if { |_, v| v == 0 }
-puts "Power cable lengths:"
+puts "5V Power cable lengths:"
 pp power_cable_lengths
 puts "---------"
+
 total_power_length = power_cable_lengths.sum { |k, v| k * v }
-puts "Total power cable lengths:"
+puts "Total 5V power cable lengths:"
 pp total_power_length
 puts "---------"
+
 ethernet_cable_lengths = bucket_cable_lengths(ethernet_cable_lengths(boxes: boxes.values.flatten, graph: graph))
 ethernet_cable_lengths.delete_if { |_, v| v == 0 }
 puts "Ethernet cable lengths:"
 pp ethernet_cable_lengths
 puts "---------"
+
 total_ethernet_length = ethernet_cable_lengths.sum { |k, v| k * v }
 puts "Total ethernet cable lengths:"
 pp total_ethernet_length
+puts "---------"
+
+ac_power_cable_lengths = bucket_cable_lengths(ac_power_cable_lengths(boxes: boxes.values.flatten, graph: graph))
+ac_power_cable_lengths.delete_if { |_, v| v == 0 }
+puts "AC power cable lengths:"
+pp ac_power_cable_lengths
 puts "---------"


### PR DESCRIPTION
And output the AC lengths that we need.

Probably doing more with outlets/circuits than we really need to tbh

### TODO

- [x] figure out offset length; see TODO In source
- [x] figure out some way to sanity check these lengths for reasonable-ness
- [x] figure out some way to track extension cords more

Output of the script is: (`length in feet => count of cables needed in that size`)

```
AC power cable lengths:
{15=>6, 20=>16, 25=>11, 35=>5}
---------
```