### PR TITLE
Brightness rework - Now built into common color control

### DIFF
--- a/resources/docs/CommonControls.md
+++ b/resources/docs/CommonControls.md
@@ -68,8 +68,8 @@ and is initialized to 0.5 (synced to half notes at the current tempo.)  Speed an
 tempo syncing mechanism and are described in their own section below.
 - Size - controls zoom, has a range of 0.0 to 5.0 and is initialized to 1.0
 - Angle - static rotational angle.  The UI range is -180 to 180 degrees, all APIs use the same angles, but in radians.
-
-(The Size control has a range of 0.0 to 5.0, and is initialized to 1.0)
+- Brightness - controls color brightness without changing alpha. (May be removed in the future, so avoid using
+  this except to multiply color as the last step in a pattern.  This is handled automatically for shader-based patterns.)
 
 ### Helper functions in TECommonControls
 From a TEPerformancePattern derived class, you can access the 'controls' object, which lets you

--- a/resources/shaders/arcedges.fs
+++ b/resources/shaders/arcedges.fs
@@ -1,0 +1,100 @@
+#define LINE_COUNT 52
+uniform vec4[LINE_COUNT] lines;
+
+// Simple fbm noise system, used to generate the noise
+// field we use for electri arcs
+vec2 hash (in vec2 p) {
+  p = vec2 (dot (p, vec2 (127.1, 311.7)),
+            dot (p, vec2 (269.5, 183.3)));
+
+  return -1. + 2.*fract (sin (p)*43758.5453123);
+}
+
+float noise (in vec2 p) {
+  const float K1 = .366025404;
+  const float K2 = .211324865;
+
+  vec2 i = floor (p + (p.x + p.y)*K1);
+   
+  vec2 a = p - i + (i.x + i.y)*K2;
+  vec2 o = step (a.yx, a.xy);    
+  vec2 b = a - o + K2;
+  vec2 c = a - 1. + 2.*K2;
+
+  vec3 h = max (.5 - vec3 (dot (a, a), dot (b, b), dot (c, c) ), .0);
+
+  vec3 n = h*h*h*h*vec3 (dot (a, hash (i + .0)),
+                         dot (b, hash (i + o)),
+                         dot (c, hash (i + 1.)));
+
+  return dot (n, vec3 (52.));
+}
+
+float fbm(vec2 pos, float tm) {
+    vec2 offset = vec2(cos(tm), 0.0);
+    float aggr = 0.0;
+    
+    aggr += noise(pos);
+    aggr += noise(pos + offset) * 0.5;
+    aggr += noise(pos + offset.yx) * 0.25;
+    aggr += noise(pos - offset) * 0.125;
+
+    aggr /= 1.0 + 0.5 + 0.25 + 0.125;
+
+    return (aggr * 0.5) + 0.5;
+}
+
+// NOTE: Two color shader.  Uses iColorRGB as the first color, and the
+// secondary palette color as the second color.
+vec3 electrify(vec2 pos, float offset,float direction) {
+    vec3 col = vec3(0.0);
+    vec2 f = vec2(0.0, iTime * 0.25*direction);
+    float noiseMag = offset * iWow1;
+
+    for (int i = 0; i < 2; i++) {
+        float time = direction * iTime + float(i);
+
+        float d1 = abs(noiseMag / (offset - fbm((pos + f) * 2.55, 2. * time)));
+        float d2 = abs(noiseMag / (offset - fbm((pos + f) * 1.41, time + 10.0)));
+        col += vec3(d1 * iColorRGB);
+        col += vec3(d2 * iPalette[TE_SECONDARY]);
+    }
+    
+    return col;
+}
+
+// more-or-less standard signed distance to line segment
+float glowline2(vec2 p, vec4 seg,float width) {
+    vec2 ld = seg.xy - seg.zw;
+    vec2 pd = p - seg.zw;
+    
+    return length(pd - ld*clamp( dot(pd, ld)/dot(ld, ld), 0.0, 1.0)) - width;    
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    vec2 uv = -1. + 2. * fragCoord / iResolution.xy;
+    uv.x *= iResolution.x / iResolution.y;
+    uv *= 0.5;
+
+    vec3 finalColor = vec3(0.0);
+    for (int i = 0; i < LINE_COUNT; i++) {
+
+      float dist = glowline2(uv,lines[i],iScale);
+
+      // add contribution of this segment's "electric arcs"
+      vec3 col = electrify(uv, dist + iQuantity,(mod(i,2) == 0) ? 1. : -1.);
+      col *= smoothstep(0.125,-0.01,dist);
+
+      // add some glow to the base line
+      col += iColorRGB * (0.75-dist) * smoothstep(0.01, -0.0051, dist);
+      finalColor += col * col * col;
+	}
+    
+    fragColor = vec4(finalColor, max(finalColor.r,max(finalColor.g,finalColor.b)));
+}
+
+
+
+
+
+

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -154,6 +154,7 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     lx.registry.addPattern(Smoke.class);
 
     // Patterns that are in development towards meeting standards
+    lx.registry.addPattern(ArcEdges.class);
     lx.registry.addPattern(BassLightning.class);
     lx.registry.addPattern(BouncingDots.class);
     lx.registry.addPattern(Bubbles.class);

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -445,13 +445,12 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     }
 
     /**
-     * NOTE: This control has functional overlap with color and channel fader settings, and
-     * could potentially can confusing brightness behavior.
+     * <b>NOTE:</b> This control has functional overlap with color and channel fader settings, and
+     * could potentially cause confusing brightness behavior.
      * <p></p>
-     * It may be deprecated in the future and at present, should only be used as a final multiplier
-     * for color values as the last step in a pattern.
+     * <b>It may be deprecated or removed in the future and should not be used in patterns.</b>
      *
-     * @return The current value of the brightness control, by default in the range 0-100.
+     * @return The current value of the brightness control, by default in the range 0.0 to 1.0
      */
     public double getBrightness() {
         return controls.getValue(TEControlTag.BRIGHTNESS);

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -373,10 +373,45 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         return controls.getValue(TEControlTag.ANGLE);
     }
 
+    /**
+     * @return Color derived from the current setting of the color and brightness controls
+     * <p></p>
+     * NOTE:  The design philosophy here is that palette colors (and the color control)
+     * have precedence.
+     * <p></p>
+     * Brightness modifies the current color, and is set to 1.0 (100%) by default. So
+     * if you don't move the brightness control you get *exactly* the currently
+     * selected color.
+     * <p></p>
+     * At present, the brightness control lets you dim the current color,
+     * but if you want to brighten it, you have to do that with the channel fader or
+     * the color control.
+     */
     public int getCurrentColor() {
+        int k = controls.color.calcColor();
+        float bri = (float) getBrightness();
+
+        float r = (float) (0xff & LXColor.red(k)) * bri;
+        float g = (float) (0xff & LXColor.green(k)) * bri;
+        float b = (float) (0xff & LXColor.blue(k)) * bri;
+        return LXColor.rgb((int) r,(int) g,(int) b);
+    }
+
+    /**
+     * Gets the current color as set in the color control, without adjusting
+     * for brightness.  This is used by the OpenGL renderer, which has
+     * a unified mechanism for handling brightness.
+     *
+     */
+    public int getCurrentColorControlValue() {
         return controls.color.calcColor();
     }
 
+    /**
+     *
+     * @return current variable time in seconds.millis.  Note that time
+     * can run both forward and backward, and can be negative.
+     */
     public double getTime() {
         return iTime.getTime();
     }
@@ -409,10 +444,17 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         return controls.getValue(TEControlTag.SPIN);
     }
 
-    // multiply by 100 so that LXColor.hsb( ... ) and similar inputs can use it, since
-    // LX expects brightness in a range of 0-100
+    /**
+     * NOTE: This control has functional overlap with color and channel fader settings, and
+     * could potentially can confusing brightness behavior.
+     * <p></p>
+     * It may be deprecated in the future and at present, should only be used as a final multiplier
+     * for color values as the last step in a pattern.
+     *
+     * @return The current value of the brightness control, by default in the range 0-100.
+     */
     public double getBrightness() {
-        return 100 * controls.getValue(TEControlTag.BRIGHTNESS);
+        return controls.getValue(TEControlTag.BRIGHTNESS);
     }
 
     public double getWow1() {

--- a/src/main/java/titanicsend/pattern/jon/ArcEdges.java
+++ b/src/main/java/titanicsend/pattern/jon/ArcEdges.java
@@ -1,0 +1,167 @@
+package titanicsend.pattern.jon;
+
+import com.jogamp.common.nio.Buffers;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.model.LXPoint;
+import titanicsend.model.TEEdgeModel;
+import titanicsend.model.TEPanelModel;
+import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
+import titanicsend.pattern.yoffa.framework.PatternTarget;
+import titanicsend.pattern.yoffa.shader_engine.NativeShader;
+import titanicsend.pattern.yoffa.shader_engine.ShaderOptions;
+import titanicsend.util.TE;
+
+import java.nio.FloatBuffer;
+import java.util.HashMap;
+import java.util.Set;
+
+@LXCategory("Native Shaders Panels")
+public class ArcEdges extends TEPerformancePattern {
+    NativeShaderPatternEffect effect;
+    NativeShader shader;
+    static final int LINE_COUNT = 52;
+    FloatBuffer gl_segments;
+    float[][] saved_lines;
+    float[][] working_lines;
+    float[][] line_velocity;
+
+
+    // Constructor
+    public ArcEdges(LX lx) {
+        super(lx);
+
+        // create new effect with alpha on and no automatic
+        // parameter uniforms
+
+        ShaderOptions options = new ShaderOptions();
+        options.useAlpha(true);
+        options.useLXParameterUniforms(false);
+
+        // TODO - Controls not yet tuned.  I just want to make sure this beast will actually
+        // TODO - work on a Mac before proceeding.
+        controls.setRange(TEControlTag.SIZE,0.008,0.0005,0.02);    // edge "line size"
+        controls.setRange(TEControlTag.QUANTITY,0.675,0.72,0.35);  // noise field position
+        controls.setRange(TEControlTag.WOW1,0.025,0.001,0.06);     // noise magnitude
+
+        // register common controls with the UI
+        addCommonControls();
+
+        effect = new NativeShaderPatternEffect("arcedges.fs",
+                PatternTarget.allPointsAsCanvas(this), options);
+
+        // create an n x 4 array, so we can pass line segment descriptors
+        // to GLSL shaders.
+        // NOTE: This buffer needs to be *exactly* large enough to contain
+        // the number of line segments you're using.  No smaller, no bigger.
+        this.gl_segments = Buffers.newDirectFloatBuffer(LINE_COUNT * 4 * 4);
+
+        // buffer to hold line descriptors taken from the vehicle
+        saved_lines = new float[LINE_COUNT][4];
+
+        // grab up some random edges to test
+        // NOTE: To add more edges, you need to change LINE_COUNT so the
+        // segment buffer will be the right size.
+        scanForHappyEdges();
+    }
+
+    // store segment descriptors in our GL line segment buffer.
+    void setUniformLine(int segNo,float x1,float y1, float x2, float y2) {
+        //TE.log("setLine %d : %.4f %.4f, %.4f %.4f",segNo,x1,y1,x2,y2);
+        gl_segments.position(segNo * 4);
+        gl_segments.put(-x1); gl_segments.put(y1);
+        gl_segments.put(-x2); gl_segments.put(y2);
+        gl_segments.rewind();
+    }
+
+    // convert from normalized physical model coords
+    // to aspect corrected normalized 2D GL surface coords
+    float modelToMapX(LXPoint pt) {
+        //correct for aspect ratio of render target
+        return 1.33333f*((-0.5f+pt.zn));
+    }
+
+    // convert from normalized physical model coords
+    // to aspect corrected normalized 2D GL surface coords
+    float modelToMapY(LXPoint pt) {
+        return -0.525f + pt.yn;
+    }
+
+    // scan for edges with at least one connected panel
+    void scanForHappyEdges() {
+         Set<TEEdgeModel> edges = model.getAllEdges();
+         int edgeCount = 0;
+
+        for (TEEdgeModel edge : edges) {
+
+            if (edge.connectedPanels.size() >= 1) {
+                for (TEPanelModel panel : edge.connectedPanels) {
+
+                    // use only starboard side panels
+                    if (panel.getId().startsWith("S")) {
+
+                        //TE.log("Found edge w/panel(s): %s",edge.getId());
+                        getLineFromEdge(edgeCount,edge.getId());
+                        edgeCount++;
+                        break;
+                    }
+                    if (edgeCount >= LINE_COUNT) break;
+                }
+            }
+
+        }
+        //TE.log("%d edges found!",edgeCount);
+    }
+
+
+    // given an edge id, adds a model edge's vertices to our list of line segments
+    void getLineFromEdge(int index, String id) {
+        LXPoint v1,v2;
+
+        HashMap<String,TEEdgeModel> edges = model.edgesById;
+
+        TEEdgeModel edge = edges.get(id);
+        if (edge != null) {
+            //TE.log("Found edge %s", id);
+        }
+        else {
+            TE.log("Null edge %s",id);
+        }
+        v1 = edge.points[0]; v2 = edge.points[edge.points.length - 1];
+
+        // set x1,y1,x2,y2 in line array
+        saved_lines[index][0] = modelToMapX(v1);  saved_lines[index][1] = modelToMapY(v1);
+        saved_lines[index][2] = modelToMapX(v2);  saved_lines[index][3] = modelToMapY(v2);
+    }
+
+    // sends an array of line segments to the shader
+    // should be called after all line computation is done,
+    // before running the shader
+    void sendSegments(float[][] lines,int nLines) {
+        for (int i = 0; i < nLines; i++) {
+            setUniformLine(i,lines[i][0],lines[i][1],lines[i][2],lines[i][3]);
+        }
+        shader.setUniform("lines", gl_segments,4);
+    }
+
+    @Override
+    public void runTEAudioPattern(double deltaMs) {
+        // send line segment array data
+        sendSegments(saved_lines,LINE_COUNT);
+
+        // run the shader
+       effect.run(deltaMs);
+    }
+
+    @Override
+    // THIS IS REQUIRED if you're not using ConstructedPattern!
+    // Initialize the NativeShaderPatternEffect and retrieve the native shader object
+    // from it when the pattern becomes active
+    public void onActive() {
+        super.onActive();
+        effect.onActive();
+        shader = effect.getNativeShader();
+    }
+
+}

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -84,15 +84,8 @@ public class SpiralDiamonds extends TEPerformancePattern {
              float dx = (float) Math.abs(Math.sin(squareocity * Math.log(x * sx + y * sy) + point.azimuth - t1));
              int on = ((dx * dx * dx) < 0.15) ? 1 : 0;
 
-             // now incorporate brightness control
-             int colorRGBWithBrightness = LXColor.hsb(
-                     LXColor.h(color),
-                     LXColor.s(color),
-                     this.getBrightness() * 100
-             );
-
              // finally, set color of pixel
-             colors[point.index] = colorRGBWithBrightness * on;
+             colors[point.index] = color * on;
          }
     }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -229,7 +229,7 @@ public class NativeShader implements GLEventListener {
 
         // color-related uniforms
         float x, y, z;
-        int color = ctl.getCurrentColor();
+        int color = ctl.getCurrentColorControlValue();
         x = (float) (0xff & LXColor.red(color)) / 255f;
         y = (float) (0xff & LXColor.green(color)) / 255f;
         z = (float) (0xff & LXColor.blue(color)) / 255f;
@@ -249,7 +249,7 @@ public class NativeShader implements GLEventListener {
         setUniform("iTranslate", (float) ctl.getXPos(), (float) ctl.getYPos());
         setUniform("iSpin",(float) ctl.getSpin());
         setUniform("iRotationAngle", (float) ctl.getRotationAngleFromSpin());
-        setUniform("iBrightness", (float) (ctl.getBrightness() / 100));
+        setUniform("iBrightness", (float) ctl.getBrightness());
         setUniform("iWow1", (float) ctl.getWow1());
         setUniform("iWow2", (float) ctl.getWow2());
         setUniform("iWowTrigger", ctl.getWowTrigger());

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/PatternControlData.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/PatternControlData.java
@@ -82,6 +82,8 @@ public class PatternControlData {
         return parent.getCurrentColor();
     }
 
+    public int getCurrentColorControlValue() { return parent.getCurrentColorControlValue(); }
+
     public FloatBuffer getCurrentPalette() { return parent.getCurrentPalette();}
 
     public double getSpeed() {


### PR DESCRIPTION
The Brightness control is now automatically used to adjust the output of the color control, so pattern developers do not have to worry about multiplying color by brightness in their patterns.  If you get color from the common control, it will just work.  This applies to both Java and GLSL.

(Also sneaking in the ArcEdges pattern - controls are definitely not tuned yet, but I'd like to get some feedback on how it runs on a Mac.  If it doesn't blow up because I've missed removing some nvidia only feature, I'd expect M1/M2 machines to be fine.  Might slow down the Intel models a bit.)