### PR TITLE
Quick Fix for Kaleidoscope index out of bounds error

### DIFF
--- a/src/main/java/titanicsend/effect/Kaleidoscope.java
+++ b/src/main/java/titanicsend/effect/Kaleidoscope.java
@@ -27,6 +27,9 @@ public class Kaleidoscope extends BasicEffect {
         addParameter("startAngle", this.startAngle);
     }
 
+    private final double LOG_FREQUENCY = 60000;
+    private double lastLogTime = 0;
+    
     @Override
     protected void run(double deltaMs, double enabledAmount) {
         if (enabledAmount > 0) {
@@ -46,6 +49,10 @@ public class Kaleidoscope extends BasicEffect {
                 projection.iterator().forEachRemaining(vectors::add);
                 if (vectors.size() < 2) {
                 	// JBelcher note: I don't know the context here, just patching last minute errors before BM
+                	if (this.lx.engine.nowMillis > lastLogTime + LOG_FREQUENCY) {
+                		LX.log("Warning! Kaleidoscope effect is trying to reference index 1 in a single-item array of vectors");
+                		this.lastLogTime = this.lx.engine.nowMillis;
+                	}
                 	continue;
                 }
                 LXVector normal = vectors.get(0).copy().cross(vectors.get(1));

--- a/src/main/java/titanicsend/effect/Kaleidoscope.java
+++ b/src/main/java/titanicsend/effect/Kaleidoscope.java
@@ -42,7 +42,12 @@ public class Kaleidoscope extends BasicEffect {
                 LXVector zAxis = new LXVector(0, 0, 1);
 
                 ArrayList<LXVector> vectors = new ArrayList<LXVector>();
+
                 projection.iterator().forEachRemaining(vectors::add);
+                if (vectors.size() < 2) {
+                	// JBelcher note: I don't know the context here, just patching last minute errors before BM
+                	continue;
+                }
                 LXVector normal = vectors.get(0).copy().cross(vectors.get(1));
                 LXVector rotationAxis = zAxis.cross(normal);
                 projection.rotate(LXVector.angleBetween(normal, zAxis), rotationAxis.x, rotationAxis.y, rotationAxis.z);


### PR DESCRIPTION
This avoids the error seen by @ssilverman "Device Kaleidoscope crash due to an unexpected error...Index 0 out of bounds for length 0"

Before this fix I was able to reproduce the error by adding the effect to the Down channel in AutoVJ.lxp.

I don't know what the context is here... someone else can fix it properly later.  FYI Kaleidoscope effect on my machine reduces framerate to 8fps(!).