### PR TITLE
Update Outrun Grid shader to use common controls

### DIFF
--- a/resources/shaders/outrun_grid.fs
+++ b/resources/shaders/outrun_grid.fs
@@ -7,6 +7,12 @@ float fov = 90.0;
 float farClip = -16.0;
 float boltSize = 0.25;
 
+// Parameters derived from controls.  Grouped here for
+// easier tuning.
+float invert = (iWowTrigger) ? 1.0 : -1.0; // WowTrigger inverts colors
+float glowScale = iScale / 10.0;  // line width/glow factor
+float gridScale = 0.5 + (iQuantity);  // grid size (number of lines visible)
+
 //  rotate a point around the origin by <angle> radians
 vec2 rotate(vec2 point, float angle) {
   mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
@@ -33,32 +39,32 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     vec2 uv = fragCoord / iResolution.xy;
     vec2 p = (fragCoord.xy - iResolution.xy*.5) / iResolution.y;
 
-    // scale and rotate according to current control settings
-    p *= iScale;
-    p = rotate(p,iRotationAngle);
-
-    // iWowTrigger puts it in boat mode!
-    horizonY += (iWowTrigger) ? 0.1 * sin(p.x * 5.0 + iTime * 3.0) : 0.0;
-
     fragColor = vec4(0.0);
 
-    // Define the current grid displacement
-    vec3 displace = vec3(0.0, -4.0*iTime, 1.5);
+    // rotate according to current control settings
+    p = rotate(p,iRotationAngle);
 
-    // bend x axis to the beat - iWow1 controls the amplitude
-    p.x += (iWow1/6.0) * sin(iTime + p.y * 12.0);
+    // iWow1 controls path curvature
+    // high values of iWow1 add 3D waves to the horizon
+    horizonY += (iWow1 > 0.5) ? (0.2*(iWow1 - 0.5)) * sin(p.x * 5.0 + iTime * 3.0) : 0.0;
+
+    // Define the current grid displacement
+    vec3 displace = vec3(0.0, -4.0 * (1.0 / gridScale) *iTime, 1.5);
+
+    // bend x axis to the beat - iWow1 controls the amplitude of the curves
+    p.x += min(0.5,iWow1)/6.0 * sin(iTime + p.y * 12.0);
 
     // Get worldspace position of grid
-    vec3 gridPos = revProject(p - vec2(0., horizonY), displace.z, fov);
+    vec3 gridPos = revProject(p - vec2(0.0, horizonY), displace.z, fov);
 
     // display grid if inside z-clipping region
     if (p.y <= horizonY && gridPos.z >= farClip)  {
 
-        // Create grid
-        vec2 grid = fract(gridPos.xz - displace.xy) - 0.5;
+        // Create grid - Quantity sets the number of gridlines (subdivision size)
+        vec2 grid = fract(gridScale * (gridPos.xz - displace.xy)) - 0.5;
 
         // Compute distance from grid edges
-        float dist = smin(-grid.x * grid.x,-grid.y * grid.y,0.2);
+        float dist = smin(invert * grid.x * grid.x,invert * grid.y * grid.y,-invert * glowScale);
         dist = dist * dist;
 
         // Send brightness pulses down the Y gridlines to the beat - iWow2 controls amplitude
@@ -67,20 +73,20 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
         float zn = gridPos.z/farClip;
 
         // change the direction of the beat pulses depending on the direction of time
-        float beatDist = (iSpeed >= 0) ? abs((1.-zn) - beat) : abs(zn - beat);
+        float beatDist = (iSpeed >= 0.0) ? abs((1.-zn) - beat) : abs(zn - beat);
 
         beatDist = (beatDist <= boltSize) ? (boltSize - beatDist) / boltSize : 0.0;
         float pattern = (grid.x * grid.x) * beatDist;
-        pattern = iWow2 * pow(pattern,1.35);
+        pattern = iWow2 * pow(pattern,1.3);
 
         // Fade grid as we approach far clipping plane.  This gets rid of a lot
         // of potential aliasing trouble.
         float fade = 2.0-zn;
 
-        // vary the underlying "terrain" color a little to enhanve movement
-        float glow = (iQuantity * 1.25 - dist) + clamp(0.3*sin(8.0 * zn - iTime*6.0),-1.0,0.0);
+        // vary the underlying "terrain" color a little to enhance movement
+        float glow = (glowScale - dist) + max(0.3*sin(8.0 * zn - iTime*6.0),0.0);
 
-        // Calculate and scale overall brightness - iQuantity controls glow level
+        // Calculate and scale overall brightness
         float intensity = max(glow,14.0 * fade * (dist + pattern));
 
         // set final color and build reasonable alpha value from brightness

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -171,7 +171,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             p = new CompoundParameter("Speed", 0.5, -4.0, 4.0)
                     .setPolarity(LXParameter.Polarity.BIPOLAR)
                     .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
-                    .setExponent(1.0)
+                    .setExponent(1.75)
                     .setDescription("Speed");
             setControl(TEControlTag.SPEED, p);
 


### PR DESCRIPTION
Outrun Grid now supports all the controls:

The globally supported controls (speed,spin,xpos,ypos, etc.) have not been changed.  They work as before.  Here's what the new ones do:

- Quantity:  Glow level
- Wow1: Curving paths
- Wow2: Bright pulses down the Z-axis on the beat
- Wow Trigger:  Boat Mode!  


Also, palette support is in, and the alpha channel now supports proper blending.