### PR TITLE
power_distribution: account for boxes with/without switches

### DIFF
--- a/script/power_distribution/junction_box.rb
+++ b/script/power_distribution/junction_box.rb
@@ -23,6 +23,12 @@ class JunctionBox
     id
   end
 
+  # A box needs an ethernet switch if it is powering any controllers. Controllers should always
+  # be powered and signal driven from the same box.
+  def needs_ethernet_switch?
+    controllers.any?
+  end
+
   def decorated_id
     "J#{@id}"
   end


### PR DESCRIPTION
This doesn't do much beyond just printing this info out, but
we'll want to reflect it in the wiring diagram later on.

We only have 25 boxes with switches due to supply constraints.