### PR TITLE
Quick fix - filter gap pixels at pattern init time.

### DIFF
--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
@@ -28,7 +28,11 @@ public class PatternTarget {
 
     public PatternTarget addPointsAsCanvas(Collection<LXPoint> points) {
         Dimensions dimensions = Dimensions.fromPoints(points);
-        points.forEach(point -> pointsToCanvas.put(point, dimensions));
+        for (LXPoint point : points) {
+            // skip gap points
+            if ((point.x == 0f) && (point.y == 0f) && (point.z == 0f)) continue;
+            pointsToCanvas.put(point,dimensions);
+        }
         return this;
     }
 

--- a/src/main/java/titanicsend/util/Dimensions.java
+++ b/src/main/java/titanicsend/util/Dimensions.java
@@ -169,6 +169,9 @@ public class Dimensions {
         Float maxZn = null;
         
         for (LXPoint point : points) {
+            // skip gap points
+            if ((point.x == 0f) && (point.y == 0f) && (point.z == 0f)) continue;
+
             minX = minX == null ? point.x : Math.min(point.x, minX);
             minY = minY == null ? point.y : Math.min(point.y, minY);
             minZ = minZ == null ? point.z : Math.min(point.z, minZ);


### PR DESCRIPTION
Gets gap pixels out of all patterns that use ConstructedPattern/PatternTarget.

**This fix requires that gap pixel x,yz all be 0.**  At the moment, this always appears to be the case.

In the longer term  we could probably pass the gap pixel object from TEWholeModel on down the hierarchy to use for these comparisons, or build a separate getSafePoints() interface with its own point list.