### PR TITLE
Add startup-time shader cache manager

### DIFF
--- a/resources/shaders/space_explosion.fs
+++ b/resources/shaders/space_explosion.fs
@@ -90,4 +90,6 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     float c = scale*perlin*2.0;
 
     fragColor = vec4(glowRing+c, glowRing, glowRing*0.5+(c*2.0), 0);
+    // alpha, derived from brightness, for LX blending.
+    fragColor.a = max(fragColor.r,max(fragColor.g,fragColor.b));	
 }

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -297,6 +297,9 @@ public class TEApp extends PApplet implements LXPlugin  {
     // At this point, the LX Studio application UI has been built. You may now add
     // additional views and components to the Ui heirarchy.
 
+    // precompile binaries for any new or changed shaders
+    ShaderPrecompiler.rebuildCache();
+
     TEVirtualOverlays visual = new TEVirtualOverlays(this.model);
     lx.ui.preview.addComponent(visual);
     new TEUIControls(ui, visual, ui.leftPane.global.getContentWidth()).addToContainer(ui.leftPane.global);

--- a/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
+++ b/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
@@ -52,11 +52,21 @@ public class ShaderPrecompiler {
         String FRAGMENT_SHADER_TEMPLATE =
                 ShaderUtils.loadResource("resources/shaders/framework/template.fs");
 
+        String VERTEX_SHADER_TEMPLATE = ShaderUtils.loadResource("resources/shaders/framework/default.vs");
+
         // set up just enough OpenGL machinery to let us compile and link
-        GLAutoDrawable surface = ShaderUtils.createGLSurface(xResolution,yResolution);
+        GLAutoDrawable surface = ShaderUtils.createGLSurface(xResolution, yResolution);
         surface.display();
         GL4 gl4 = surface.getGL().getGL4();
         int programId = gl4.glCreateProgram();
+
+        try {
+            int vertexShaderId = ShaderUtils.createShader(gl4, programId,
+                    VERTEX_SHADER_TEMPLATE, GL4.GL_VERTEX_SHADER);
+        } catch (Exception e) {
+            TE.log("Error building vertex shader");
+            throw new RuntimeException(e);
+        }
 
         // enumerate all files in the shader directory and
         // attempt to compile them to cached .bin files.
@@ -76,6 +86,8 @@ public class ShaderPrecompiler {
                         String shaderCode = FRAGMENT_SHADER_TEMPLATE.replace(SHADER_BODY_PLACEHOLDER, shaderBody);
 
                         try {
+
+
                             int fragmentShaderId = ShaderUtils.createShader(gl4, programId,
                                     shaderCode, GL4.GL_FRAGMENT_SHADER);
                             ShaderUtils.link(gl4, programId);
@@ -84,6 +96,7 @@ public class ShaderPrecompiler {
 
                             gl4.glDetachShader(programId, fragmentShaderId);
                         } catch (Exception e) {
+                            TE.log("Error building shader %s",file.getName());
                             throw new RuntimeException(e);
                         }
                         compiledFiles++;

--- a/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
+++ b/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
@@ -1,0 +1,101 @@
+package titanicsend.pattern.jon;
+
+import com.jogamp.opengl.*;
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.LXParameter;
+import titanicsend.pattern.yoffa.shader_engine.*;
+import titanicsend.util.TE;
+
+/**
+ * Checks shader cache and builds binaries for any changed or previously
+ * uncached shaders.
+ */
+public class ShaderPrecompiler {
+    private final static int xResolution = OffscreenShaderRenderer.getXResolution();
+    private final static int yResolution = OffscreenShaderRenderer.getYResolution();
+
+    private final static String cachePath = "resources/shaders";
+
+    private static final String SHADER_BODY_PLACEHOLDER = "{{%shader_body%}}";
+
+    public static boolean needsRebuild(File shaderFile,String cacheName) {
+
+        // if there's no cache file, we need to make one
+        File shaderBin = new File(cacheName);
+        if (!shaderBin.exists()) return true;
+
+        // if the shader (.fs) file has been changed, we need to refresh the cache
+        long timeStamp = shaderFile.lastModified();
+        if (timeStamp > shaderBin.lastModified()) return true;
+
+        // otherwise, this file is good to go!
+        return false;
+    }
+
+    /**
+     * Create and save binary versions of any shaders that need it.
+     *
+     */
+    public static void rebuildCache() {
+        long timer = System.currentTimeMillis();
+        int totalFiles = 0;
+        int compiledFiles = 0;
+
+        TE.log("Refreshing shader cache...");
+
+        String FRAGMENT_SHADER_TEMPLATE =
+                ShaderUtils.loadResource("resources/shaders/framework/template.fs");
+
+        // set up just enough OpenGL machinery to let us compile and link
+        GLAutoDrawable surface = ShaderUtils.createGLSurface(xResolution,yResolution);
+        surface.display();
+        GL4 gl4 = surface.getGL().getGL4();
+        int programId = gl4.glCreateProgram();
+
+        // enumerate all files in the shader directory and
+        // attempt to compile them to cached .bin files.
+        File dir = new File(cachePath);
+        File[] directoryListing = dir.listFiles();
+        if (directoryListing != null) {
+            for (File file: directoryListing) {
+                if (file.getName().endsWith(".fs")) {
+                    totalFiles++;
+
+                    String shaderName = ShaderUtils.getCacheFilename(file.getName());
+
+                    if (needsRebuild(file, shaderName)) {
+                        String shaderText = ShaderUtils.loadResource(file.getPath());
+                        String shaderBody = ShaderUtils.preprocessShader(shaderText, null);
+                        ;
+                        String shaderCode = FRAGMENT_SHADER_TEMPLATE.replace(SHADER_BODY_PLACEHOLDER, shaderBody);
+
+                        try {
+                            int fragmentShaderId = ShaderUtils.createShader(gl4, programId,
+                                    shaderCode, GL4.GL_FRAGMENT_SHADER);
+                            ShaderUtils.link(gl4, programId);
+
+                            ShaderUtils.saveShaderToCache(gl4, shaderName, programId);
+
+                            gl4.glDetachShader(programId, fragmentShaderId);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                        compiledFiles++;
+                    }
+                }
+            }
+        } else {
+           // ignore directories and other file system objects
+        }
+        gl4.glDeleteProgram(programId);
+
+        TE.log("%d shaders processed in %d ms.",totalFiles,System.currentTimeMillis() - timer);
+        TE.log("%d cache file%s updated.",compiledFiles,(compiledFiles == 1) ? "" : "s");
+    }
+}

--- a/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
+++ b/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
@@ -60,14 +60,6 @@ public class ShaderPrecompiler {
         GL4 gl4 = surface.getGL().getGL4();
         int programId = gl4.glCreateProgram();
 
-        try {
-            int vertexShaderId = ShaderUtils.createShader(gl4, programId,
-                    VERTEX_SHADER_TEMPLATE, GL4.GL_VERTEX_SHADER);
-        } catch (Exception e) {
-            TE.log("Error building vertex shader");
-            throw new RuntimeException(e);
-        }
-
         // enumerate all files in the shader directory and
         // attempt to compile them to cached .bin files.
         File dir = new File(cachePath);
@@ -82,12 +74,13 @@ public class ShaderPrecompiler {
                     if (needsRebuild(file, shaderName)) {
                         String shaderText = ShaderUtils.loadResource(file.getPath());
                         String shaderBody = ShaderUtils.preprocessShader(shaderText, null);
-                        ;
                         String shaderCode = FRAGMENT_SHADER_TEMPLATE.replace(SHADER_BODY_PLACEHOLDER, shaderBody);
 
                         try {
+                            TE.log("Building shader %s",file.getPath());
 
-
+                            int vertexShaderId = ShaderUtils.createShader(gl4, programId,
+                                    VERTEX_SHADER_TEMPLATE, GL4.GL_VERTEX_SHADER);
                             int fragmentShaderId = ShaderUtils.createShader(gl4, programId,
                                     shaderCode, GL4.GL_FRAGMENT_SHADER);
                             ShaderUtils.link(gl4, programId);
@@ -95,7 +88,9 @@ public class ShaderPrecompiler {
                             ShaderUtils.saveShaderToCache(gl4, shaderName, programId);
 
                             gl4.glDetachShader(programId, fragmentShaderId);
+                            gl4.glDetachShader(programId, vertexShaderId);
                             gl4.glDeleteShader(fragmentShaderId);
+                            gl4.glDeleteShader(vertexShaderId);
                         } catch (Exception e) {
                             TE.log("Error building shader %s",file.getName());
                             throw new RuntimeException(e);

--- a/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
+++ b/src/main/java/titanicsend/pattern/jon/ShaderPrecompiler.java
@@ -95,6 +95,7 @@ public class ShaderPrecompiler {
                             ShaderUtils.saveShaderToCache(gl4, shaderName, programId);
 
                             gl4.glDetachShader(programId, fragmentShaderId);
+                            gl4.glDeleteShader(fragmentShaderId);
                         } catch (Exception e) {
                             TE.log("Error building shader %s",file.getName());
                             throw new RuntimeException(e);

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
@@ -12,9 +12,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FragmentShader {
-
-    private static final Pattern PLACEHOLDER_FINDER = Pattern.compile("\\{%(.*?)(\\[(.*?)\\])??\\}");
-
     private final String shaderBody;
     private String shaderName;
     private long shaderTimestamp;
@@ -34,54 +31,17 @@ public class FragmentShader {
             channelToTexture.put(i+1, textureFiles.get(i).getPath());
         }
         this.parameters = new ArrayList<>();
-        this.shaderBody = parseCustomParameters(shaderBody);;
+        this.shaderBody = ShaderUtils.preprocessShader(shaderBody,this.parameters);;
         this.channelToTexture = channelToTexture;
         this.remoteTextures = false;
     }
 
     public FragmentShader(String shaderBody, Map<Integer, String> channelToTexture, Integer audioInputChannel) {
         this.parameters = new ArrayList<>();
-        this.shaderBody = parseCustomParameters(shaderBody);;
+        this.shaderBody = ShaderUtils.preprocessShader(shaderBody,this.parameters);;
         this.channelToTexture = channelToTexture;
         this.audioInputChannel = audioInputChannel;
         this.remoteTextures = true;
-    }
-
-    private String parseCustomParameters(String shaderBody) {
-        Matcher matcher = PLACEHOLDER_FINDER.matcher(shaderBody);
-        StringBuilder stringBuilder = new StringBuilder();
-        while (matcher.find()) {
-            try {
-                String placeholderName = matcher.group(1);
-                if (matcher.groupCount() >= 3) {
-                    String metadata = matcher.group(3);
-                    if ("bool".equals(metadata)) {
-                        parameters.add(new BooleanParameter(placeholderName));
-                    } else {
-                        Double[] rangeValues = Arrays.stream(metadata.split(","))
-                                .map(Double::parseDouble)
-                                .toArray(Double[]::new);
-                        parameters.add(new CompoundParameter(placeholderName, rangeValues[0], rangeValues[1], rangeValues[2]));
-                    }
-                }
-                matcher.appendReplacement(stringBuilder, placeholderName + Uniforms.CUSTOM_SUFFIX);
-            } catch (Exception e) {
-                throw new RuntimeException("Problem parsing placeholder: " + matcher.group(0), e);
-            }
-        }
-        matcher.appendTail(stringBuilder);
-        return buildCustomUniforms(parameters) + stringBuilder.toString();
-    }
-
-    private String buildCustomUniforms(List<LXParameter> customParameters) {
-        StringBuilder stringBuilder = new StringBuilder();
-        for (LXParameter parameter : customParameters) {
-            String type = parameter instanceof BooleanParameter ? "bool" : "float";
-            stringBuilder.append("uniform ").append(type).append(" ")
-                    .append(parameter.getLabel()).append(Uniforms.CUSTOM_SUFFIX)
-                    .append(";\n");
-        }
-        return stringBuilder.toString();
     }
 
     public String getShaderBody() {

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/OffscreenShaderRenderer.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/OffscreenShaderRenderer.java
@@ -11,24 +11,9 @@ public class OffscreenShaderRenderer {
     private final GLAutoDrawable offscreenDrawable;
 
     public OffscreenShaderRenderer(FragmentShader fragmentShader,ShaderOptions shaderOptions) {
-        GLProfile glProfile = GLProfile.getGL4ES3();
-        GLCapabilities glCapabilities = new GLCapabilities(glProfile);
-        glCapabilities.setHardwareAccelerated(true);
-        glCapabilities.setOnscreen(false);
-        glCapabilities.setDoubleBuffered(false);
-        // set bit count for all channels to get alpha to work correctly
-        glCapabilities.setAlphaBits(8);
-        glCapabilities.setRedBits(8);
-        glCapabilities.setBlueBits(8);
-        glCapabilities.setGreenBits(8);
-        GLDrawableFactory factory = GLDrawableFactory.getFactory(glProfile);
-
-        //need to specifically create an offscreen drawable
-        //there is no way to have a normal drawable render on a panel/canvas which is not visible
-        offscreenDrawable = factory.createOffscreenAutoDrawable(factory.getDefaultDevice(), glCapabilities,
-                new DefaultGLCapabilitiesChooser(), xResolution, yResolution);
-        nativeShader = new NativeShader(fragmentShader, xResolution, yResolution,shaderOptions);
+        offscreenDrawable = ShaderUtils.createGLSurface(xResolution,yResolution);
         offscreenDrawable.display();
+        nativeShader = new NativeShader(fragmentShader, xResolution, yResolution,shaderOptions);
     }
 
     // use default shader options
@@ -37,8 +22,8 @@ public class OffscreenShaderRenderer {
     }
 
     public void initializeNativeShader() {
-        ;  // do nothing, for now
-    }
+       // do nothing for now.
+    };
 
     public int[][] getFrame(AudioInfo audioInfo) {
         // initialize as late as possible to avoid stepping on LX's toes
@@ -57,5 +42,8 @@ public class OffscreenShaderRenderer {
     }
 
     public NativeShader getNativeShader() { return nativeShader; }
+
+    public static int getXResolution() { return xResolution; }
+    public static int getYResolution() { return yResolution; }
 
 }


### PR DESCRIPTION
The shader cache is now checked at each LX startup, and precompiled binaries for any new or updated shaders are generated and saved in the ```resources/shaders/cache``` directory.

This is completely automatic and, until we're dealing with hundreds of shaders, should have no noticeable effect on startup times. (there's a timer in the log, if you want to check!)

Having all the shaders precompiled means that shader pattern load times will be consistently fast, even the very first time you load a pattern.

Manual override instructions:
- To clear the cache, delete all the ```.bin``` files from ```resources/shaders/cache```
- To disable caching entirely, delete or empty, then write protect the cache directory.