### PR TITLE
Fixes for shadertoy shaders and local file textures

### DIFF
--- a/resources/shaders/jet_stream.fs
+++ b/resources/shaders/jet_stream.fs
@@ -85,13 +85,13 @@ float nse3d(in vec3 x)
     vec3 f = fract(x);
 	f = f * f * (3.0 - 2.0 * f);
 	vec2 uv = (p.xy + vec2(37.0, 17.0) * p.z) + f.xy;
-	vec2 rg = textureLod( iChannel0, (uv+.5)/256., 0.).yx;
+	vec2 rg = textureLod( iChannel1, (uv+.5)/256., 0.).yx;
 	return mix(rg.x, rg.y, f.z);
 }
 
 float nse(vec2 p)
 {
-    return texture(iChannel0, p).x;
+    return texture(iChannel1, p).x;
 }
 
 float density2(vec2 p, float z, float t)

--- a/resources/shaders/storm_scanner.fs
+++ b/resources/shaders/storm_scanner.fs
@@ -13,7 +13,7 @@
 #define time iTime*0.2
 
 mat2 makem2(in float theta){float c = cos(theta);float s = sin(theta);return mat2(c,-s,s,c);}
-float noise( in vec2 x ){return texture(iChannel0, x*.01).x;}
+float noise( in vec2 x ){return texture(iChannel1, x*.01).x;}
 
 mat2 m2 = mat2( 0.80,  0.60, -0.60,  0.80 );
 float fbm( in vec2 p )

--- a/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/NativeShaderPatternEffect.java
@@ -46,19 +46,19 @@ public class NativeShaderPatternEffect extends PatternEffect {
     public NativeShaderPatternEffect(FragmentShader fragmentShader, PatternTarget target, ShaderOptions options) {
         super(target);
         this.colorType = target.colorType;
+        this.audioInfo = new AudioInfo(pattern.getLX().engine.audio.meter);
+        this.shaderOptions = options;
+        painter = new ShaderPainter();
+
+        // create an 5 x 3 array that we can pass to OpenGL so we can
+        // share the entire current palette with GLSL shaders
+        this.palette = Buffers.newDirectFloatBuffer(15);
+
 
         if (fragmentShader != null) {
             this.fragmentShader = fragmentShader;
             this.offscreenShaderRenderer = new OffscreenShaderRenderer(fragmentShader,options);
             this.parameters = fragmentShader.getParameters();
-            this.audioInfo = new AudioInfo(pattern.getLX().engine.audio.meter);
-            this.shaderOptions = options;
-
-            // create an 5 x 3 array that we can pass to OpenGL so we can
-            // share the entire current palette with GLSL shaders
-            this.palette = Buffers.newDirectFloatBuffer(15);
-
-            painter = new ShaderPainter();
 
         } else {
             this.parameters = null;
@@ -124,19 +124,21 @@ public class NativeShaderPatternEffect extends PatternEffect {
         int col;
         float r,g,b;
 
-        palette.rewind();
-        for (int i = 0; i < 5; i++) {
+        if (palette != null ) {
+            palette.rewind();
+            for (int i = 0; i < 5; i++) {
 
-            int color = pattern.getLX().engine.palette.swatch.getColor(i).getColor();
+                int color = pattern.getLX().engine.palette.swatch.getColor(i).getColor();
 
-            r = (float) (0xff & LXColor.red(color)) / 255f;
-            palette.put(r);
-            g = (float) (0xff & LXColor.green(color)) / 255f;
-            palette.put(g);
-            b = (float) (0xff & LXColor.blue(color)) / 255f;
-            palette.put(b);
+                r = (float) (0xff & LXColor.red(color)) / 255f;
+                palette.put(r);
+                g = (float) (0xff & LXColor.green(color)) / 255f;
+                palette.put(g);
+                b = (float) (0xff & LXColor.blue(color)) / 255f;
+                palette.put(b);
+            }
+            palette.rewind();
         }
-        palette.rewind();
     }
 
 

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
@@ -51,7 +51,10 @@ public class PatternTarget {
     }
 
     public static PatternTarget allPointsAsCanvas(TEAudioPattern pattern) {
-        return new PatternTarget(pattern).addPointsAsCanvas(pattern.getModel().getPoints());
+        PatternTarget pt = new PatternTarget(pattern);
+        pt.addPointsAsCanvas(pattern.getModel().panelPoints);
+        pt.addPointsAsCanvas(pattern.getModel().edgePoints);
+        return pt;
     }
 
     public static PatternTarget allEdgesAsCanvas(TEAudioPattern pattern) {

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -221,8 +221,6 @@ public class NativeShader implements GLEventListener {
         // add texture channels
         // TODO - need to expand the "setUniform()" mechanism to support textures too.
 
-        // track textures loaded from file or URL so we can set our audio channel
-        // after the last one.
         for (Map.Entry<Integer, Texture> textureInput : textures.entrySet()) {
             Texture texture = textureInput.getValue();
             gl4.glActiveTexture(INDEX_TO_GL_ENUM.get(textureInput.getKey()));
@@ -236,12 +234,8 @@ public class NativeShader implements GLEventListener {
             texture.disable(gl4);
         }
 
-        // if enabled, set audio waveform and fft data as a 512x2 texture on the first
-        // available iChannel after other user supplied textures.
-        //
-        // NOTE: That if you're using all 4 pre-declared iChannels for textures
-        // and you still want to use audio, you'll have to declare "uniform sampler2D iChannel4"
-        // in your shader code.
+        // if enabled, set audio waveform and fft data as a 512x2 texture on the specified audio
+        // channel if it's a shadertoy shader, or iChannel0 if it's a local shader.
         if (audioChannel != null && shaderOptions.getWaveData()) {
 
             gl4.glActiveTexture(INDEX_TO_GL_ENUM.get(0));

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
@@ -36,7 +36,6 @@ public class ShaderPainter {
     public void paint(Collection<? extends TEModel> panels) {
         Dimensions dimensions = Dimensions.fromModels(panels);
 
-
         for (TEModel panel : panels) {
             for (LXPoint point : panel.getPoints()) {
                 paint(point, dimensions);

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
@@ -33,16 +33,6 @@ public class ShaderPainter {
         return image[0].length;
     }
 
-    public void paint(Collection<? extends TEModel> panels) {
-        Dimensions dimensions = Dimensions.fromModels(panels);
-
-        for (TEModel panel : panels) {
-            for (LXPoint point : panel.getPoints()) {
-                paint(point, dimensions);
-            }
-        }
-    }
-
     public void paint(LXPoint point, Dimensions canvasDimensions) {
         // here the 'z' dimension of TE corresponds with 'x' dimension of the image based on the side that
         // we're painting

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
@@ -140,6 +140,9 @@ public class ShaderUtils {
      */
     public static boolean loadShaderFromCache(GL4 gl4,int programID, String shaderName, long timeStamp) {
 
+        // account for shadertoy shaders pulled in via URL
+        if (shaderName == null) return false;
+
         // compare timestamp to see if the shader has been updated.
         File shaderBin = new File(shaderName);
         if (!shaderBin.exists()) {
@@ -177,6 +180,9 @@ public class ShaderUtils {
      * resources/shaders/cache
      */
     public static void saveShaderToCache(GL4 gl4, String shaderName, int programId) {
+
+        // account for shadertoy shaders pulled in via URL
+        if (shaderName == null) return;
 
         // get the size of the shader binary in bytes
         int[] len = new int[1];


### PR DESCRIPTION
For now, here's our texture behavior:
- For local shaders, LX audio is **always** on iChannel0.  This means that if you bring in a shader with textures on iChannel0, you have to move them to another channel in the code.  I've done this for jetstream and stormscanner.
- For shadertoy shaders, if they support audio, it must be on iChannel0.  If they don't, they can use that channel freely for textures.   This works with a great many shadertoy shaders, including most of the audio-enabled spectrum meters, and such.  But of course, there are going to be exceptions.
- Shadertoy shaders can use non-audio textures on all 4 channels if they like.

(the aspect ratio/panel mapping problem doesn't appear to be shader-related.  Will deal with that separately.)