### PR TITLE
Waveform data + small refactor to reduce per-frame overhead for shaders with audio support.

### DIFF
--- a/resources/shaders/audio_test2.fs
+++ b/resources/shaders/audio_test2.fs
@@ -14,7 +14,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
     // create pixel coordinates
 	vec2 uv = fragCoord.xy / iResolution.xy;
-	uv.y = 1.-uv.y;   // flip y axis direction
+	//uv.y = 1.-uv.y;   // flip y axis direction
 
     // sound texture size is 512x2
     int tx = int(uv.x*512.0);
@@ -27,12 +27,14 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord )
 	vec3 col = hsv2rgb(hsv);
 	
 	// make a simple spectrum analyzer display
-	col *= (freq <= uv.y) ? 1. : 0.;
+	col *= (freq > uv.y) ? 1. : 0.;
 
     // second row is normalized sound waveform data
-	// just draw this over the spectrum analyzer
-    float wave = texelFetch( iChannel0, ivec2(tx,1), 0 ).x;
-	col += 1.0 -  smoothstep( 0.0, 0.015, abs(wave - uv.y) );
+	// just draw this over the spectrum analyzer.  Sound data
+	// coming from LX is in the range -1 to 1, so we scale it and move it down
+	// a bit so we can see it better.
+    float wave = (0.5 * (1.0+texelFetch( iChannel0, ivec2(tx,1), 0 ).x)) - 0.25;
+	col += 1.0 - smoothstep( 0.0, 0.035, abs(wave - uv.y));
 
 	// return pixel color
 	fragColor = vec4(col,1.0);

--- a/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
@@ -1,5 +1,6 @@
 package titanicsend.pattern.yoffa.effect;
 
+import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
@@ -22,12 +23,15 @@ public class NativeShaderPatternEffect extends PatternEffect {
     private FragmentShader fragmentShader;
     private final List<LXParameter> parameters;
 
+    AudioInfo audioInfo;
+
     public NativeShaderPatternEffect(FragmentShader fragmentShader, PatternTarget target) {
         super(target);
         if (fragmentShader != null) {
             this.fragmentShader = fragmentShader;
             this.offscreenShaderRenderer = new OffscreenShaderRenderer(fragmentShader);
             this.parameters = fragmentShader.getParameters();
+            this.audioInfo = new AudioInfo(pattern.getLX().engine.audio.meter);
         } else {
             this.parameters = null;
         }
@@ -55,9 +59,9 @@ public class NativeShaderPatternEffect extends PatternEffect {
             return;
         }
 
-        AudioInfo audioInfo = new AudioInfo(pattern.getTempo().basis(),
-                pattern.sinePhaseOnBeat(), pattern.getBassLevel(), pattern.getTrebleLevel(),
-                pattern.getLX().engine.audio.meter.bands);
+        audioInfo.setFrameData(pattern.getTempo().basis(),
+                pattern.sinePhaseOnBeat(), pattern.getBassLevel(), pattern.getTrebleLevel());
+
         int[][] snapshot = offscreenShaderRenderer.getFrame(audioInfo);
         //TODO we should really use setColor for this instead of exposing colors as this will break blending
         //ImagePainter is the last thing that hasn't been migrated to new framework

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -7,7 +7,6 @@ import com.jogamp.opengl.util.GLBuffers;
 import com.jogamp.opengl.util.texture.Texture;
 import com.jogamp.opengl.util.texture.TextureIO;
 import heronarts.lx.parameter.LXParameter;
-import titanicsend.util.TEMath;
 
 import java.awt.*;
 import java.io.File;
@@ -66,8 +65,8 @@ public class NativeShader implements GLEventListener {
     private int[][] snapshot;
     private AudioInfo audioInfo;
 
-    private int audioTextureWidth = 512;
-    private int audioTextureHeight = 2;
+    private final int audioTextureWidth;
+    private final int audioTextureHeight;
     FloatBuffer audioTextureData;
 
 

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -163,8 +163,7 @@ public class NativeShader implements GLEventListener {
             texture.disable(gl4);
         }
 
-        //TODO for plumbing audio frequency data through as a texture similar to shadertoy
-        // idk yet why this code doesn't work tbh
+        // Set up audio frequency data as a texture similar to shadertoy
         if (audioChannel != null) {
 
             gl4.glActiveTexture(INDEX_TO_GL_ENUM.get(0));
@@ -173,20 +172,14 @@ public class NativeShader implements GLEventListener {
             gl4.glGenTextures(1, texHandle, 0);
             gl4.glBindTexture(GL4.GL_TEXTURE_2D, texHandle[0]);
 
-            for (int h = 0; h < audioTextureHeight; h++) {
-                for (int w = 0; w < audioTextureWidth; w++) {
-
-                    // IMPORTANT:  THE ACTUAL CODE WE WANT!
-                    //float value = h == 0 ? audioInfo.getFrequencyData()[w] : audioInfo.getWaveformData()[w];
-
-                    // fake test data for waveform data
-                    float value = (h == 0) ?
-                            audioInfo.getFrequencyData()[w] :
-                            (float) (0.5f + 0.25f * TEMath.wavef(timeSeconds + 2 * (float) w / audioTextureWidth));
-                    audioTextureData.put(value);
-                }
+            // load frequency and waveform data into our texture, fft data in the first row,
+            // normalized audio waveform data in the second.
+            for (int n = 0; n < audioTextureWidth; n++) {
+                audioTextureData.put(n, audioInfo.getFrequencyData(n));
+                audioTextureData.put(n + audioTextureWidth, audioInfo.getWaveformData(n));
             }
-            audioTextureData.rewind();
+
+ //           audioTextureData.rewind();
             gl4.glTexImage2D(GL4.GL_TEXTURE_2D, 0, GL4.GL_R32F, audioTextureWidth, audioTextureHeight, 0, GL4.GL_RED, GL_FLOAT, audioTextureData);
             gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
             gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);


### PR DESCRIPTION
Darn it, I can't be up there to help with the wiring and construction, but I can do a little coding!   Audio waveform data is available in shaders now -- try out the AudioTest2 example to see it in action.   