### PR TITLE
Fix startup issue related to Vehicle.lxp

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -113,7 +113,9 @@ public class TEApp extends PApplet implements LXPlugin  {
           if (finalProjectFile.exists()) {
             LX.log("Opening project file passed as argument: " + projectFileName);
             lx.openProject(finalProjectFile);
-          }          
+          } else {
+        	LX.error("Project filename not found: " + projectFileName);
+          }
         } catch (Exception x) {
           LX.error(x, "Exception loading project: " + x.getLocalizedMessage());
         }
@@ -261,8 +263,6 @@ public class TEApp extends PApplet implements LXPlugin  {
 
     GPOutput gpOutput = new GPOutput(lx, this.gpBroadcaster);
     lx.addOutput(gpOutput);
-    
-    loadCLfile(lx);
   }
 
   private TEPatternLibrary initializePatternLibrary(LX lx) {
@@ -361,6 +361,8 @@ public class TEApp extends PApplet implements LXPlugin  {
 
     // precompile binaries for any new or changed shaders
     ShaderPrecompiler.rebuildCache();
+       
+    loadCLfile(lx);
   }
 
   @Override


### PR DESCRIPTION
Turns out openProject() should only be called *after* the UI is built, in case the project file contains mappings to UI elements.

Missed this on my previous testing because I only tested auto-starting AutoVJ.lxp which did not have maps to UI elements.  The autostart broke on Vehicle.lxp because it has a map to the audio meter which is UI.

Tested as working in my [eclipse] environment.