### PR TITLE
Revert GL initialization to be as late as possible

### DIFF
--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/OffscreenShaderRenderer.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/OffscreenShaderRenderer.java
@@ -37,16 +37,20 @@ public class OffscreenShaderRenderer {
     }
 
     public void initializeNativeShader() {
-        if (!nativeShader.isInitialized()) {
-            nativeShader.init(offscreenDrawable);
-        }
+        ;  // do nothing, for now
     }
 
     public int[][] getFrame(AudioInfo audioInfo) {
+        // initialize as late as possible to avoid stepping on LX's toes
+        if (!nativeShader.isInitialized()) {
+            nativeShader.init(offscreenDrawable);
+        }
+
         nativeShader.updateAudioInfo(audioInfo);
         nativeShader.display(offscreenDrawable);
         return nativeShader.getSnapshot();
     }
+
 
     public void reset() {
         nativeShader.reset();


### PR DESCRIPTION
I was overly optimistic about initializing GL contexts for our shader patterns before LX was done with its initialization.  Moved initialization back to the way @Mike Yoffa had it -- at the last possible instant before display.