### PR TITLE
fix pixelblaze pixelCount on init

### DIFF
--- a/resources/pixelblaze/glue.js
+++ b/resources/pixelblaze/glue.js
@@ -10,8 +10,6 @@ var System = Java.type("java.lang.System");
 /* Globals available in pattern code */
 var global = this;
 var point;
-var pixelCount = 0;
-
 
 /* Internal globals used by glue */
 var __now, __points, __colors;


### PR DESCRIPTION
having a var was shadowing the pixelCount injected at the script level
and so pixelCount was always 0 on init.