### PR TITLE
Keep pixelblaze emulator from touching the gapPoint

### DIFF
--- a/resources/pixelblaze/glue.js
+++ b/resources/pixelblaze/glue.js
@@ -206,6 +206,7 @@ function glueRender() {
   for (i = 0; i < __points.length; i++) {
     __color = 0;
     point = __points[i];
+    if (point == __pattern.model.gapPoint) continue;
     r(i, point.xn, point.yn, point.zn);
     __colors[point.index] = __color;
   }


### PR DESCRIPTION
Fixed for all Pixelblaze patterns in the javascript glue.  