### PR TITLE
Add color controls and uniforms to constructed patterns

### DIFF
--- a/resources/shaders/circuitry.fs
+++ b/resources/shaders/circuitry.fs
@@ -1,0 +1,51 @@
+
+vec3 hsv2rgb(vec3 c)
+{
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+mat2 rot(float a) {
+    float s=sin(a), c=cos(a);
+    return mat2(c,s,-s,c);
+}
+
+vec3 fractal(vec2 p) {    
+    p.x += 0.3333 * sin(iTime*.4);
+       
+    float ot1 = 1000., ot2=ot1, it=0.;
+    
+    for (float i = 0.; i < 4.; i++) {
+        p=abs(p);
+        p=p/clamp(p.x*p.y,0.15,5.)-vec2(1.5,1.);
+        float m = abs(p.x+sin(iTime));
+        if (m<ot1) {
+            ot1=m+step(fract(iTime*1.+float(i)*.05),.15*abs(p.y));
+            it=i;
+        }
+        ot2=min(ot2,length(p));
+    }
+    
+    ot1=exp(-30.*ot1);
+    ot2=exp(-130.*ot2);
+    return hsv2rgb(vec3(it*0.13+.5,.7,1.))*sqrt(ot1+ot2);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    vec2 uv = fragCoord.xy/iResolution.xy-.5;
+    uv.x*=iResolution.x/iResolution.y;
+    
+    float aa=2.;
+    
+    vec2 sc=1./iResolution.xy/aa;
+    
+    vec3 c=vec3(0.);
+    for (float i=-aa; i < aa; i++) {
+        for (float j =- aa; j < aa; j++) {
+            vec2 p = uv + vec2(i,j) * sc;
+            c += fractal(p);
+        }
+    }
+    fragColor = vec4(c/(aa*aa*0.35),1.);
+}

--- a/resources/shaders/followthatstar.fs
+++ b/resources/shaders/followthatstar.fs
@@ -44,7 +44,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
         // TODO - add a little bump with the beat.
         vec2 point = vec2(0.92 * sin(t) + 0.08 * cos(t * 6.0),
                          -0.3 + (0.65 * sin(t * 0.85) + dance * sin(t * 2.0)));
-        point = uPos - point/2f;
+        point = uPos - point/2.0;
 
         // if we're rotating, give the individual stars slightly different rates
         // by playing with the matrix scale a little

--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -5,6 +5,8 @@ out vec4 finalColor;
 uniform float iTime;
 uniform vec2 iResolution;
 uniform vec4 iMouse;
+uniform vec3 iColorRGB;
+uniform vec3 iColorHSB;
 uniform sampler2D iChannel0;
 uniform sampler2D iChannel1;
 uniform sampler2D iChannel2;

--- a/resources/shaders/marbling.fs
+++ b/resources/shaders/marbling.fs
@@ -8,5 +8,6 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ){
         uv.y += 0.6 / i * cos(i * {%yWave[1.5,1,10]} * uv.x + iTime);
     }
 
-    fragColor = vec4(vec3(0.1)/abs(sin(iTime-uv.y-uv.x)),1.0);
+    //fragColor = vec4(vec3(0.1)/abs(sin(iTime-uv.y-uv.x)),1.0);
+    fragColor = vec4(iColorRGB*abs(sin(iTime-uv.y-uv.x)),1.0);
 }

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -66,7 +66,7 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
    */
 
 
-  protected LinkedColorParameter registerColor(String label, String path, ColorType colorType, String description) {
+  public LinkedColorParameter registerColor(String label, String path, ColorType colorType, String description) {
     LinkedColorParameter lcp = new LinkedColorParameter(label)
             .setDescription(description);
     addParameter(path, lcp);

--- a/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
+++ b/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
@@ -32,8 +32,8 @@ public class EdgeKITT extends TEAudioPattern {
 
 
     public final LinkedColorParameter color =
-            registerColor("Color", "color", ColorType.PANEL,
-                    "Panel Color");
+            registerColor("Color", "color", ColorType.EDGE,
+                    "Color");
 
     public EdgeKITT(LX lx) {
         super(lx);

--- a/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
@@ -1,6 +1,7 @@
 package titanicsend.pattern.yoffa.framework;
 
 import heronarts.lx.LX;
+import heronarts.lx.color.LinkedColorParameter;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.TEAudioPattern;
 
@@ -17,6 +18,10 @@ public abstract class ConstructedPattern extends TEAudioPattern {
         for (LXParameter parameter : getPatternParameters()) {
             addParameter(parameter.getLabel(), parameter);
         }
+
+        registerColor("Color", "iColor", ColorType.PANEL,
+                "Color");
+
     }
 
 

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
@@ -15,9 +15,15 @@ public class PatternTarget {
     final Map<LXPoint, Dimensions> pointsToCanvas = new HashMap<>();
 
     TEAudioPattern pattern;
+    public TEPattern.ColorType colorType = TEPattern.ColorType.PANEL;
 
     public PatternTarget(TEAudioPattern pattern) {
         this.pattern = pattern;
+    }
+
+    public PatternTarget(TEAudioPattern pattern,TEPattern.ColorType ct) {
+        this.pattern = pattern;
+        this.colorType = ct;
     }
 
     public PatternTarget addPointsAsCanvas(Collection<LXPoint> points) {
@@ -49,7 +55,7 @@ public class PatternTarget {
     }
 
     public static PatternTarget allEdgesAsCanvas(TEAudioPattern pattern) {
-        return new PatternTarget(pattern).addPointsAsCanvas(pattern.getModel().edgePoints);
+        return new PatternTarget(pattern,TEPattern.ColorType.EDGE).addPointsAsCanvas(pattern.getModel().edgePoints);
     }
 
     public static PatternTarget allPanelsAsCanvas(TEAudioPattern pattern) {

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/AudioInfo.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/AudioInfo.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.yoffa.shader_engine;
 
 import heronarts.lx.LX;
 import heronarts.lx.audio.GraphicMeter;
+import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.NormalizedParameter;
 import titanicsend.util.TEMath;
 
@@ -15,19 +16,26 @@ public class AudioInfo {
     GraphicMeter meter;
     float fftResampleFactor;
 
+    int color;
+
     public AudioInfo(GraphicMeter meter) {
         this.meter = meter;
         fftResampleFactor = meter.bands.length / 512f;
     }
 
     
-    public void setFrameData(double basis, double sinPhaseBeat, double bassLevel, double trebleLevel) {
+    public void setFrameData(double basis, double sinPhaseBeat, double bassLevel, double trebleLevel, int col) {
         uniformMap = Map.of(
             Uniforms.Audio.BEAT, (float) basis,
             Uniforms.Audio.SIN_PHASE_BEAT, (float) sinPhaseBeat,
             Uniforms.Audio.BASS_LEVEL, (float) bassLevel,
             Uniforms.Audio.TREBLE_LEVEL, (float) trebleLevel
         );
+
+        this.color = col;
+    }
+
+    public void setFrameData(double basis, double sinPhaseBeat, double bassLevel, double trebleLevel) {
     }
 
     public Map<Uniforms.Audio, Float> getUniformMap() {

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -20,10 +20,6 @@ import java.util.Map;
 import static com.jogamp.opengl.GL.*;
 import static titanicsend.pattern.yoffa.shader_engine.GeneralUniforms.*;
 
-// ***************************************************************************
-//
-// Class to store a user-specified value for a uniform parameter
-// in the shader
 
 //Technically we don't need to implement GLEventListener unless we plan on rendering on screen, but let's leave it
 //for good practice
@@ -158,6 +154,8 @@ public class NativeShader implements GLEventListener {
         }
     }
 
+
+
     private void setUpCanvas(GL4 gl4) {
         // allocate geometry buffer handles
         int[] bufferHandlesB = new int[1];
@@ -174,6 +172,25 @@ public class NativeShader implements GLEventListener {
         gl4.glDrawElements(GL2.GL_TRIANGLES, INDICES.length, GL2.GL_UNSIGNED_INT, 0);
     }
 
+    private void setColorUniforms(int color) {
+        float x,y,z;
+
+        // this lets us harmlessly deal with patterns without
+        // the iColorXXX controls, because the unset uniforms
+        // will default to 0.
+        if (color == 0) return;
+
+        x = (float) (0xff & LXColor.red(color)) / 255f;
+        y = (float) (0xff & LXColor.green(color)) / 255f;
+        z = (float) (0xff & LXColor.blue(color)) / 255f;
+        setUniform("iColorRGB",x,y,z);
+
+        x = LXColor.h(color) / 360f;
+        y = LXColor.s(color) / 100f;
+        z = LXColor.b(color)/ 100f;
+        setUniform("iColorHSB",x,y,z);
+    }
+
     private void setUniforms(GL4 gl4) {
         float timeSeconds = ((float) (System.currentTimeMillis() - startTime)) / 1000;
 
@@ -186,6 +203,7 @@ public class NativeShader implements GLEventListener {
         for (Map.Entry<Uniforms.Audio, Float> audioEntry : audioInfo.getUniformMap().entrySet()) {
             setUniform(audioEntry.getKey().getUniformName(), audioEntry.getValue());
         }
+        setColorUniforms(audioInfo.color);
 
         // if enabled, add all LX parameters as uniforms
         if (shaderOptions.getLXParameterUniforms()) {


### PR DESCRIPTION
Adds a linked color control, tied to the current palette, to all patterns built using the ConstructedPattern mechanism.  (This is most of the GLSL shaders.)

Patterns created with a PatternTarget specifying edges only will get the **ColorType.EDGE** color,  all other patterns will get **ColorType.PANELS**.

The current color setting is transmitted to shaders via two new uniforms:
```
vec3 iColorRGB;  // palette color as normalized (0.0 to 1.0) RGB
vec3 iColorHSB.  // palette color as normalized (0.0 to 1.0) HSB
```
Shaders can use either or both as needed.   

The control appears immediately on all constructed shaders, but it won't do anything 'till the shader
code is changed to make use of it.   I've made a one line change to the shader **marbling.fs** as a demo.
