### PR TITLE
Disable non-used channels to save FPS and ignore old OSC messages

### DIFF
--- a/.lxpreferences
+++ b/.lxpreferences
@@ -1,6 +1,6 @@
 {
   "version": "0.4.1",
-  "projectFileName": "Vehicle.lxp",
+  "projectFileName": "AutoVJ.lxp",
   "windwWidth": 1728,
   "windowHeight": 984,
   "uiZoom": 100,

--- a/src/main/java/titanicsend/app/autopilot/utils/TEMixerUtils.java
+++ b/src/main/java/titanicsend/app/autopilot/utils/TEMixerUtils.java
@@ -26,6 +26,18 @@ public class TEMixerUtils {
         }
     }
 
+    public static void setFaderTo(LX lx, TEChannelName name, double faderLevel) {
+        LXChannel channel = (LXChannel) lx.engine.mixer.channels.get(name.getIndex());
+        channel.fader.setValue(faderLevel);
+
+        // save CPU cycles by disabling OFF channels
+        if (faderLevel < 0.01) {
+            channel.enabled.setValue(false);
+        } else if (faderLevel > 0.01) {
+            channel.enabled.setValue(true);
+        }
+    }
+
     public static TEChannelName getChannelNameFromPhraseType(TEPhrase phraseType) {
         if (phraseType == TEPhrase.CHORUS)
             return TEChannelName.CHORUS;


### PR DESCRIPTION
This saves CPU cycles by disabling channels when setting the fader value to 0 or very close. 

Also discards old OSC messages, which would often mess up if the change to master deck in ShowKontrol took too long.