### PR TITLE
 Provisional Fix:  Change to allow projects to load w/o autopilot channels

### DIFF
--- a/src/main/java/titanicsend/app/TEAutopilot.java
+++ b/src/main/java/titanicsend/app/TEAutopilot.java
@@ -170,16 +170,17 @@ public class TEAutopilot implements LXLoopTask {
     public void loop(double deltaMs) {
         long now = System.currentTimeMillis();
 
-        // check our patterns are indexed
-        // this requires that LX's mixer / channels are setup, so
-        // we do this here, as opposed to in the constructor, which is called
-        // in TEApp before LX is really finished
-        if (!this.library.isReady())
-            this.library.indexPatterns();
-
         try {
             // if autopilot isn't enabled, just ignore for now
             if (!isEnabled()) return;
+
+            // check our patterns are indexed
+            // this requires that LX's mixer / channels are setup, so
+            // we do this here, as opposed to in the constructor, which is called
+            // in TEApp before LX is really finished
+            if (!this.library.isReady()) {
+                this.library.indexPatterns();
+            }
 
             // collect audio/FFT statistics
             // TODO(will) for when we want to act without OSC messages -- just based on pure audio


### PR DESCRIPTION
Prior to this, new projects created without the channel setup expected by autopilot would cause a chain of exceptions, resulting in the UI not working.   This allows non-autopilot projects to load successfully.

However, would greatly appreciate review for downstream side-effects.