### PR TITLE
Update run config and .lxpreferences to default AutoVJ

### DIFF
--- a/.lxpreferences
+++ b/.lxpreferences
@@ -1,6 +1,6 @@
 {
   "version": "0.4.1",
-  "projectFileName": "Debugging.lxp",
+  "projectFileName": "AutoVJ.lxp",
   "windwWidth": 1682,
   "windowHeight": 952,
   "uiZoom": 100,

--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -2,7 +2,7 @@
   <configuration default="false" name="Titanic's End" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="titanicsend.app.TEApp" />
     <module name="LXStudio-TE" />
-    <option name="PROGRAM_PARAMETERS" value="vehicle Vehicle.lxp" />
+    <option name="PROGRAM_PARAMETERS" value="vehicle AutoVJ.lxp" />
     <option name="VM_PARAMETERS" value="-ea" />
     <method v="2">
       <option name="Make" enabled="true" />


### PR DESCRIPTION
This should make the default run configuration and .lxp to load be AutoVJ.lxp

This helps with odd behavior introduced (?) in this PR
https://github.com/titanicsend/LXStudio-TE/pull/147

But also is a move we're making to the car being default ready for CDJ connection and DJ performance