### PR TITLE
Replace LX patterns that touch gap pixels

### DIFF
--- a/Projects/AutoVJ.lxp
+++ b/Projects/AutoVJ.lxp
@@ -2641,7 +2641,7 @@
             "patterns": [
               {
                 "id": 9708,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2698,7 +2698,7 @@
               },
               {
                 "id": 27382,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2755,7 +2755,7 @@
               },
               {
                 "id": 11477,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2812,7 +2812,7 @@
               },
               {
                 "id": 27388,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2908,7 +2908,7 @@
               },
               {
                 "id": 30201,
-                "class": "heronarts.lx.pattern.texture.SparklePattern",
+                "class": "titanicsend.pattern.jon.TESparklePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3183,7 +3183,7 @@
             "patterns": [
               {
                 "id": 12031,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3357,7 +3357,7 @@
               },
               {
                 "id": 9992,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3508,7 +3508,7 @@
               },
               {
                 "id": 9733,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3803,7 +3803,7 @@
               },
               {
                 "id": 30461,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -4020,7 +4020,7 @@
             "patterns": [
               {
                 "id": 27917,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -5099,7 +5099,7 @@
               },
               {
                 "id": 33153,
-                "class": "heronarts.lx.pattern.texture.SparklePattern",
+                "class": "titanicsend.pattern.jon.TESparklePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/AutoVJ_backup.lxp
+++ b/Projects/AutoVJ_backup.lxp
@@ -2641,7 +2641,7 @@
             "patterns": [
               {
                 "id": 9708,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2698,7 +2698,7 @@
               },
               {
                 "id": 27382,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2755,7 +2755,7 @@
               },
               {
                 "id": 11477,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2812,7 +2812,7 @@
               },
               {
                 "id": 27388,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -2908,7 +2908,7 @@
               },
               {
                 "id": 30201,
-                "class": "heronarts.lx.pattern.texture.SparklePattern",
+                "class": "titanicsend.pattern.jon.TESparklePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3183,7 +3183,7 @@
             "patterns": [
               {
                 "id": 12031,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3357,7 +3357,7 @@
               },
               {
                 "id": 9992,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3508,7 +3508,7 @@
               },
               {
                 "id": 9733,
-                "class": "heronarts.lx.pattern.color.GradientPattern",
+                "class": "titanicsend.pattern.jon.TEGradientPattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3803,7 +3803,7 @@
               },
               {
                 "id": 30461,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -4020,7 +4020,7 @@
             "patterns": [
               {
                 "id": 27917,
-                "class": "heronarts.lx.pattern.texture.NoisePattern",
+                "class": "titanicsend.pattern.jon.TENoisePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -5099,7 +5099,7 @@
               },
               {
                 "id": 33153,
-                "class": "heronarts.lx.pattern.texture.SparklePattern",
+                "class": "titanicsend.pattern.jon.TESparklePattern",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -32,9 +32,9 @@ import heronarts.lx.LXPlugin;
 import heronarts.lx.LX.ProjectListener.Change;
 import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.pattern.LXPattern;
-import heronarts.lx.pattern.color.GradientPattern;
-import heronarts.lx.pattern.texture.NoisePattern;
-import heronarts.lx.pattern.texture.SparklePattern;
+//import heronarts.lx.pattern.color.GradientPattern;
+//import heronarts.lx.pattern.texture.NoisePattern;
+//import heronarts.lx.pattern.texture.SparklePattern;
 import heronarts.lx.studio.LXStudio;
 import processing.core.PApplet;
 import titanicsend.app.autopilot.*;
@@ -295,7 +295,7 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     TEPhrase up = TEPhrase.UP;
 
     // CHORUS patterns
-    l.addPattern(NoisePattern.class, covBoth, cPalette, chorus);
+    l.addPattern(TENoisePattern.class, covBoth, cPalette, chorus);
     l.addPattern(PBXorcery.class, covPanelPartial, cPalette, chorus);
     l.addPattern(ShaderPanelsPatternConfig.NeonBlocks.class, covPanelPartial, cNonConforming, chorus);
     l.addPattern(PBAudio1.class, covPanelPartial, cPalette, chorus);
@@ -316,20 +316,20 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     //l.addPattern(OrganicPatternConfig.NeonSnake.class, covPanels, cPalette, chorus); // removed at request of tergel
 
     // DOWN patterns
-    l.addPattern(GradientPattern.class, covPanelPartial, cPalette, down);
+    l.addPattern(TEGradientPattern.class, covPanelPartial, cPalette, down);
     l.addPattern(OrganicPatternConfig.WaterEdges.class, covEdges, cPalette, down);
     l.addPattern(OrganicPatternConfig.WaterPanels.class, covPanelPartial, cPalette, down);
     l.addPattern(OrganicPatternConfig.WavyEdges.class, covEdges, cPalette, down);
-    l.addPattern(NoisePattern.class, covBoth, cPalette, down);
+    l.addPattern(TENoisePattern.class, covBoth, cPalette, down);
     l.addPattern(ShaderPanelsPatternConfig.Galaxy.class, covPanelPartial, cPalette, down);
     l.addPattern(ShaderPanelsPatternConfig.StormScanner.class, covPanels, cPalette, down);
     //l.addPattern(Smoke.class, covBoth, cPalette, down); // can't see with colorize
     //l.addPattern(OrganicPatternConfig.NeonSnake.class, covPanels, cPalette, down); // removed at request of tergel
 
     // UP patterns
-    l.addPattern(NoisePattern.class, covPanelPartial, cNonConforming, up);
+    l.addPattern(TENoisePattern.class, covPanelPartial, cNonConforming, up);
     l.addPattern(OrganicPatternConfig.WavyEdges.class, covPanelPartial, cNonConforming, up);
-    l.addPattern(SparklePattern.class, covBoth, cNonConforming, up);
+    l.addPattern(TESparklePattern.class, covBoth, cNonConforming, up);
     l.addPattern(ShaderPanelsPatternConfig.Electric.class, covPanelPartial, cNonConforming, up);
     l.addPattern(ShaderPanelsPatternConfig.Marbling.class, covPanels, cNonConforming, up);
     l.addPattern(ShaderPanelsPatternConfig.SlitheringSnake.class, covPanelPartial, cPalette, up);

--- a/src/main/java/titanicsend/model/TEWholeModel.java
+++ b/src/main/java/titanicsend/model/TEWholeModel.java
@@ -95,7 +95,7 @@ public class TEWholeModel extends LXModel {
     for (TEPanelModel panel : this.panelsById.values()) {
       for (LXPoint pt : panel.points) {
         if (isGapPoint(pt)) {
-          TE.log("Kicking out gap point");
+          //TE.log("Kicking out gap point");
         } else {
           this.panelPoints.add(pt);
         }

--- a/src/main/java/titanicsend/pattern/jon/TEGradientPattern.java
+++ b/src/main/java/titanicsend/pattern/jon/TEGradientPattern.java
@@ -1,0 +1,319 @@
+package titanicsend.pattern.jon;
+
+/**
+ * Copyright 2016- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ *
+ * **********************************************************
+ * Modified version that avoids Titanic's End's Gap Points
+ * ********************************************************** *
+ *
+ */
+
+import heronarts.lx.LXCategory;
+import heronarts.lx.LX;
+import heronarts.lx.color.ColorParameter;
+import heronarts.lx.color.GradientUtils;
+import heronarts.lx.color.GradientUtils.BlendMode;
+import heronarts.lx.color.GradientUtils.ColorStops;
+import heronarts.lx.color.GradientUtils.GradientFunction;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LXDynamicColor;
+import heronarts.lx.color.LXSwatch;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.pattern.LXPattern;
+import heronarts.lx.utils.LXUtils;
+import titanicsend.pattern.TEPattern;
+
+import java.util.ArrayList;
+
+@LXCategory(LXCategory.COLOR)
+public class TEGradientPattern extends TEPattern implements GradientFunction {
+
+    public enum ColorMode {
+        FIXED("Fixed"),
+        PRIMARY("Primary"),
+        PALETTE("Palette");
+
+        public final String label;
+
+        private ColorMode(String label) {
+            this.label = label;
+        }
+
+        @Override
+        public String toString() {
+            return this.label;
+        }
+    };
+
+    private interface CoordinateFunction {
+        float getCoordinate(LXPoint p, float normalized, float offset);
+    }
+
+    public static enum CoordinateMode {
+
+        NORMAL("Normal", (p, normalized, offset) ->  {
+            return normalized - offset;
+        }),
+
+        CENTER("Center", (p, normalized, offset) -> {
+            return 2 * Math.abs(normalized - (.5f + offset * .5f));
+        }),
+
+        RADIAL("Radial", (p, normalized, offset) -> {
+            return p.rcn - offset;
+        });
+
+        public final String name;
+        public final CoordinateFunction function;
+        public final CoordinateFunction invert;
+
+        private CoordinateMode(String name, CoordinateFunction function) {
+            this.name = name;
+            this.function = function;
+            this.invert = (p, normalized, offset) -> { return function.getCoordinate(p, normalized, offset) - 1; };
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    public final EnumParameter<ColorMode> colorMode =
+            new EnumParameter<ColorMode>("Color Mode", ColorMode.PRIMARY)
+                    .setDescription("Which source the gradient selects colors from");
+
+    public final EnumParameter<BlendMode> blendMode =
+            new EnumParameter<BlendMode>("Blend Mode", BlendMode.HSV)
+                    .setDescription("How to blend between colors in the gradient");
+
+    public final ColorParameter fixedColor =
+            new ColorParameter("Fixed", LXColor.RED)
+                    .setDescription("Fixed color to start the gradient from");
+
+    public final ColorParameter secondaryColor =
+            new ColorParameter("Secondary", LXColor.RED)
+                    .setDescription("Secondary color that the gradient blends to");
+
+    public final DiscreteParameter paletteIndex =
+            new DiscreteParameter("Index", 1, LXSwatch.MAX_COLORS + 1)
+                    .setDescription("Which index at the palette to start from");
+
+    public final DiscreteParameter paletteStops =
+            new DiscreteParameter("Stops", LXSwatch.MAX_COLORS, 2, LXSwatch.MAX_COLORS + 1)
+                    .setDescription("How many color stops to use in the palette");
+
+    public final CompoundParameter gradient =
+            new CompoundParameter("Amount", 0, -1, 1)
+                    .setDescription("Amount of color gradient")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter gradientRange =
+            new CompoundParameter("Range", 360, 0, 360 * 10)
+                    .setDescription("Range of total possible color gradient");
+
+    public final EnumParameter<CoordinateMode> xMode =
+            new EnumParameter<CoordinateMode>("X Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the X-dimension uses");
+
+    public final EnumParameter<CoordinateMode> yMode =
+            new EnumParameter<CoordinateMode>("Y Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the Y-dimension uses");
+
+    public final EnumParameter<CoordinateMode> zMode =
+            new EnumParameter<CoordinateMode>("Z Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the Z-dimension uses");
+
+    public final CompoundParameter xAmount =
+            new CompoundParameter("X-Amt", 0, -1, 1)
+                    .setDescription("Sets the amount of hue spread on the X axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter yAmount =
+            new CompoundParameter("Y-Amt", 0, -1, 1)
+                    .setDescription("Sets the amount of hue spread on the Y axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter zAmount =
+            new CompoundParameter("Z-Amt", 0, -1, 1)
+                    .setDescription("Sets the amount of hue spread on the Z axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter xOffset =
+            new CompoundParameter("X-Off", 0, -1, 1)
+                    .setDescription("Sets the offset of the hue spread point on the X axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter yOffset =
+            new CompoundParameter("Y-Off", 0, -1, 1)
+                    .setDescription("Sets the offset of the hue spread point on the Y axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    public final CompoundParameter zOffset =
+            new CompoundParameter("Z-Off", 0, -1, 1)
+                    .setDescription("Sets the offset of the hue spread point on the Z axis")
+                    .setPolarity(LXParameter.Polarity.BIPOLAR);
+
+    private final ColorStops colorStops = new ColorStops();
+
+    LXPoint[] points;
+
+    public TEGradientPattern(LX lx) {
+        super(lx);
+        addParameter("xAmount", this.xAmount);
+        addParameter("yAmount", this.yAmount);
+        addParameter("zAmount", this.zAmount);
+        addParameter("xOffset", this.xOffset);
+        addParameter("yOffset", this.yOffset);
+        addParameter("zOffset", this.zOffset);
+        addParameter("colorMode", this.colorMode);
+        addParameter("blendMode", this.blendMode);
+        addParameter("gradient", this.gradient);
+        addParameter("fixedColor", this.fixedColor);
+        addParameter("xMode", this.xMode);
+        addParameter("yMode", this.yMode);
+        addParameter("zMode", this.zMode);
+        addParameter("paletteIndex", this.paletteIndex);
+        addParameter("paletteStops", this.paletteStops);
+        addParameter("gradientRange", this.gradientRange);
+
+        // get safe list of points for TE
+        ArrayList<LXPoint> newPoints = new ArrayList<>();
+        for (LXPoint pt : model.points) {
+            if (model.isGapPoint(pt)) continue;
+            newPoints.add(pt);
+        }
+        points = newPoints.toArray(new LXPoint[0]);
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter p) {
+        if (this.gradient == p ||
+                this.gradientRange == p ||
+                this.colorMode == p ||
+                this.paletteIndex == p ||
+                this.fixedColor.hue == p) {
+            setSecondaryColor();
+        }
+    }
+
+    public LXDynamicColor getPrimaryColor() {
+        return this.lx.engine.palette.getSwatchColor(this.paletteIndex.getValuei() - 1);
+    }
+
+    private void setSecondaryColor() {
+        double gradient = this.gradient.getValue() * this.gradientRange.getValue();
+
+        switch (this.colorMode.getEnum()) {
+            case FIXED:
+                this.secondaryColor.setColor(LXColor.hsb(
+                        this.fixedColor.hue.getValue() + gradient,
+                        this.fixedColor.saturation.getValue(),
+                        this.fixedColor.brightness.getValue()
+                ));
+                break;
+            case PRIMARY:
+                LXDynamicColor primary = getPrimaryColor();
+                int c = primary.getColor();
+                this.secondaryColor.setColor(LXColor.hsb(
+                        primary.getHue() + gradient,
+                        LXColor.s(c),
+                        LXColor.b(c)
+                ));
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void setColorStops() {
+        float gradientf = this.gradient.getValuef() * this.gradientRange.getValuef();
+
+        switch (this.colorMode.getEnum()) {
+            case FIXED:
+                this.colorStops.stops[0].set(this.fixedColor);
+                this.colorStops.stops[1].set(this.fixedColor, gradientf);
+                this.colorStops.setNumStops(2);
+                break;
+            case PRIMARY:
+                LXDynamicColor swatchColor = getPrimaryColor();
+                this.colorStops.stops[0].set(swatchColor);
+                this.colorStops.stops[1].set(swatchColor, gradientf);
+                this.colorStops.setNumStops(2);
+                setSecondaryColor();
+                break;
+            case PALETTE:
+                this.colorStops.setPaletteGradient(
+                        this.lx.engine.palette,
+                        this.paletteIndex.getValuei() - 1,
+                        this.paletteStops.getValuei()
+                );
+                break;
+        }
+    }
+
+    @Override
+    public int getGradientColor(float lerp) {
+        return this.colorStops.getColor(lerp, this.blendMode.getEnum().function);
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        setColorStops();
+
+        float xAmount = this.xAmount.getValuef();
+        float yAmount = this.yAmount.getValuef();
+        float zAmount = this.zAmount.getValuef();
+
+        final float total = Math.abs(xAmount) + Math.abs(yAmount) + Math.abs(zAmount);
+        if (total > 1) {
+            xAmount /= total;
+            yAmount /= total;
+            zAmount /= total;
+        }
+
+        final float xOffset = this.xOffset.getValuef();
+        final float yOffset = this.yOffset.getValuef();
+        final float zOffset = this.zOffset.getValuef();
+
+        final CoordinateMode xMode = this.xMode.getEnum();
+        final CoordinateMode yMode = this.yMode.getEnum();
+        final CoordinateMode zMode = this.zMode.getEnum();
+
+        final CoordinateFunction xFunction = (xAmount < 0) ? xMode.invert : xMode.function;
+        final CoordinateFunction yFunction = (yAmount < 0) ? yMode.invert : yMode.function;
+        final CoordinateFunction zFunction = (zAmount < 0) ? zMode.invert : zMode.function;
+
+        final GradientUtils.BlendFunction blendFunction = this.blendMode.getEnum().function;
+
+        for (LXPoint p : points) {
+            float lerp = (this.colorStops.numStops - 1) * LXUtils.clampf(
+                    xAmount * xFunction.getCoordinate(p, p.xn, xOffset) +
+                            yAmount * yFunction.getCoordinate(p, p.yn, yOffset) +
+                            zAmount * zFunction.getCoordinate(p, p.zn, zOffset),
+                    0, 1
+            );
+            int stop = (int) Math.floor(lerp);
+            colors[p.index] = blendFunction.blend(this.colorStops.stops[stop], this.colorStops.stops[stop+1], lerp - stop);
+        }
+    }
+}

--- a/src/main/java/titanicsend/pattern/jon/TENoisePattern.java
+++ b/src/main/java/titanicsend/pattern/jon/TENoisePattern.java
@@ -1,0 +1,404 @@
+package titanicsend.pattern.jon; /**
+
+ * Copyright 2013- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ *
+ * **********************************************************
+ * Modified version that avoids Titanic's End's Gap Points
+ * **********************************************************
+ */
+
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.modulator.LXModulator;
+import heronarts.lx.modulator.LinearEnvelope;
+import heronarts.lx.modulator.SawLFO;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.BoundedParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.parameter.FunctionalParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.LX;
+import heronarts.lx.pattern.LXPattern;
+import heronarts.lx.utils.LXUtils;
+import titanicsend.pattern.TEPattern;
+
+import java.util.ArrayList;
+
+import static heronarts.lx.utils.Noise.*;
+import static heronarts.lx.utils.LXUtils.clamp;
+
+@LXCategory(LXCategory.TEXTURE)
+public class TENoisePattern extends TEPattern {
+
+    public enum Algorithm {
+        PERLIN("Perlin", false),
+        RIDGE("Ridge", true),
+        FBM("FBM", true),
+        TURBULENCE("Turbulence", true),
+        STATIC("Static", false);
+
+        private final String name;
+        private boolean isPerlinFeedback;
+
+        private Algorithm(String name, boolean isPerlinFeedback) {
+            this.name = name;
+            this.isPerlinFeedback = isPerlinFeedback;
+        }
+
+        public boolean isPerlinFeedback() {
+            return this.isPerlinFeedback;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    private interface CoordinateFunction {
+        float getCoordinate(LXPoint p, float normalized, float offset);
+    }
+
+    public static enum CoordinateMode {
+
+        NORMAL("Normal", (p, normalized, offset) ->  {
+            return normalized + offset;
+        }),
+
+        CENTER("Center", (p, normalized, offset) -> {
+            return Math.abs(normalized - .5f * (1 + offset));
+        }),
+
+        RADIAL("Radial", (p, normalized, offset) -> {
+            return p.rcn + offset * normalized;
+        }),
+
+        NONE("None", (p, normalized, offset) -> {
+            return .5f + offset;
+        });
+
+        public final String name;
+        public final CoordinateFunction function;
+
+        private CoordinateMode(String name, CoordinateFunction function) {
+            this.name = name;
+            this.function = function;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    public final EnumParameter<Algorithm> algorithm =
+            new EnumParameter<Algorithm>("Algorithm", Algorithm.PERLIN);
+
+    public final DiscreteParameter seed =
+            new DiscreteParameter("Seed", 0, 256)
+                    .setDescription("Seed value supplied to the noise function");
+
+    public final CompoundParameter level =
+            new CompoundParameter("Level", 50, 0, 100)
+                    .setDescription("Midpoint brightness level for the noise generation");
+
+    public final CompoundParameter contrast =
+            new CompoundParameter("Contrast", 100, 0, 500)
+                    .setExponent(2)
+                    .setDescription("Dynamic contrast of noise generation");
+
+    public final EnumParameter<CoordinateMode> xMode =
+            new EnumParameter<CoordinateMode>("X Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the X-dimension uses");
+
+    public final EnumParameter<CoordinateMode> yMode =
+            new EnumParameter<CoordinateMode>("Y Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the Y-dimension uses");
+
+    public final EnumParameter<CoordinateMode> zMode =
+            new EnumParameter<CoordinateMode>("Z Mode", CoordinateMode.NORMAL)
+                    .setDescription("Which coorindate mode the Z-dimension uses");
+
+    public final CompoundParameter xOffset =
+            new CompoundParameter("X-Pos", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("The coordinate offset on the X-axis");
+
+    public final CompoundParameter yOffset =
+            new CompoundParameter("Y-Pos", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("The coordinate offset on the Y-axis");
+
+    public final CompoundParameter zOffset =
+            new CompoundParameter("Z-Pos", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("The coordinate offset on the Z-axis");
+
+    public final CompoundParameter scale =
+            new CompoundParameter("Scale", .5f)
+                    .setDescription("Scale factor for the size of the noise variation");
+
+    public final BoundedParameter minScale =
+            new BoundedParameter("Min Scale", 1, 0.1, 100)
+                    .setExponent(2)
+                    .setDescription("Minimum scaling value for noise variation");
+
+    public final BoundedParameter maxScale =
+            new BoundedParameter("Max Scale", 10, 1, 1000)
+                    .setExponent(2)
+                    .setDescription("Maximum scaling value for noise variation");
+
+    public final CompoundParameter xScale =
+            new CompoundParameter("X-Scale", 1)
+                    .setDescription("Amount of scaling applied to the X-axis");
+
+    public final CompoundParameter yScale =
+            new CompoundParameter("Y-Scale", 1)
+                    .setDescription("Amount of scaling applied to the Y-axis");
+
+    public final CompoundParameter zScale =
+            new CompoundParameter("Z-Scale", 1)
+                    .setDescription("Amount of scaling applied to the Z-axis");
+
+    public final BooleanParameter motion =
+            new BooleanParameter("Motion", false)
+                    .setDescription("Whether motion is applied to the noise");
+
+    public final CompoundParameter motionSpeed =
+            new CompoundParameter("Speed", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("Maximum motion speed");
+
+    public final BoundedParameter motionSpeedRange =
+            new BoundedParameter("Speed Range", 128, 1, 256)
+                    .setDescription("Range of the speed control");
+
+    public final CompoundParameter xMotion =
+            new CompoundParameter("X-Motion", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("Rate of motion on the X-axis");
+
+    public final CompoundParameter yMotion =
+            new CompoundParameter("Y-Motion", 0, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("Rate of motion on the Y-axis");
+
+    public final CompoundParameter zMotion =
+            new CompoundParameter("Z-Motion", 1, -1, 1)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setDescription("Rate of motion on the Z-axis");
+
+    private final LinearEnvelope motionDamped = addModulator(new LinearEnvelope(motion.isOn() ? 1 : 0, 1, 250));
+
+    private class MotionSpeedParameter extends FunctionalParameter {
+        private final LXParameter amount;
+
+        private MotionSpeedParameter(LXParameter amount) {
+            this.amount = amount;
+        }
+
+        @Override
+        public double getValue() {
+            double ms = motionSpeed.getValue();
+            return 6000000 / (motionSpeedRange.getValue() * ms * Math.abs(ms) * motionDamped.getValue() * this.amount.getValue());
+        }
+    }
+
+    private final LXModulator xModulation = startModulator(new SawLFO(0, 256, new MotionSpeedParameter(this.xMotion)));
+    private final LXModulator yModulation = startModulator(new SawLFO(0, 256, new MotionSpeedParameter(this.yMotion)));
+    private final LXModulator zModulation = startModulator(new SawLFO(0, 256, new MotionSpeedParameter(this.zMotion)));
+
+    public final DiscreteParameter octaves =
+            new DiscreteParameter("Octaves", 3, 1, 9)
+                    .setDescription("Number of octaves of perlin noise to sum");
+
+    public final BoundedParameter lacunarity =
+            new BoundedParameter("Lacunarity", 2, 0, 4)
+                    .setDescription("Spacing between successive octaves (use exactly 2.0 for wrapping output)");
+
+    public final BoundedParameter gain =
+            new BoundedParameter("Gain", 0.5, 0, 1)
+                    .setDescription("Relative weighting applied to each successive octave");
+
+    public final BoundedParameter ridgeOffset =
+            new BoundedParameter("Ridge", .9, 0, 2)
+                    .setDescription("Used to invert the feedback ridges");
+
+    LXPoint[] points;
+
+    public TENoisePattern(LX lx) {
+        super(lx);
+
+        addParameter("midpoint", this.level);
+        addParameter("contrast", this.contrast);
+        addParameter("xOffset", this.xOffset);
+        addParameter("yOffset", this.yOffset);
+        addParameter("zOffset", this.zOffset);
+        addParameter("scale", this.scale);
+        addParameter("minScale", this.minScale);
+        addParameter("maxScale", this.maxScale);
+
+        addParameter("xScale", this.xScale);
+        addParameter("yScale", this.yScale);
+        addParameter("zScale", this.zScale);
+
+        addParameter("motion", this.motion);
+        addParameter("motionSpeed", this.motionSpeed);
+        addParameter("motionSpeedRange", this.motionSpeedRange);
+        addParameter("xMotion", this.xMotion);
+        addParameter("yMotion", this.yMotion);
+        addParameter("zMotion", this.zMotion);
+
+        addParameter("algorithm", this.algorithm);
+        addParameter("seed", this.seed);
+        addParameter("octaves", this.octaves);
+        addParameter("lacunarity", this.lacunarity);
+        addParameter("gain", this.gain);
+        addParameter("ridgeOffset", this.ridgeOffset);
+
+        addParameter("xMode", this.xMode);
+        addParameter("yMode", this.yMode);
+        addParameter("zMode", this.zMode);
+
+        // Set the order of most useful control parameters
+        setRemoteControls(
+                this.scale,
+                this.level,
+                this.contrast,
+                this.motionSpeed,
+                this.xMotion,
+                this.yMotion,
+                this.zMotion,
+                this.motionSpeedRange
+        );
+
+        // get safe list of points for TE
+        ArrayList<LXPoint> newPoints = new ArrayList<>();
+        for (LXPoint pt : model.points) {
+            if (model.isGapPoint(pt)) continue;
+            newPoints.add(pt);
+        }
+        points = newPoints.toArray(new LXPoint[0]);
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter p) {
+        super.onParameterChanged(p);
+        if (this.motion == p) {
+            if (this.motion.isOn()) {
+                this.motionDamped.setRangeFromHereTo(1).trigger();
+            } else {
+                this.motionDamped.setRangeFromHereTo(0).trigger();
+            }
+        }
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        switch (this.algorithm.getEnum()) {
+            case PERLIN:
+            case FBM:
+            case RIDGE:
+            case TURBULENCE:
+                runPerlin(deltaMs, this.algorithm.getEnum());
+                break;
+            case STATIC:
+                runStatic(deltaMs);
+                break;
+        }
+    }
+
+    private void runPerlin(double deltaMs, Algorithm algorithm) {
+        int seed = this.seed.getValuei();
+
+        float scale = LXUtils.lerpf(this.minScale.getValuef(), this.maxScale.getValuef(), this.scale.getValuef());
+
+        float xa = this.xModulation.getValuef();
+        float ya = this.yModulation.getValuef();
+        float za = this.zModulation.getValuef();
+
+        float xo = this.xOffset.getValuef();
+        float yo = this.yOffset.getValuef();
+        float zo = this.zOffset.getValuef();
+
+        float xs = scale * this.xScale.getValuef();
+        float ys = scale * this.yScale.getValuef();
+        float zs = scale * this.zScale.getValuef();
+
+        float contrast = this.contrast.getValuef();
+        float level = this.level.getValuef() - contrast / 4;;
+
+        CoordinateFunction xMode = this.xMode.getEnum().function;
+        CoordinateFunction yMode = this.yMode.getEnum().function;
+        CoordinateFunction zMode = this.zMode.getEnum().function;
+
+        if (algorithm.equals(Algorithm.PERLIN)) {
+            for (LXPoint p : points) {
+                float xd = xMode.getCoordinate(p, p.xn, xo);
+                float yd = yMode.getCoordinate(p, p.yn, yo);
+                float zd = zMode.getCoordinate(p, p.zn, zo);
+
+                float b = level + contrast * stb_perlin_noise3_seed(xa + xs * xd, ya + ys * yd, za + zs * zd, 0, 0, 0, seed);
+                this.colors[p.index] = LXColor.gray(clamp(b, 0, 100));
+            }
+        } else {
+            int octaves = this.octaves.getValuei();
+            float lacunarity = this.lacunarity.getValuef();
+            float gain = this.gain.getValuef();
+
+            if (algorithm.equals(Algorithm.RIDGE)) {
+                float ridgeOffset = this.ridgeOffset.getValuef();
+                for (LXPoint p : points) {
+                    float xd = xMode.getCoordinate(p, p.xn, xo);
+                    float yd = yMode.getCoordinate(p, p.yn, yo);
+                    float zd = zMode.getCoordinate(p, p.zn, zo);
+                    float b = level + contrast * stb_perlin_ridge_noise3(xa + xs * xd, ya + ys * yd, za + zs * zd, lacunarity, gain, ridgeOffset, octaves);
+                    this.colors[p.index] = LXColor.gray(clamp(b, 0, 100));
+                }
+            } else if (algorithm.equals(Algorithm.FBM)) {
+                for (LXPoint p : points) {
+                    float xd = xMode.getCoordinate(p, p.xn, xo);
+                    float yd = yMode.getCoordinate(p, p.yn, yo);
+                    float zd = zMode.getCoordinate(p, p.zn, zo);
+                    float b = level + contrast * stb_perlin_fbm_noise3(xa + xs * xd, ya + ys * yd, za + zs * zd, lacunarity, gain, octaves);
+                    this.colors[p.index] = LXColor.gray(clamp(b, 0, 100));
+                }
+            } else if (algorithm.equals(Algorithm.TURBULENCE)) {
+                for (LXPoint p : points) {
+                    float xd = xMode.getCoordinate(p, p.xn, xo);
+                    float yd = yMode.getCoordinate(p, p.yn, yo);
+                    float zd = zMode.getCoordinate(p, p.zn, zo);
+                    float b = level + contrast * stb_perlin_turbulence_noise3(xa + xs * xd, ya + ys * yd, za + zs * zd, lacunarity, gain, octaves);
+                    this.colors[p.index] = LXColor.gray(clamp(b, 0, 100));
+                }
+            }
+        }
+    }
+
+    private void runStatic(double deltaMs) {
+        float level = this.level.getValuef();
+        float contrast = this.contrast.getValuef();
+        for (LXPoint p : points) {
+            float b = level + contrast * (-1 + 2 * (float) Math.random());
+            this.colors[p.index] = LXColor.gray(clamp(b, 0, 100));
+        }
+    }
+
+}

--- a/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
+++ b/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
@@ -1,0 +1,304 @@
+package titanicsend.pattern.jon;
+
+/**
+ * Copyright 2020- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ *
+ * **********************************************************
+ * Modified version that avoids Titanic's End's Gap Points
+ * **********************************************************
+ *
+ */
+
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.modulator.LXWaveshape;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.ObjectParameter;
+import heronarts.lx.LX;
+import heronarts.lx.pattern.LXPattern;
+import heronarts.lx.utils.LXUtils;
+import titanicsend.pattern.TEPattern;
+
+@LXCategory(LXCategory.TEXTURE)
+public class TESparklePattern extends TEPattern {
+
+    public static class Engine {
+
+        private final static int MAX_SPARKLES = 1024;
+        private final static double MAX_DENSITY = 4;
+
+        private class Sparkle {
+
+            private boolean isOn = false;
+
+            // Moves through 0-1 for sparkle lifecycle
+            private double basis;
+
+            // Random 0-1 constant used to control how much time-scale variation is applied
+            private double randomVar;
+
+            // Random 0-1 constant used to control brightness of sparkle
+            private double randomLevel;
+
+            // How many pixels to output to
+            private int activePixels;
+
+            // Each individual sparkle maintains a list of output indices that it is applied to
+            private int[] indexBuffer;
+
+            private Sparkle() {
+                this.isOn = false;
+                this.basis = Math.random();
+                this.randomVar = Math.random();
+                this.randomLevel = Math.random();
+            }
+
+            private void rebuffer(LXModel model) {
+                this.indexBuffer = new int[maxPixelsPerSparkle];
+                reindex(model);
+            }
+
+            private void reindex(LXModel model) {
+                // Choose a set of LED indices at random for this sparkle to point to
+                for (int i = 0; i < this.indexBuffer.length; ++i) {
+                    this.indexBuffer[i] = LXUtils.constrain((int) (Math.random() * model.size), 0, model.size - 1);
+                }
+            }
+        }
+
+        public final ObjectParameter<LXWaveshape> waveshape = new ObjectParameter<LXWaveshape>("Wave", new LXWaveshape[] {
+                LXWaveshape.TRI,
+                LXWaveshape.SIN,
+                LXWaveshape.UP,
+                LXWaveshape.DOWN,
+                LXWaveshape.SQUARE,
+        });
+
+        private final Sparkle[] sparkles = new Sparkle[MAX_SPARKLES];
+
+        /**
+         * Array of raw value output levels, matching the size of the model
+         */
+        public double[] outputLevels;
+
+        private int numSparkles;
+        private int maxPixelsPerSparkle;
+
+        public final CompoundParameter minInterval = (CompoundParameter)
+                new CompoundParameter("Fast", 1, .1, 60)
+                        .setExponent(2)
+                        .setUnits(CompoundParameter.Units.SECONDS)
+                        .setDescription("Minimum interval between sparkles");
+
+        public final CompoundParameter maxInterval = (CompoundParameter)
+                new CompoundParameter("Slow", 1, .1, 60)
+                        .setExponent(2)
+                        .setUnits(CompoundParameter.Units.SECONDS)
+                        .setDescription("Maximum interval between sparkles");
+
+        public final CompoundParameter speed =
+                new CompoundParameter("Speed", 0.5)
+                        .setPolarity(CompoundParameter.Polarity.BIPOLAR)
+                        .setDescription("Speed of the sparkle effect");
+
+        public final CompoundParameter variation = (CompoundParameter)
+                new CompoundParameter("Variation", 25, 0, 100)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Variation of sparkle interval");
+
+        public final CompoundParameter duration = (CompoundParameter)
+                new CompoundParameter("Duration", 100, 0, 100)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Duration of a sparkle as percentage of interval");
+
+        public final CompoundParameter density = (CompoundParameter)
+                new CompoundParameter("Density", 50, 0, MAX_DENSITY * 100)
+                        .setExponent(2)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Density of sparkles");
+
+        public final CompoundParameter sharp =
+                new CompoundParameter("Sharp", 0, -1, 1)
+                        .setPolarity(CompoundParameter.Polarity.BIPOLAR)
+                        .setDescription("Sharpness of sparkle curve");
+
+        public final CompoundParameter baseLevel = (CompoundParameter)
+                new CompoundParameter("Base", 0, 0, 100)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Base Level");
+
+        public final CompoundParameter minLevel = (CompoundParameter)
+                new CompoundParameter("Min", 75, 0, 100)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Minimum brightness level, as a percentage of the maximum");
+
+        public final CompoundParameter maxLevel = (CompoundParameter)
+                new CompoundParameter("Max", 100, 0, 100)
+                        .setUnits(CompoundParameter.Units.PERCENT)
+                        .setDescription("Peak sparkle brightness level");
+
+        public Engine(LXModel model) {
+            setModel(model);
+        }
+
+        public void setModel(LXModel model) {
+            // An output level for every pixel in the model
+            this.outputLevels = new double[model.size];
+
+            // Set a cap on the maximum number of sparkle generators
+            this.numSparkles = LXUtils.min(model.size, MAX_SPARKLES);
+
+            // There can be up to MAX_DENSITY times the size of the model sparkle destinations,
+            // so each generator will address up to that many pixels
+            this.maxPixelsPerSparkle = (int) Math.ceil(MAX_DENSITY * model.size / this.numSparkles);
+
+            // Make sure we have enough sparkles allocated, and reindex them all against this model
+            for (int i = 0; i < this.numSparkles; ++i) {
+                if (this.sparkles[i] == null) {
+                    this.sparkles[i] = new Sparkle();
+                }
+                this.sparkles[i].rebuffer(model);
+            }
+        }
+
+        public void run(double deltaMs, LXModel model, double amount) {
+            final double minIntervalMs = 1000 * this.minInterval.getValue();
+            final double maxIntervalMs = 1000 * this.maxInterval.getValue();
+            final double speed = this.speed.getValue();
+            final double variation = .01 * this.variation.getValue();
+            final double durationInv = 100 / this.duration.getValue();
+            final double density = .01 * this.density.getValue();
+            final double baseLevel = LXUtils.lerp(100, this.baseLevel.getValue(), amount);
+
+            LXWaveshape waveshape = this.waveshape.getObject();
+
+            double maxLevel = this.maxLevel.getValue();
+            double minLevel = maxLevel * .01 * this.minLevel.getValue();
+
+            // Amount is used when in effect mode, if amount is cranked down to 0, then
+            // the max and min levels with both lerp back to 100 resulting in a full-white
+            // output that doesn't mask anything
+            maxLevel = LXUtils.lerp(100, maxLevel, amount);
+            minLevel = LXUtils.lerp(100, minLevel, amount);
+
+            // Compute how much brightness sparkles can add to reach top level
+            final double maxDelta = maxLevel - baseLevel;
+            final double minDelta = minLevel - baseLevel;
+
+            double shape = this.sharp.getValue();
+            if (shape >= 0) {
+                shape = LXUtils.lerp(1, 3, shape);
+            } else {
+                shape = 1 / LXUtils.lerp(1, 3, -shape);
+            }
+
+            // Initialize all output levels to base level
+            for (int i = 0; i < this.outputLevels.length; ++i) {
+                this.outputLevels[i] = baseLevel;
+            }
+
+            // Run all the sparkles
+            for (int i = 0; i < this.numSparkles; ++i) {
+                final Sparkle sparkle = this.sparkles[i];
+                double sparkleInterval = LXUtils.lerp(maxIntervalMs, minIntervalMs, LXUtils.constrain(speed + variation * (sparkle.randomVar - .5), 0, 1));
+                sparkle.basis += deltaMs / sparkleInterval;
+
+                // Check if the sparkle has looped
+                if (sparkle.basis > 1) {
+                    sparkle.basis = sparkle.basis % 1.;
+
+                    int desiredPixels = (int) (model.size * density);
+                    float desiredPixelsPerSparkle = desiredPixels / (float) this.numSparkles;
+
+                    if (desiredPixels < this.numSparkles) {
+                        sparkle.activePixels = 1;
+                        sparkle.isOn = Math.random() < desiredPixelsPerSparkle;
+                    } else {
+                        sparkle.isOn = true;
+                        sparkle.activePixels = Math.round(desiredPixelsPerSparkle);
+                    }
+
+                    // Re-randomize this sparkle
+                    if (sparkle.isOn) {
+                        sparkle.randomVar = Math.random();
+                        sparkle.randomLevel = Math.random();
+                        sparkle.reindex(model);
+                    }
+                }
+
+                // Process active sparkles
+                if (sparkle.isOn && (amount > 0)) {
+                    // The duration is a percentage 0-100% of the total period time for which the
+                    // sparkle is active. Here we scale the sparkle's raw 0-1 basis onto this portion
+                    // of duration, and only process the sparkle if it's still in the 0-1 range, e.g.
+                    // if duration is 50% then durationInv = 2 and we'll be done after 0-0.5
+                    double sBasis = sparkle.basis * durationInv;
+                    if (sBasis < 1) {
+                        // Compute and scale the sparkle's waveshape
+                        double g = waveshape.compute(sBasis);
+                        if (shape != 1) {
+                            g = Math.pow(g, shape);
+                        }
+
+                        // Determine how much brightness to add for this sparkle
+                        double maxSparkleDelta = LXUtils.lerp(minDelta, maxDelta, sparkle.randomLevel);
+                        double sparkleAdd = maxSparkleDelta * g;
+
+                        // Add the sparkle's brightness level to all output pixels
+                        for (int c = 0; c < sparkle.activePixels; ++c) {
+                            this.outputLevels[sparkle.indexBuffer[c]] += sparkleAdd;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public final Engine engine = new Engine(model);
+
+    public TESparklePattern(LX lx) {
+        super(lx);
+        addParameter("density", engine.density);
+        addParameter("speed", engine.speed);
+        addParameter("variation", engine.variation);
+        addParameter("duration", engine.duration);
+        addParameter("sharp", engine.sharp);
+        addParameter("waveshape", engine.waveshape);
+        addParameter("minInterval", engine.minInterval);
+        addParameter("maxInterval", engine.maxInterval);
+        addParameter("baseLevel", engine.baseLevel);
+        addParameter("minLevel", engine.minLevel);
+        addParameter("maxLevel", engine.maxLevel);
+    }
+
+    @Override
+    protected void onModelChanged(LXModel model) {
+        engine.setModel(model);
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        engine.run(deltaMs, model, 1.);
+        int i = 0;
+        for (LXPoint p : model.points) {
+            if (model.isGapPoint(p)) continue;
+            colors[p.index] = LXColor.gray(LXUtils.clamp(engine.outputLevels[i++], 0, 100));
+        }
+    }
+}


### PR DESCRIPTION
#### Replaced the following LX patterns with TE-specific versions:
- NoisePattern => TENoisePattern
- GradientPattern => TEGradientPattern
- SparklePattern => TESparklePattern

The new "TE" versions avoid gap pixels but are otherwise identical to the originals.

#### Replaced heronarts.lx.pattern.xxx with our new versions in TEApp.java

#### Replaced heronarts.lx.pattern.xxx with our versions in AutoVJ.lxp and AutoVJ_backup.lxp

(also remove extra log spam from TEWholeModel.java -- I forgot to take it out last night.)