### PR TITLE
Fix some compile warnings

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -21,10 +21,13 @@ package titanicsend.app;
 import java.io.File;
 import java.io.IOException;
 import java.net.SocketException;
+import java.util.Arrays;
+import java.util.function.Function;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXPlugin;
 import heronarts.lx.parameter.LXParameterListener;
+import heronarts.lx.pattern.LXPattern;
 import heronarts.lx.pattern.color.GradientPattern;
 import heronarts.lx.pattern.texture.NoisePattern;
 import heronarts.lx.pattern.texture.SparklePattern;
@@ -150,9 +153,17 @@ public class TEApp extends PApplet implements LXPlugin  {
     lx.registry.addPattern(ArtStandards.class);
     lx.registry.addEffect(titanicsend.effect.BasicEffect.class);
     lx.registry.addEffect(titanicsend.effect.Kaleidoscope.class);
-    lx.registry.addPatterns(OrganicPatternConfig.getPatterns());
-    lx.registry.addPatterns(ShaderPanelsPatternConfig.getPatterns());
-    lx.registry.addPatterns(ShaderEdgesPatternConfig.getPatterns());
+
+    @SuppressWarnings("unchecked")
+    Function<Class<?>, Class<LXPattern>[]> patternGetter =
+        (Class<?> patternConfigClass) ->
+            (Class<LXPattern>[]) Arrays.stream(patternConfigClass.getDeclaredClasses())
+            .filter(LXPattern.class::isAssignableFrom)
+            .toArray();
+
+    lx.registry.addPatterns(patternGetter.apply(OrganicPatternConfig.class));
+    lx.registry.addPatterns(patternGetter.apply(ShaderPanelsPatternConfig.class));
+    lx.registry.addPatterns(patternGetter.apply(ShaderEdgesPatternConfig.class));
 
     // Test/debug patterns
     lx.registry.addPattern(ModelDebugger.class);

--- a/src/main/java/titanicsend/app/TEVirtualOverlays.java
+++ b/src/main/java/titanicsend/app/TEVirtualOverlays.java
@@ -226,7 +226,7 @@ public class TEVirtualOverlays extends TEUIComponent {
 
         pg.scale(10000, -10000);
         pg.fill(255, 0, 0);
-        pg.textAlign(pg.CENTER, pg.CENTER);
+        pg.textAlign(PGraphics.CENTER, PGraphics.CENTER);
         pg.text(entry.getKey(), 0, 0, -100000);
         pg.popMatrix();
       }

--- a/src/main/java/titanicsend/app/autopilot/TEPatternLibrary.java
+++ b/src/main/java/titanicsend/app/autopilot/TEPatternLibrary.java
@@ -101,15 +101,15 @@ public class TEPatternLibrary {
          */
         public static HashSet<TEPatternColorCategoryType> getCompatible(TEPatternColorCategoryType colorCat) {
             if (colorCat == PALETTE) {
-                return new HashSet(List.of(PALETTE, WHITE, NONCONFORMING));
+                return new HashSet<>(List.of(PALETTE, WHITE, NONCONFORMING));
             } else if (colorCat == WHITE) {
-                return  new HashSet(List.of(PALETTE, WHITE, NONCONFORMING));
+                return  new HashSet<>(List.of(PALETTE, WHITE, NONCONFORMING));
             } else if (colorCat == NONCONFORMING) {
-                return  new HashSet(List.of(PALETTE, WHITE));
+                return  new HashSet<>(List.of(PALETTE, WHITE));
             }
 
             // default to allowing everything
-            return  new HashSet(List.of(PALETTE, WHITE, NONCONFORMING));
+            return  new HashSet<>(List.of(PALETTE, WHITE, NONCONFORMING));
         }
     }
 

--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -157,7 +157,7 @@ public abstract class TEAudioPattern extends TEPattern {
 
     public void addParameters(List<? extends LXParameter> newParameters) {
         for(LXParameter parameter : newParameters) {
-            addParameter(parameter);
+            addParameter(parameter.getLabel(), parameter);
         }
     }
 }

--- a/src/main/java/titanicsend/pattern/ben/BassLightning.java
+++ b/src/main/java/titanicsend/pattern/ben/BassLightning.java
@@ -231,7 +231,7 @@ public class BassLightning extends TEAudioPattern {
 
 		this.model.vertexesById.values().forEach(v -> {
 			v.virtualColor.alpha *= .99;
-			v.virtualColor.alpha = (float) Math.max(64, v.virtualColor.alpha);
+			v.virtualColor.alpha = Math.max(64, v.virtualColor.alpha);
 		} );
 
 		synchronized (bolts) {

--- a/src/main/java/titanicsend/pattern/ben/BassLightning.java
+++ b/src/main/java/titanicsend/pattern/ben/BassLightning.java
@@ -78,10 +78,10 @@ public class BassLightning extends TEAudioPattern {
 			ArrayList<TEEdgeModel> candidateEdges;
 
 			if (allowLoopsParam.getValueb()) {
-				candidateEdges = new ArrayList(origin.edges);
+				candidateEdges = new ArrayList<>(origin.edges);
 				candidateEdges.remove(edge);
 			} else {
-				candidateEdges = new ArrayList(
+				candidateEdges = new ArrayList<>(
 						origin.edges.stream().filter(e -> !visitedEdges.contains(e.getId())).collect(Collectors.toList())
 				);
 			}

--- a/src/main/java/titanicsend/pattern/jon/FrameBrights.java
+++ b/src/main/java/titanicsend/pattern/jon/FrameBrights.java
@@ -88,10 +88,10 @@ public class FrameBrights extends TEAudioPattern {
     // choose between minLit and maxLit random segments of an edge to light
     // and prepare the data necessary to do quickly
     void lightRandomSegments(int zoneCount, int minLit, int maxLit) {
-        int nLit = Math.max(minLit,(int) Math.round(maxLit * prng.nextFloat()));
+        int nLit = Math.max(minLit, Math.round(maxLit * prng.nextFloat()));
 
         // set all segments dark
-        for (int i = 0; i < (int) zoneCount; i++) {
+        for (int i = 0; i < zoneCount; i++) {
             zoneIsLit[i] = false;
         }
 

--- a/src/main/java/titanicsend/pattern/jon/Iceflow.java
+++ b/src/main/java/titanicsend/pattern/jon/Iceflow.java
@@ -24,7 +24,7 @@ public class Iceflow extends TEAudioPattern {
     // In this pattern the "energy" is how quickly the scenes can progress,
     // IE shorter tempoDivisions
 
-    protected final CompoundParameter focus = (CompoundParameter)
+    protected final CompoundParameter focus =
             new CompoundParameter("Detail", 5, 4, 8)
                     .setDescription("Detail/Sharpness");
 

--- a/src/main/java/titanicsend/pattern/tom/Fire.java
+++ b/src/main/java/titanicsend/pattern/tom/Fire.java
@@ -21,10 +21,10 @@ public class Fire extends TEPattern {
     private int[][] buffer;
     private int[] gradient;
 
-    protected final CompoundParameter fuel = (CompoundParameter)
+    protected final CompoundParameter fuel =
             new CompoundParameter("Fuel", 1);
 
-    protected final CompoundParameter colorPosition = (CompoundParameter)
+    protected final CompoundParameter colorPosition =
             new CompoundParameter("Color Position", 0.5);
 
     public final LinkedColorParameter fireColor =

--- a/src/main/java/titanicsend/pattern/tom/PulsingTriangles.java
+++ b/src/main/java/titanicsend/pattern/tom/PulsingTriangles.java
@@ -151,6 +151,7 @@ public class PulsingTriangles extends TEPattern {
             BooleanParameter p = (BooleanParameter) parameter;
             this.phase.tempoSync.setValue(p.getValueb());
         } else if (parameter.getPath().equals("tempoDivision")) {
+            @SuppressWarnings("unchecked")
             EnumParameter<Tempo.Division> p = (EnumParameter<Tempo.Division>) parameter;
             this.phase.tempoDivision.setValue(p.getEnum());
         } else if (parameter.getPath().equals("tempoLock")) {

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -16,10 +16,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class OrganicPatternConfig {
 
-    public static Class[] getPatterns() {
-        return OrganicPatternConfig.class.getDeclaredClasses();
-    }
-
     @LXCategory("Yoffa Panel Combo")
     public static class StarryOutrun extends ConstructedPattern {
         public StarryOutrun(LX lx) {

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
@@ -13,10 +13,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class ShaderEdgesPatternConfig {
 
-    public static Class[] getPatterns() {
-        return ShaderEdgesPatternConfig.class.getDeclaredClasses();
-    }
-    
     //multiple
     @LXCategory("Native Shaders Edges")
     public static class LightBeamsEdges extends ConstructedPattern {

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -14,10 +14,6 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class ShaderPanelsPatternConfig {
 
-    public static Class[] getPatterns() {
-        return ShaderPanelsPatternConfig.class.getDeclaredClasses();
-    }
-
     @LXCategory("Native Shaders Panels")
     public static class ShaderToyPattern extends ConstructedPattern {
         public ShaderToyPattern(LX lx) {

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
@@ -55,7 +55,7 @@ public class PatternTarget {
     }
 
     public static PatternTarget allPointsAsCanvas(TEAudioPattern pattern) {
-        ArrayList<LXPoint> points = new ArrayList();
+        ArrayList<LXPoint> points = new ArrayList<>();
         points.addAll(pattern.getModel().panelPoints);
         points.addAll(pattern.getModel().edgePoints);
 

--- a/src/main/java/titanicsend/pattern/yoffa/media/BasicVideoPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/media/BasicVideoPattern.java
@@ -25,7 +25,7 @@ public class BasicVideoPattern extends TEPattern {
 
     public BasicVideoPattern(LX lx) throws IOException {
         super(lx);
-        addParameter(edges);
+        addParameter(edges.getLabel(), edges);
         videoPainter = new VideoPainter(VID_PATH, colors);
     }
 

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -298,7 +298,7 @@ public class NativeShader implements GLEventListener {
         buffer.rewind();
         gl4.glBindBuffer(destinationBufferConstant, bufferHandles[0]);
         gl4.glBufferData(destinationBufferConstant, (long) buffer.capacity() * bufferElementBytes,
-                buffer, gl4.GL_STATIC_DRAW);
+                buffer, GL.GL_STATIC_DRAW);
     }
 
     @Override

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderPainter.java
@@ -47,8 +47,8 @@ public class ShaderPainter {
 
         // calculate so that if normalized x/y are always in range 0-1, x and y will be
         // limited to between the proper image array index range, no clamping is needed
-        int xi = (int) Math.round((1f - normalizedX) * (imageWidth() - 1f));
-        int yi = (int) Math.round(normalizedY * (imageHeight() - 1f));
+        int xi = Math.round((1f - normalizedX) * (imageWidth() - 1f));
+        int yi = Math.round(normalizedY * (imageHeight() - 1f));
 
         colors[point.index] = image[xi][yi];
     }


### PR DESCRIPTION
This fixes four types of warnings:
1. Static-member-access warnings
2. Unchecked and raw type generics-related warnings
3. "Redundant cast" warnings
4. A couple deprecation warnings

I added a bunch of reviewers because those reviewers have touched the code being changed here in some way. Please double-check my work.