### PR TITLE
BomeBox: add midi surface names for MidiFighterTwister

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,15 @@ encapsulation protocol. To make this work:
     Bome Network tool, enable Remote Direct Midi for those devices.
 5. You can disable MIDI routes that aren't used, such as the DIN ports or
     MIDI messaging between the USB devices. This likely helps performance.
-    Leave 2 routes per device: The bidirection pair LX->⃗Device, and Device->LX. 
+    Leave 2 routes per device: The bidirection pair LX->Device, and Device->LX. 
 6. Register the correct new names in LX. The Bome Remote Direct Midi device 
     names follow a pattern of "{BomeBoxName}: {DeviceName}", like
     "FoH: APC40 mkII". For example, in your main app you may need to
     `lx.engine.midi.registerSurface(name, class)` or match the name with 
-    an entry in lx.engine.midi.inputs[].getName() 
+    an entry in `lx.engine.midi.inputs[].getName()`. If using more than one midi
+    device of the same type BoxBox will present each device with a unique name by
+    appending a number such as "FoH: Midi Fighter Twister (2)".
+    `registerSurface(name, class)` needs to be called for each of these unique names.
 
 [Here's a video](https://youtu.be/ulBLF_IR46I) illustrating our configuration.
 

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -223,7 +223,13 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     lx.registry.addPattern(TEEdgeTestPattern.class);
     lx.registry.addPattern(TEPanelTestPattern.class);
 
+    // Midi surface names for use with BomeBox
     lx.engine.midi.registerSurface("FoH: APC40 mkII", APC40Mk2.class);
+    lx.engine.midi.registerSurface("FoH: Midi Fighter Twister", MidiFighterTwister.class);
+    lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (2)", MidiFighterTwister.class);
+    lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (3)", MidiFighterTwister.class);
+    lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (4)", MidiFighterTwister.class);
+
     // create our library for autopilot
     this.library = initializePatternLibrary(lx);
 


### PR DESCRIPTION
Allows multiple MidiFighterTwister midi surfaces to be used across the network with a BomeBox.