### PR TITLE
Mode for phrase changes with no OSC

### DIFF
--- a/src/main/java/titanicsend/app/TEAutopilot.java
+++ b/src/main/java/titanicsend/app/TEAutopilot.java
@@ -186,6 +186,8 @@ public class TEAutopilot implements LXLoopTask {
 
             } else {
                 //TE.log("Adding OSC message to queue: %s", address);
+                history.setLastOscMsgAt(oscTE.timestamp);
+                noOscModeOn = false;
                 unprocessedOscMessages.add(oscTE);
             }
         } catch (Exception e) {
@@ -332,12 +334,9 @@ public class TEAutopilot implements LXLoopTask {
 
                 // handle OSC message based on type
                 if (TEOscMessage.isBeat(address)) {
-                    history.setLastOscMsgAt(now);
                     onBeatEvent(oscTE);
 
                 } else if (TEOscMessage.isPhraseChange(address)) {
-                    history.setLastOscMsgAt(now);
-
                     // let's make sure this is a valid phrase change!
                     int msSinceLastMasterChange = history.calcMsSinceLastDeckChange();
                     int msSinceLastDownbeat = history.calcMsSinceLastDownbeat();
@@ -583,8 +582,8 @@ public class TEAutopilot implements LXLoopTask {
         this.updatePhraseState(detectedPhrase);
         boolean predictedCorrectly = (oldNextPhrase == curPhrase);
         boolean isSamePhrase = (prevPhrase == curPhrase);
-        TE.log("HIT: %s: [%s -> %s -> %s (?)], (old next: %s) oscBeatModeOnlyOn=%s"
-                , curPhrase, prevPhrase, curPhrase, nextPhrase, oldNextPhrase, oscBeatModeOnlyOn);
+        TE.log("HIT: %s: [%s -> %s -> %s (?)], (old next: %s) OSC beats=%s No OSC=%s"
+                , curPhrase, prevPhrase, curPhrase, nextPhrase, oldNextPhrase, oscBeatModeOnlyOn, noOscModeOn);
 
         // record history for pattern library
         // need to do this before we a) pick new patterns, and b) logPhrase() with historian

--- a/src/main/java/titanicsend/app/TEAutopilot.java
+++ b/src/main/java/titanicsend/app/TEAutopilot.java
@@ -179,7 +179,6 @@ public class TEAutopilot implements LXLoopTask {
     protected void onOscMessage(OscMessage msg) {
         try {
             TEOscMessage oscTE = new TEOscMessage(msg);
-
             if (!isEnabled()) {
                 // if autopilot isn't enabled, don't bother tracking these
                 return;
@@ -187,7 +186,14 @@ public class TEAutopilot implements LXLoopTask {
             } else {
                 //TE.log("Adding OSC message to queue: %s", address);
                 history.setLastOscMsgAt(oscTE.timestamp);
-                noOscModeOn = false;
+
+                // if we'd previously entered No OSC mode, let's turn that off
+                if (noOscModeOn) {
+                    noOscModeOn = false;
+                    TE.log("No OSC mode OFF! We got OSC message");
+                }
+
+                // then add message to queue to be processed on next loop()
                 unprocessedOscMessages.add(oscTE);
             }
         } catch (Exception e) {

--- a/src/main/java/titanicsend/app/autopilot/TEHistorian.java
+++ b/src/main/java/titanicsend/app/autopilot/TEHistorian.java
@@ -163,11 +163,19 @@ public class TEHistorian {
 
     public void resetBeatTracking() {
         beatEvents = new CircularFifoQueue<TEBeatEvent>(BEAT_MAX_WINDOW);
+        long now = System.currentTimeMillis();
+        lastBeatAt = now;
     }
 
     public void resetPhraseTracking() {
         phraseEvents = new CircularFifoQueue<TEPhraseEvent>(PHRASE_EVENT_MAX_WINDOW);
         curPhraseEvent = null;
+
+        // reset osc message tracking timestamps
+        long now = System.currentTimeMillis();
+        lastSynthethicPhraseAt = now;
+        lastOscPhraseAt = now;
+        lastOscMsgAt = now;
     }
 
     public void resetDeckChangeTracking() {

--- a/src/main/java/titanicsend/app/autopilot/TEHistorian.java
+++ b/src/main/java/titanicsend/app/autopilot/TEHistorian.java
@@ -56,8 +56,15 @@ public class TEHistorian {
     private long lastBeatAt;
     private long lastDownbeatAt;
 
+    // last time we saw any OSC message
+    private long lastOscMsgAt;
+
     // timestamp of when we saw OSC phrase event last at
     private long lastOscPhraseAt;
+
+    // timestamp of when we last triggered a synthetic phrase (no OSC)
+    private long lastSynthethicPhraseAt;
+
     // timestamp of when we started the most recent palette
     private long paletteStartedAt;
 
@@ -219,5 +226,17 @@ public class TEHistorian {
 
     public long getPaletteStartedAt() {
         return paletteStartedAt;
+    }
+
+    public void setLastSynthethicPhraseAt(long timestamp) {
+        lastSynthethicPhraseAt = timestamp;
+    }
+    public long getLastSynthethicPhraseAt() { return lastSynthethicPhraseAt; }
+
+    public void setLastOscMsgAt(long timestamp) {
+        lastOscMsgAt = timestamp;
+    }
+    public long getLastOscMsgAt() {
+        return lastOscMsgAt;
     }
 }


### PR DESCRIPTION
We now have three "modes" of operation:

- Normal: we're getting OSC messages and phrase data
- OSC beat only: we're getting beat, tempo data, but NOT phrase data
- No OSC mode: we're getting no input, we need to tap to get tempo!

Autopilot should now work in all of these conditions!