### PR TITLE
Fix for stuttering on native shader pattern load/activate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ bin/
 target/
 classes/
 Projects/project.lxp
+resources/shaders/cache

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ bin/
 target/
 classes/
 Projects/project.lxp
-resources/shaders/cache
+resources/shaders/cache/*.bin

--- a/resources/shaders/cache/shadercache.md
+++ b/resources/shaders/cache/shadercache.md
@@ -1,0 +1,7 @@
+#### /resources/shaders/cache
+
+This directory holds the native shader cache. If it doesn't exist, the caching
+system will be disabled.
+
+
+To clear the cache, erase all the .bin files from this directory

--- a/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
@@ -90,12 +90,10 @@ public class NativeShaderPatternEffect extends PatternEffect {
     @Override
     public void onPatternActive() {
         if (fragmentShader != null) {
-            offscreenShaderRenderer = new OffscreenShaderRenderer(fragmentShader,shaderOptions);
+            if (offscreenShaderRenderer == null) {
+                offscreenShaderRenderer = new OffscreenShaderRenderer(fragmentShader, shaderOptions);
+            }
         }
-        // lazy initialization of our GL stuff, to avoid disrupting LX's GL startup
-        // TODO - test to be sure that this is sufficiently lazy, or look for a way to tell if
-        // LX is done with its initialization.
-        offscreenShaderRenderer.initializeNativeShader();
     }
 
     @Override

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
@@ -16,12 +16,16 @@ public class FragmentShader {
     private static final Pattern PLACEHOLDER_FINDER = Pattern.compile("\\{%(.*?)(\\[(.*?)\\])??\\}");
 
     private final String shaderBody;
+    private String shaderName;
+    private long shaderTimestamp;
     private final Map<Integer, String> channelToTexture;
     private boolean remoteTextures;
     private final Integer audioInputChannel;
     private final List<LXParameter> parameters;
 
     public FragmentShader(File shaderFile, List<File> textureFiles) {
+        shaderName = ShaderUtils.getCacheFilename(shaderFile.getName());
+        shaderTimestamp = shaderFile.lastModified();
         String shaderBody = ShaderUtils.loadResource(shaderFile.getPath());
         Map<Integer, String> channelToTexture = new HashMap<>();
         this.audioInputChannel = 0;
@@ -83,6 +87,10 @@ public class FragmentShader {
     public String getShaderBody() {
         return shaderBody;
     }
+
+    public String getShaderName() { return shaderName; }
+
+    public long getShaderTimestamp() { return shaderTimestamp; }
 
     public Map<Integer, String> getChannelToTexture() {
         return channelToTexture;

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -126,9 +126,11 @@ public class NativeShader implements GLEventListener {
         glAutoDrawable.getContext().makeCurrent();
         GL4 gl4 = glAutoDrawable.getGL().getGL4();
 
-        initShaderProgram(gl4);
-        downloadTextureFiles(fragmentShader);
-        gl4.glUseProgram(shaderProgram.getProgramId());
+        if (!isInitialized()) {
+          initShaderProgram(gl4);
+          downloadTextureFiles(fragmentShader);
+          gl4.glUseProgram(shaderProgram.getProgramId());
+        }
 
         startTime = System.currentTimeMillis();
     }
@@ -238,7 +240,8 @@ public class NativeShader implements GLEventListener {
         File vertexShader = new File("resources/shaders/framework/default.vs");
         shaderProgram = new ShaderProgram();
         String shaderCode = FRAGMENT_SHADER_TEMPLATE.replace(SHADER_BODY_PLACEHOLDER, fragmentShader.getShaderBody());
-        shaderProgram.init(gl4, vertexShader, shaderCode);
+        shaderProgram.init(gl4, vertexShader, shaderCode,
+                           fragmentShader.getShaderName(),fragmentShader.getShaderTimestamp());
         setUpCanvas(gl4);
     }
 

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderProgram.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderProgram.java
@@ -14,33 +14,38 @@ public class ShaderProgram {
     private int vertexShaderId;
     private int fragmentShaderId;
 
-    public void init(GL4 gl4, File vertexShader, String fragmentShaderCode) {
+    public void init(GL4 gl4, File vertexShader, String fragmentShaderCode, String shaderName, long ts) {
         if (initialized) {
             throw new IllegalStateException(
                     "Unable to initialize the shader program! (it was already initialized)");
         }
 
         try {
-            String vertexShaderCode = ShaderUtils.loadResource(vertexShader
-                    .getPath());
-
             programId = gl4.glCreateProgram();
-            vertexShaderId = ShaderUtils.createShader(gl4, programId,
-                    vertexShaderCode, GL4.GL_VERTEX_SHADER);
-            fragmentShaderId = ShaderUtils.createShader(gl4, programId,
-                    fragmentShaderCode, GL4.GL_FRAGMENT_SHADER);
+            boolean inCache = ShaderUtils.loadShaderFromCache(gl4,programId,shaderName,ts);
 
-            ShaderUtils.link(gl4, programId);
+            if (!inCache) {
+                String vertexShaderCode = ShaderUtils.loadResource(vertexShader
+                        .getPath());
+                vertexShaderId = ShaderUtils.createShader(gl4, programId,
+                        vertexShaderCode, GL4.GL_VERTEX_SHADER);
+                fragmentShaderId = ShaderUtils.createShader(gl4, programId,
+                        fragmentShaderCode, GL4.GL_FRAGMENT_SHADER);
 
-            shaderAttributeLocations.put(ShaderAttribute.POSITION,
-                    gl4.glGetAttribLocation(programId, ShaderAttribute.POSITION.getAttributeName()));
-            shaderAttributeLocations.put(ShaderAttribute.INDEX,
-                    gl4.glGetAttribLocation(programId, ShaderAttribute.INDEX.getAttributeName()));
+                ShaderUtils.link(gl4, programId);
 
-            initialized = true;
+                shaderAttributeLocations.put(ShaderAttribute.POSITION,
+                        gl4.glGetAttribLocation(programId, ShaderAttribute.POSITION.getAttributeName()));
+                shaderAttributeLocations.put(ShaderAttribute.INDEX,
+                        gl4.glGetAttribLocation(programId, ShaderAttribute.INDEX.getAttributeName()));
+
+                ShaderUtils.saveShaderToCache(gl4, shaderName, programId);
+            }
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+        initialized = true;
     }
 
     public void dispose(GL4 gl4) {

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
@@ -4,9 +4,13 @@ import com.jogamp.opengl.GL4;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Scanner;
+import titanicsend.util.TE;
 
 public class ShaderUtils {
 
@@ -28,6 +32,89 @@ public class ShaderUtils {
         validateStatus(gl4, shaderId, GL4.GL_COMPILE_STATUS);
         gl4.glAttachShader(programId, shaderId);
         return shaderId;
+    }
+
+    /**
+     * Takes shader filename with extension, returns string containing path to
+     * corresponding cache file.
+     */
+    public static String getCacheFilename(String shaderName) {
+        String[] parts = shaderName.split("\\.");
+        return String.format("resources/shaders/cache/%s.bin",parts[0]);
+    }
+
+    /**
+     * Attempts to read the named shader from resources/shaders/cache.  Returns
+     * a ByteBuffer full of shader binary if successful, null otherwise.
+     */
+    public static boolean loadShaderFromCache(GL4 gl4,int programID, String shaderName, long timeStamp) {
+
+        // compare timestamp to see if the shader has been updated.
+        File shaderBin = new File(shaderName);
+        if (!shaderBin.exists()) {
+            TE.log("Shader '%s' not found in cache",shaderName);
+            return false;
+        }
+
+        if (timeStamp > shaderBin.lastModified()) {
+            TE.log("Shader '%s` has been modified.",shaderName);
+            return false;
+        }
+
+        // attempt to read shader binary from cache file
+        try {
+            byte [] outBuf = Files.readAllBytes(Path.of( shaderName));
+            ByteBuffer shader = ByteBuffer.wrap(outBuf);
+
+            // attach binary to our shader program
+            gl4.glProgramBinary(programID,0,shader,outBuf.length);
+        }
+        catch (IOException e) {
+            TE.log("I/O Exception reading shader '%s'.",shaderName);
+            return false;
+        }
+        
+        // see if it worked
+        int[] status = new int[1];
+        gl4.glGetIntegerv(GL4.GL_LINK_STATUS,status,0);
+        TE.log("Shader '%s' loaded from cache",shaderName);
+        return (status[0] != GL4.GL_FALSE);
+    }
+
+    /**
+     * Save compiled and linked shader binary in a cache file, in
+     * resources/shaders/cache
+     */
+    public static void saveShaderToCache(GL4 gl4, String shaderName, int programId) {
+
+        // get the size of the shader binary in bytes
+        int[] len = new int[1];
+        gl4.glGetProgramiv(programId,GL4.GL_PROGRAM_BINARY_LENGTH,len,0);
+
+        // get available binary formats for shader storage
+        int[] fmtCount = new int[1];
+        gl4.glGetIntegerv(GL4.GL_NUM_PROGRAM_BINARY_FORMATS,fmtCount,0);
+
+        if (fmtCount[0] < 1) {
+            TE.log("Shader cache: No compatible binary shader format available.");
+            return;
+        }
+
+        // take the first available format
+        int[] formatList = new int[fmtCount[0]];
+        gl4.glGetIntegerv(GL4.GL_PROGRAM_BINARY_FORMATS,formatList,0);
+
+        // now we can get the shader binary
+        ByteBuffer bin = ByteBuffer.allocate(len[0]);
+        gl4.glGetProgramBinary(programId,len[0],len,0,formatList, 0,bin);
+
+        // and at long last, save it to a file!
+        try {
+            Files.write(Path.of(shaderName), bin.array());
+        }
+        catch (IOException e) {
+            TE.log("I/O exception writing shader '%s",shaderName);
+        }
     }
 
     public static void link(GL4 gl4, int programId) throws Exception {


### PR DESCRIPTION
Implemented new shader caching system which should greatly speed up the loading of shader-based patterns and clips.   

Details:
- Once a shader is loaded, compiled and linked, the binary is kept in memory until its pattern instance is removed from the channel.
- When shaders are compiled and linked, the resulting binary is stored in the */resources/shaders/cache* directory.  On subsequent loads, if the shader has not been modified (determined by the timestamp of the .fs file), the precompiled binary is loaded.
- Add *resources/shaders/cache* directory to gitignore so shader binaries won't get copied around.  They're about the least portable thing in existence, pretty much tied to a single machine's GPU, OS, driver version, etc.

To reset your cache completely, erase all the .bin files from /resources/shaders/cache.
