### PR TITLE
Avoid long load time error

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -362,7 +362,9 @@ public class TEApp extends PApplet implements LXPlugin  {
     // precompile binaries for any new or changed shaders
     ShaderPrecompiler.rebuildCache();
        
-    loadCLfile(lx);
+    lx.engine.addTask(() -> {
+      loadCLfile(lx);
+    });
   }
 
   @Override


### PR DESCRIPTION
Move the command line filename openProject() command to an engine task so it doesn't take away from the 5 second load time limit.

This works on my machine, but checking to see if there is a better way to avoid this problem...