### PR TITLE
MF64 fixes and connectivity improvements

### DIFF
--- a/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
+++ b/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
@@ -5,6 +5,7 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.midi.*;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.mf64.*;
 
 @LXCategory("Combo FG")
@@ -230,29 +231,31 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
     addParameter("pokePitch", this.pokePitch);
     addParameter("poke", this.pokeButton);
 
-    this.fakePush.addListener((p) -> {
-      this.mapping.page = Mapping.Page.LEFT;
-      this.mapping.row = 7;
-      this.mapping.col = 0;
-
-      if (p.getValuef() != 0f) {
-        this.patterns[0].buttonDown(this.mapping);
-      }
-      else {
-        this.patterns[0].buttonUp(this.mapping);
-      }
-    });
-
-    this.pokeButton.addListener((p) -> {
-      if (this.midiOut == null) {
-        LX.log("No MF64 attached");
-      } else {
-        this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
-                this.pokeVelocity.getValuei());
-      }
-    });
-
+    this.fakePush.addListener(this.fakepushListener);
+    this.pokeButton.addListener(this.pokeListener);
   }
+
+  private final LXParameterListener fakepushListener = (p) -> {
+    this.mapping.page = Mapping.Page.LEFT;
+    this.mapping.row = 7;
+    this.mapping.col = 0;
+    
+    if (p.getValuef() != 0f) {
+      this.patterns[0].buttonDown(this.mapping);
+    }
+    else {
+      this.patterns[0].buttonUp(this.mapping);
+    }
+  };
+
+  private final LXParameterListener pokeListener = (p) -> {
+    if (this.midiOut == null) {
+      LX.log("No MF64 attached");
+    } else {
+      this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
+        this.pokeVelocity.getValuei());
+    }
+  };
 
   private void sendAllOff() {
     for (int channel = 2; channel >= 1; channel--) {
@@ -349,5 +352,12 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
     this.eSparks.run(deltaMs,colors);
     this.spin.run(deltaMs,colors);
     this.xwave.run(deltaMs,colors);
+  }
+  
+  @Override
+  public void dispose() {
+	this.fakePush.removeListener(this.fakepushListener);
+	this.pokeButton.removeListener(this.pokeListener);
+	super.dispose();
   }
 }

--- a/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
+++ b/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
@@ -236,24 +236,28 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
   }
 
   private final LXParameterListener fakepushListener = (p) -> {
-    this.mapping.page = Mapping.Page.LEFT;
-    this.mapping.row = 7;
-    this.mapping.col = 0;
+    if (this.fakePush.isOn()) {
+      this.mapping.page = Mapping.Page.LEFT;
+      this.mapping.row = 7;
+      this.mapping.col = 0;
     
-    if (p.getValuef() != 0f) {
-      this.patterns[0].buttonDown(this.mapping);
-    }
-    else {
-      this.patterns[0].buttonUp(this.mapping);
+      if (p.getValuef() != 0f) {
+        this.patterns[0].buttonDown(this.mapping);
+      }
+      else {
+        this.patterns[0].buttonUp(this.mapping);
+      }
     }
   };
 
   private final LXParameterListener pokeListener = (p) -> {
-    if (this.midiOut == null) {
-      LX.log("No MF64 attached");
-    } else {
-      this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
-        this.pokeVelocity.getValuei());
+    if (this.pokeButton.isOn()) {
+	  if (this.midiOut == null) {
+        LX.log("No MF64 attached");
+      } else {
+        this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
+          this.pokeVelocity.getValuei());
+      }
     }
   };
 

--- a/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
+++ b/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
@@ -254,6 +254,8 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
     if (this.pokeButton.isOn()) {
 	  if (this.midiOut == null) {
         LX.log("No MF64 attached");
+	  } else if (!this.midiOut.connected.isOn()) {
+		LX.log("MF64 was diconnected.  Please reconnect physical device.");
       } else {
         this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
           this.pokeVelocity.getValuei());

--- a/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
+++ b/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
@@ -161,11 +161,11 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
                   .setDescription("Channel number");
 
   public final DiscreteParameter pokeVelocity =
-          new DiscreteParameter("Vel", 0, 256)
+          new DiscreteParameter("Vel", 0, 128)
                   .setDescription("Velocity");
 
   public final DiscreteParameter pokePitch =
-          new DiscreteParameter("Pitch", 0, 256)
+          new DiscreteParameter("Pitch", 0, 128)
                   .setDescription("Pitch");
 
   public final BooleanParameter pokeButton =
@@ -258,6 +258,7 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
 	  } else if (!this.midiOut.connected.isOn()) {
 		LX.log("MF64 connection lost.  Please reconnect physical device.");
       } else {
+        LX.log("Poke MF64 at Channel=" + this.pokeChannel.getValuei() + ", Pitch=" + this.pokePitch.getValuei() + ", Velocity=" + this.pokeVelocity.getValuei());
         this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
           this.pokeVelocity.getValuei());
       }

--- a/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
+++ b/src/main/java/titanicsend/pattern/TEMidiFighter64DriverPattern.java
@@ -256,7 +256,7 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
         LX.log("No MF64 attached. Checking again...");
         connect();
 	  } else if (!this.midiOut.connected.isOn()) {
-		LX.log("MF64 was diconnected.  Please reconnect physical device.");
+		LX.log("MF64 connection lost.  Please reconnect physical device.");
       } else {
         this.midiOut.sendNoteOn(this.pokeChannel.getValuei(), this.pokePitch.getValuei(),
           this.pokeVelocity.getValuei());
@@ -313,6 +313,7 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
         } else {
           this.midiOut = lmo;
           lmo.open();
+          lmo.connected.addListener(this.midiOutConnectedListener);
           sendColors();
         }
       }
@@ -339,6 +340,7 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
       this.midiIn.removeListener(this);
     }
     if (this.midiOut != null) {
+      this.midiOut.connected.removeListener(this.midiOutConnectedListener);
       if (this.midiOut.connected.isOn()) {
         sendAllOff();
       }
@@ -346,6 +348,15 @@ public class TEMidiFighter64DriverPattern extends TEPattern implements LXMidiLis
     this.midiIn = null;
     this.midiOut = null;
   }
+  
+  private final LXParameterListener midiOutConnectedListener = (p) -> {
+    // Note this pattern is duplicating a lot of LXMidiSurface behavior
+    if (this.midiOut.connected.isOn()) {    	
+      // It's a reconnect.  Bring the lights back on!
+      sendColors();
+      LX.log("Reconnected to MF64 device!");
+    }
+  };
 
   @Override
   public void noteOnReceived(MidiNoteOn note) {


### PR DESCRIPTION
Fixed stranded listener errors and  improved connection retention and troubleshooting with Poke button:

- Fix double-poke and double-push, only do action on button down not button up
- If device loses connection, inform user on Poke button push
- If program was started without device connected, then cable is plugged in, connection can be established by pressing the Poke button
- Resend surface lights on reconnection (previously, unplug/plugging midi surface would lose lights)
- Restrict pitch and velocity to valid midi ranges (previously, poking >127 threw error)