### PR TITLE
Edgefall:  Fix log spam

### DIFF
--- a/src/main/java/titanicsend/pattern/jon/EdgeFall.java
+++ b/src/main/java/titanicsend/pattern/jon/EdgeFall.java
@@ -148,7 +148,7 @@ public class EdgeFall extends TEAudioPattern {
                         // don't use the upper panels
                         if (panel.getId().startsWith("SU")) continue;
 
-                        TE.log("We like edge: %s",edge.getId());
+                        //TE.log("We like edge: %s",edge.getId());
                         getLineFromEdge(edgeCount,edge.getId());
                         edgeCount++;
                         break;


### PR DESCRIPTION
Oops.  Disabled debug logger on vehicle->glsl edge coord mapper.  Don't need to see the edges it picks, now that it's working!