### PR TITLE
Give GLSL shaders access to the complete TE palette

### DIFF
--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -6,7 +6,7 @@ uniform float iTime;
 uniform vec2 iResolution;
 uniform vec4 iMouse;
 uniform vec3 iColorRGB;
-uniform vec3 iColorHSB;
+uniform vec3 iPalette[5];
 uniform sampler2D iChannel0;
 uniform sampler2D iChannel1;
 uniform sampler2D iChannel2;
@@ -16,6 +16,12 @@ uniform float beat;
 uniform float sinPhaseBeat;
 uniform float bassLevel;
 uniform float trebleLevel;
+
+#define TE_EDGE 0
+#define TE_SECONDARY 1
+#define TE_PANEL 2
+#define TE_EDGE_BG 3
+#define TE_PANEL_BG 4
 
 {{%shader_body%}}
 

--- a/resources/shaders/palette_test.fs
+++ b/resources/shaders/palette_test.fs
@@ -1,0 +1,28 @@
+// fork of https://www.shadertoy.com/view/WtdXR8
+// Demo of new iPalette capability - switches between palette colors every second
+
+
+// these constants are predefined and can be used by all shaders
+// to index iPalette[] when choosing a palette color:
+//
+// TE_EDGE      - Primary color to use on edges
+// TE_SECONDARY - Secondary color to use on edges or panels
+// TE_PANEL     - Primary color to use on panels
+// TE_EDGE_BG   - Background color to use on edges
+// TE_PANEL_BG  - Background color to use on edges
+
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ){
+    vec2 uv =  ({%tile[.5,2,15]} * fragCoord - iResolution.xy) / min(iResolution.x, iResolution.y);
+
+    for(float i = 1.0; i < {%curve[10,1,10]}; i++){
+        uv.x += 0.6 / i * cos(i * {%xWave[2.5,1,10]}* uv.y + iTime);
+        uv.y += 0.6 / i * cos(i * {%yWave[1.5,1,10]} * uv.x + iTime);
+    }
+
+    //fragColor = vec4(vec3(0.1)/abs(sin(iTime-uv.y-uv.x)),1.0);
+
+    // switch between palette colors at 1hz!
+    vec3 col = iPalette[int(mod(iTime,5f))];
+    fragColor = vec4(col*abs(sin(iTime-uv.y-uv.x)),1.0);
+}

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -222,7 +222,7 @@ public class ShaderPanelsPatternConfig {
         }
     }
 
-    @LXCategory("Native Shaders Panels")
+    @LXCategory("Test")
     public static class AudioTest2 extends ConstructedPattern {
         public AudioTest2(LX lx) {
             super(lx);
@@ -230,6 +230,18 @@ public class ShaderPanelsPatternConfig {
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("audio_test2.fs",
+                    PatternTarget.allPanelsAsCanvas(this)));
+        }
+    }
+
+    @LXCategory("Test")
+    public static class ShaderPaletteTest extends ConstructedPattern {
+        public ShaderPaletteTest(LX lx) {
+            super(lx);
+        }
+        @Override
+        protected List<PatternEffect> createEffects() {
+            return List.of(new NativeShaderPatternEffect("palette_test.fs",
                     PatternTarget.allPanelsAsCanvas(this)));
         }
     }

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/AudioInfo.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/AudioInfo.java
@@ -6,6 +6,7 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.NormalizedParameter;
 import titanicsend.util.TEMath;
 
+import java.nio.FloatBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +18,7 @@ public class AudioInfo {
     float fftResampleFactor;
 
     int color;
+    FloatBuffer palette;
 
     public AudioInfo(GraphicMeter meter) {
         this.meter = meter;
@@ -24,7 +26,9 @@ public class AudioInfo {
     }
 
     
-    public void setFrameData(double basis, double sinPhaseBeat, double bassLevel, double trebleLevel, int col) {
+    public void setFrameData(double basis, double sinPhaseBeat,
+                             double bassLevel, double trebleLevel, int col,
+                             FloatBuffer pal) {
         uniformMap = Map.of(
             Uniforms.Audio.BEAT, (float) basis,
             Uniforms.Audio.SIN_PHASE_BEAT, (float) sinPhaseBeat,
@@ -32,6 +36,7 @@ public class AudioInfo {
             Uniforms.Audio.TREBLE_LEVEL, (float) trebleLevel
         );
 
+        this.palette = pal;
         this.color = col;
     }
 


### PR DESCRIPTION
### Added new uniform, available to all shaders:
```
uniform vec3 iPalette[];
```
This contains all the colors available in the current palette.  I've added the following handy constants to 
make it easy to index the color you want:
```
// TE_EDGE      - Primary color to use on edges
// TE_SECONDARY - Secondary color to use on edges or panels
// TE_PANEL     - Primary color to use on panels
// TE_EDGE_BG   - Background color to use on edges
// TE_PANEL_BG  - Background color to use on edges
```
So, for example to use the current primary panel color in your shader, you could:

``` 
vec3 color = iPalette[TE_PANEL];
```
### Other things:
The previous  ```iColorRGB``` which contains the current setting of the pattern's color control, is still available.   

I removed ```iColorHSB``` in this build, to save some calculation at frame time.  If anybody needs it back, or needs a good way to convert between color formats in a shader, just ask.

