### PR TITLE
Pull GP points from model, skip TEPattern dependency

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -61,6 +61,7 @@ import titanicsend.util.TE;
 
 public class TEApp extends PApplet implements LXPlugin  {
   private TEWholeModel model;
+  static public TEWholeModel wholeModel;
 
   private static int WIDTH = 1280;
   private static int HEIGHT = 800;
@@ -92,6 +93,7 @@ public class TEApp extends PApplet implements LXPlugin  {
     flags.startMultiThreaded = true;
 
     this.model = new TEWholeModel(resourceSubdir);
+    TEApp.wholeModel = this.model;
 
     new LXStudio(this, flags, this.model);
     this.surface.setTitle(this.model.name);

--- a/src/main/java/titanicsend/output/GPOutput.java
+++ b/src/main/java/titanicsend/output/GPOutput.java
@@ -2,14 +2,12 @@ package titanicsend.output;
 
 import heronarts.lx.LX;
 import heronarts.lx.color.LXDynamicColor;
-import heronarts.lx.mixer.LXAbstractChannel;
-import heronarts.lx.mixer.LXChannel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.output.LXOutput;
-import heronarts.lx.pattern.LXPattern;
 import titanicsend.app.GigglePixelBroadcaster;
-import titanicsend.pattern.TEPattern;
-
+import titanicsend.app.TEApp;
+import titanicsend.model.TEPanelModel;
+import titanicsend.model.TEWholeModel;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,36 +18,80 @@ public class GPOutput extends LXOutput {
     super(lx);
     this.broadcaster = broadcaster;
   }
+  
+  private boolean initialized = false;
+  private boolean alwaysUsePalette = false;
+  private ArrayList<LXPoint> gpPoints = new ArrayList<LXPoint>();
+  
+  private void findGigglePixelPoints() {
+    /*
+      GigglePixel color sync protocol methods
+     */
+
+    // Finds a set of points that GP should use to make its palette broadcasts.
+    // By default, it will pick a point in the middle of SUA and SDC panels and
+    // a point in the middle of one of each of their edges. 
+
+    TEWholeModel model = TEApp.wholeModel;
+    
+    TEPanelModel sua = model.panelsById.get("SUA");
+    TEPanelModel sdc = model.panelsById.get("SDC");
+
+    if (sua != null) {
+      int halfway = sua.points.length / 2;
+      if (halfway < sua.points.length) gpPoints.add(sua.points[halfway]);
+
+      halfway = sua.e0.points.length / 2;
+      if (halfway < sua.e0.points.length) gpPoints.add(sua.e0.points[halfway]);
+    }
+
+    if (sdc != null) {
+      int halfway = sdc.points.length / 2;
+      if (halfway < sdc.points.length) gpPoints.add(sdc.points[halfway]);
+
+      halfway = sdc.e0.points.length / 2;
+      if (halfway < sdc.e0.points.length) gpPoints.add(sdc.e0.points[halfway]);
+    }
+    
+    if (gpPoints.size() > 0) {
+      this.initialized = true;
+    }
+  }
+  
+  // Handy public method for changing the GP points, if you like!
+  public void setGigglePixelPoints(ArrayList<LXPoint> points) {
+	this.gpPoints = new ArrayList<LXPoint>(points);
+	this.initialized = true;
+  }
+  
+  // Handy public method for toggling GP pixel source
+  public void usePalette(boolean alwaysUsePalette) {
+	this.alwaysUsePalette = alwaysUsePalette;
+  }
 
   @Override
   protected void onSend(int[] colors, byte[][] glut, double brightness) {
-    int channelIndex = 0; // TODO: Expose in the UI
-
-    List<LXAbstractChannel> abstractChannels = this.lx.engine.mixer.channels;
-    List<LXChannel> channels = new ArrayList<>();
-    for (LXAbstractChannel ac : abstractChannels) {
-      if (ac instanceof LXChannel) {
-        channels.add((LXChannel) ac);
-      }
+    // Look for standard GP points on the model.
+    // Take out the surrounding IF if you want to refresh from the model every frame
+    if (!this.initialized) {
+       findGigglePixelPoints();
     }
+
+    // If you want to come back later and allow patterns to choose their GP points,
+    // loop over every channel here.  Then combine those distinct pixels with
+    // the colors array to get your GP output colors
 
     List<Integer> gpColors = new ArrayList<>();
-    for (LXDynamicColor dc : lx.engine.palette.swatch.colors) {
-      gpColors.add(dc.getColor());
-    }
-    this.broadcaster.setColors(gpColors);
-
-    if (channelIndex >= channels.size()) return;
-    LXChannel channel = channels.get(channelIndex);
-    LXPattern pattern = channel.getActivePattern();
-    if (!(pattern instanceof TEPattern)) return;
-    TEPattern tePattern = (TEPattern) pattern;
-    List<LXPoint> points = tePattern.getGigglePixelPoints();
-    if (points.isEmpty()) return;
-
-    gpColors = new ArrayList<>();
-    for (LXPoint point : points) {
-      gpColors.add(colors[point.index]);
+    if (this.gpPoints.isEmpty() || this.alwaysUsePalette) {
+      // Use active swatch
+      for (LXDynamicColor dc : lx.engine.palette.swatch.colors) {
+        gpColors.add(dc.getColor());
+      }
+    } else {
+      // GP points were found on the model
+      for (LXPoint point : this.gpPoints) {
+        gpColors.add(colors[point.index]);
+      }
     }
     this.broadcaster.setColors(gpColors);
   }


### PR DESCRIPTION
Only lightly tested.  Please test!

- Makes the GPOutput stand on its own without scanning for TEPattern.
- Doesn't recalculate source pixels every frame (but you could easily revert to that by removing the IF statement)
- Handy public method for toggling between palette and frame pixels

This is an alternative to the previous PR #166 .