### PR TITLE
Replace broken mod() fn in SpiralDiamonds pattern

### DIFF
--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -24,19 +24,6 @@ public class SpiralDiamonds extends TEPerformancePattern {
             new CompoundParameter("Energy", .1, 0, 1)
                     .setDescription("Ummm.... what does this button do?");
 
-    /**
-     * FFS -- Java has no real mod operator?  Why??  Are we not
-     * well into the Century of the Fruit Bat?  Isn't forcing
-     * all bytes to be signed trouble enough for one language?  What next?<p>
-     *
-     * @return The floored remainder of the division a/b. The result will have
-     * the same sign as b.
-     */
-    public static float mod(float a, float b) {
-        float result = a % b;
-        return (result < 0) ? result + b : result;
-    }
-
     public SpiralDiamonds(LX lx) {
         super(lx);
 
@@ -73,10 +60,10 @@ public class SpiralDiamonds extends TEPerformancePattern {
              x *= scaleFactor;
              y *= scaleFactor;
 
-             // repeat pattern over x axis at interval cx
-             // because!
+             // repeat pattern over x axis at interval cx to make
+             // two spirals at the default scale, one on each end of car.
              float cx = 0.3f;
-             x = mod(x + 0.5f * cx, cx) - 0.5f * cx;
+             x = TEMath.floorModf(x + 0.5f * cx, cx) - 0.5f * cx;
 
              // rotate according to spin control setting
              // we do this inline, using precomputed sin/cos

--- a/src/main/java/titanicsend/pattern/mf64/MF64SpiralSquares.java
+++ b/src/main/java/titanicsend/pattern/mf64/MF64SpiralSquares.java
@@ -72,22 +72,6 @@ public class MF64SpiralSquares extends TEMidiFighter64Subpattern {
         if (refCount == 0) this.stopRequest = true;
     }
 
-    /**
-     * FFS -- Java has no real mod operator?  Why??  Are we not
-     * well into the Century of the Fruit Bat?  Isn't forcing
-     * all bytes to be signed trouble enough for one language?  What next?<p>
-     *
-     * @return The floored remainder of the division a/b. The result will have
-     * the same sign as b.
-     */
-    public static float mod(float a, float b) {
-        float result = a % b;
-        if (result < 0) {
-            result += b;
-        }
-        return result;
-    }
-
     private void paintAll(int colors[], int color) {
 
         // clear the decks if we're getting ready to stop
@@ -115,11 +99,10 @@ public class MF64SpiralSquares extends TEMidiFighter64Subpattern {
             float x = point.zn - 0.5f;
             float y = point.yn - 0.25f;
 
-            // repeat pattern over x axis at interval cx
-            // because!
-            float cx = 0.3f;
-            x = mod(x + 0.5f * cx, cx) - 0.5f * cx;
-
+            // repeat pattern over x axis at interval cx to make
+            // two spirals, one on each end of car.
+            float cx = 0.3f;  // two spirals, one on each end of car
+            x = TEMath.floorModf(x + 0.5f * cx, cx) - 0.5f * cx;
 
             // set up our square spiral
             float x1 = Math.signum(x);


### PR DESCRIPTION
...and MF64SpiralSquares.  Using TEMath.floorModf() instead now.   Zoom is much smoother as intended.

