### PR TITLE
Pattern Rework 1 - Pixelblaze (and others)

### DIFF
--- a/resources/pixelblaze/audio1.js
+++ b/resources/pixelblaze/audio1.js
@@ -7,7 +7,7 @@ export function sliderEnergyLevel(v) {
 }
 
 export function beforeRender(delta) {
-  energy = getWow1();
+  energy = getQuantity();
   t1 = time(.1 * 256)
 }
 

--- a/resources/pixelblaze/audio1.js
+++ b/resources/pixelblaze/audio1.js
@@ -7,6 +7,7 @@ export function sliderEnergyLevel(v) {
 }
 
 export function beforeRender(delta) {
+  energy = getWow1();
   t1 = time(.1 * 256)
 }
 

--- a/resources/pixelblaze/glue.js
+++ b/resources/pixelblaze/glue.js
@@ -138,6 +138,73 @@ function getTrebleRatio() {
   return __pattern.getTrebleRatio();
 }
 
+// getter functions for the common controls
+function getRotationAngleFromSpeed() {
+    return __pattern.getRotationAngleFromSpeed();
+}
+
+function getRotationAngleFromSpin() {
+    return __pattern.getRotationAngleFromSpin();
+}
+
+function getStaticRotationAngle() {
+    return __pattern.getStaticRotationAngle();
+}
+
+function getCurrentColor() {
+    var k = __pattern.controls.color.calcColor();
+    var bri = __pattern.getBrightness();
+
+    var r = (0xff & LXColor.red(k)) * bri;
+    var g = (0xff & LXColor.green(k)) * bri;
+    var b = (0xff & LXColor.blue(k)) * bri;
+    return rgb(r, g, b);
+}
+
+function getTime() {
+    return __pattern.getTime();
+}
+
+function getSpeed() {
+    return __pattern.getSpeed();
+}
+
+function getXPos() {
+    return __pattern.getXPos();
+}
+
+function getYPos() {
+    return __pattern.getYPos();
+}
+
+function getSize() {
+    return __pattern.getSize();
+}
+
+function getQuantity() {
+    return __pattern.getQuantity();
+}
+
+/**
+ * As in Java, for for most uses, getRotationAngle() is recommended, but if you
+ * need direct access to the spin control value, here it is.
+ */
+function getSpin() {
+    return __pattern.getSpin();
+}
+
+function getWow1() {
+    return __pattern.getWow1();
+}
+
+function getWow2() {
+    return __pattern.getWow2();
+}
+
+function getWowTrigger() {
+    return __pattern.getWowTrigger();
+}
+
 /* Pixelblaze compatibility framework glue */
 
 function sentenceCase(text) {
@@ -202,12 +269,14 @@ function glueRender() {
   } else {
     r = render;
   }
+  var xOffs = __pattern.getXPos();
+  var yOffs = -__pattern.getYPos();
   var i;
   for (i = 0; i < __points.length; i++) {
     __color = 0;
     point = __points[i];
     if (point == __pattern.model.gapPoint) continue;
-    r(i, point.xn, point.yn, point.zn);
+    r(i, point.xn + xOffs, point.yn + yOffs, point.zn);
     __colors[point.index] = __color;
   }
 }

--- a/resources/shaders/audio_test2.fs
+++ b/resources/shaders/audio_test2.fs
@@ -1,7 +1,13 @@
+
 // TE Audio Test Shader
-// 
+//
 // NOTE: If we flip y axis direction in the shader framework, as we should,
 // remember to take the "uv.y = 1-uv.y" out of this shader
+
+#define TEXTURE_SIZE 512.0
+#define CHANNEL_COUNT 16.0
+#define pixPerBin (TEXTURE_SIZE / CHANNEL_COUNT)
+#define halfBin (pixPerBin / 2.0)
 
 vec3 hsv2rgb(vec3 c)
 {
@@ -10,32 +16,59 @@ vec3 hsv2rgb(vec3 c)
     return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
+//  rotate a point around the origin by <angle> radians
+vec2 rotate(vec2 point, float angle) {
+  mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+  return rotationMatrix * point;
+}
+
 void mainImage( out vec4 fragColor, in vec2 fragCoord )
 {
-    // create pixel coordinates
+    // normalize coordinates
 	vec2 uv = fragCoord.xy / iResolution.xy;
-	//uv.y = 1.-uv.y;   // flip y axis direction
+
+    // translate to roughly vehicle origin, then scale and rotate according
+    // to common control settings.
+    uv -= vec2(0.5,0.5);
+    uv = rotate(uv,iRotationAngle);
+    uv += vec2(0.5,0.5);
+    uv *= 1.0/iScale;
+
 
     // sound texture size is 512x2
-    int tx = int(uv.x*512.0);
+    // we're going to quantize that into a 32 channel EQ
 
-	// first row is frequency data 
+    float index = mod(uv.x * 512.0,512.0);
+    float p = floor(index / pixPerBin);
+    float tx = halfBin+pixPerBin * p;
+    float dist = abs(halfBin - mod(index,pixPerBin)) / halfBin;
+
+    // since we're using dist to calculate desatuation for a specular
+    // reflection effect, we'll modulate it with beat, to change
+    // apparent shininess.
+    dist = (dist * dist * dist) - iWow1 * beat;
+
+	// first row is frequency data
 	float freq  = texelFetch( iChannel0, ivec2(tx,0), 0 ).x;
-	
+
 	// convert frequency data to shifting colors, just because we can!
-	vec3 hsv = vec3(0.5+0.5 * sin(iTime + 6.28* freq),1.,1.);
-	vec3 col = hsv2rgb(hsv);
-	
+	vec3 hsvLayer1 = vec3(0.5 + 0.5 * sin(iTime+p*0.618),dist,iWow2);
+    vec3 hsvLayer2 =
+    vec3(hsvLayer1.x, max(hsvLayer1.y,1.0-dist)- 0.1,hsvLayer1.z + (1.0-dist));
+
+	vec3 col = hsv2rgb(hsvLayer2);
+
 	// make a simple spectrum analyzer display
-	col *= (freq > uv.y) ? 1. : 0.;
+	col *= ((freq > uv.y) ? 1.0 : 0.);
+
 
     // second row is normalized sound waveform data
 	// just draw this over the spectrum analyzer.  Sound data
 	// coming from LX is in the range -1 to 1, so we scale it and move it down
 	// a bit so we can see it better.
-    float wave = (0.5 * (1.0+texelFetch( iChannel0, ivec2(tx,1), 0 ).x)) - 0.25;
-	col += 1.0 - smoothstep( 0.0, 0.035, abs(wave - uv.y));
+    float wave = (0.5 * (1.0+texelFetch( iChannel0, ivec2(index,1), 0 ).x)) - 0.25;
+	col += (1.0-smoothstep( 0.0, 0.04, abs(wave - uv.y)));
 
 	// return pixel color
-	fragColor = vec4(col,1.0);
+	fragColor = vec4(col,max(col.r,max(col.g,col.b)));
 }

--- a/resources/shaders/audio_test2.fs
+++ b/resources/shaders/audio_test2.fs
@@ -1,9 +1,6 @@
-
 // TE Audio Test Shader
+// Spectrum Analyzer and Waveform Display
 //
-// NOTE: If we flip y axis direction in the shader framework, as we should,
-// remember to take the "uv.y = 1-uv.y" out of this shader
-
 #define TEXTURE_SIZE 512.0
 #define CHANNEL_COUNT 16.0
 #define pixPerBin (TEXTURE_SIZE / CHANNEL_COUNT)
@@ -18,57 +15,69 @@ vec3 hsv2rgb(vec3 c)
 
 //  rotate a point around the origin by <angle> radians
 vec2 rotate(vec2 point, float angle) {
-  mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
-  return rotationMatrix * point;
+    mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+    return rotationMatrix * point;
 }
 
-void mainImage( out vec4 fragColor, in vec2 fragCoord )
-{
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec3 col;
     // normalize coordinates
-	vec2 uv = fragCoord.xy / iResolution.xy;
+    vec2 uv = fragCoord.xy / iResolution.xy;
 
-    // translate to roughly vehicle origin, then scale and rotate according
+    // translate coords to roughly vehicle origin, then scale and rotate according
     // to common control settings.
-    uv -= vec2(0.5,0.5);
-    uv = rotate(uv,iRotationAngle);
-    uv += vec2(0.5,0.5);
+    uv -= vec2(0.5, 0.5);
+    uv = rotate(uv, iRotationAngle);
+    uv += vec2(0.5, 0.5);
     uv *= 1.0/iScale;
 
+    // The audio texture size is 512x2
+    // mapping to screen depends on iScale and iQuantity - here
+    // we use iQuantity to figure out which texture pixels are relevant
+    float index = mod(uv.x * TEXTURE_SIZE * 2.0 * iQuantity, TEXTURE_SIZE);
 
-    // sound texture size is 512x2
-    // we're going to quantize that into a 32 channel EQ
+    // The second row of is normalized waveform data
+    // we'll just draw this over the spectrum analyzer.  Sound data
+    // coming from LX is in the range -1 to 1, so we scale it and move it down
+    // a bit so we can see it better.
+    float wave = (0.5 * (1.0+texelFetch(iChannel0, ivec2(index, 1), 0).x)) - 0.25;
 
-    float index = mod(uv.x * 512.0,512.0);
-    float p = floor(index / pixPerBin);
-    float tx = halfBin+pixPerBin * p;
-    float dist = abs(halfBin - mod(index,pixPerBin)) / halfBin;
+    // iWowTrigger solos the waveform display in the current primary color
+    if (iWowTrigger) {
+        col = iColorRGB * (1.0-smoothstep(0.0, 0.06, abs(wave - uv.y)));
+    }
+    else {
+        // subdivide fft data into bins determined by iQuantity
+        float p = floor(index / pixPerBin);
+        float tx = halfBin+pixPerBin * p;
+        float dist = abs(halfBin - mod(index, pixPerBin)) / halfBin;
 
-    // since we're using dist to calculate desatuation for a specular
-    // reflection effect, we'll modulate it with beat, to change
-    // apparent shininess.
-    dist = (dist * dist * dist) - iWow1 * beat;
+        // since we're using dist to calculate desatuation for a specular
+        // reflection effect, we'll modulate it with beat, to change
+        // apparent shininess and give it some extra bounce.
+        dist = dist - (beat * beat);
 
-	// first row is frequency data
-	float freq  = texelFetch( iChannel0, ivec2(tx,0), 0 ).x;
+        // display frequency bands in shifting colors, just because we can!
+        vec3 hsvLayer1 = vec3(0.5 + 0.5 * sin(iTime+p*0.618), dist, 0.5);
+        vec3 hsvLayer2 =
+        vec3(hsvLayer1.x, max(hsvLayer1.y,1.0-dist), hsvLayer1.z +1.0- dist);
 
-	// convert frequency data to shifting colors, just because we can!
-	vec3 hsvLayer1 = vec3(0.5 + 0.5 * sin(iTime+p*0.618),dist,iWow2);
-    vec3 hsvLayer2 =
-    vec3(hsvLayer1.x, max(hsvLayer1.y,1.0-dist)- 0.1,hsvLayer1.z + (1.0-dist));
+        // iWow2 controls "palette compliance". Technically, this is one
+        // of the many wrong ways to mix color, but it works for this purpose.
+        // More iWow2 == more color
+        col = hsv2rgb(mix(hsvLayer2, iColorHSB, mix(0.0, 0.66667, 1.0-iWow2)));
 
-	vec3 col = hsv2rgb(hsvLayer2);
+        // get frequency data pixel from texture
+        float freq  = texelFetch(iChannel0, ivec2(tx, 0), 0).x;
 
-	// make a simple spectrum analyzer display
-	col *= ((freq > uv.y) ? 1.0 : 0.);
+        // make a simple beat reactive spectrum analyzer display
+        col *= ((freq > uv.y) ? uv.y/freq : 0.);
 
+        // iWow1 controls the brightness of the waveform display. Higher iWow1
+        // means less waveform
+        col += (1.0 - iWow1) *  (1.0-smoothstep(0.0, 0.04, abs(wave - uv.y)));
+    }
 
-    // second row is normalized sound waveform data
-	// just draw this over the spectrum analyzer.  Sound data
-	// coming from LX is in the range -1 to 1, so we scale it and move it down
-	// a bit so we can see it better.
-    float wave = (0.5 * (1.0+texelFetch( iChannel0, ivec2(index,1), 0 ).x)) - 0.25;
-	col += (1.0-smoothstep( 0.0, 0.04, abs(wave - uv.y)));
-
-	// return pixel color
-	fragColor = vec4(col,max(col.r,max(col.g,col.b)));
+    // return pixel color
+    fragColor = vec4(col, max(col.r, max(col.g, col.b)));
 }

--- a/resources/shaders/followthatstar.fs
+++ b/resources/shaders/followthatstar.fs
@@ -1,5 +1,3 @@
-uniform float glow;
-uniform float energy;
 
 const float step = 0.5;  // star spacing
 
@@ -21,8 +19,8 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     vec2 uPos = -0.5+(fragCoord.xy / iResolution.xy );
     
     // star size pulses with the music!
-    float pulse = (0.3 * energy * (-0.5+beat)) + 1.618 * iScale;
-    float dance = 0.2 + (0.5 * bassLevel * energy);
+    float pulse = (0.3 * iWow1 * (-0.5+beat)) + 1.618 * iScale;
+    float dance = 0.2 + (0.5 * bassLevel * iWow1);
     float brightness = 0.;
 
     // set up matrix for optional rotation
@@ -56,9 +54,10 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     // version of this pattern. (I didn't see that LX wanted alpha in a different
     // range from everything else when setting hsba colors.)
     vec3 col = vec3(iColorHSB.x,
-                    iColorHSB.y * clamp((pulse+(2.25f-brightness)),0,1),
-                    brightness = iColorHSB.z * clamp(brightness * brightness,0,1));
+                    iColorHSB.y * clamp(pulse+(2.25f-brightness),0.0,1.0),
+                    brightness = iColorHSB.z * clamp(brightness * brightness,0.0,1.0));
+
 
     col = hsv2rgb(col);
-    fragColor = vec4(col, brightness * glow);
+    fragColor = vec4(col, brightness * iWow2);
 }

--- a/resources/shaders/phasers.fs
+++ b/resources/shaders/phasers.fs
@@ -1,14 +1,22 @@
-uniform float energy;
-uniform float iCanvasAngle;
+
+
+// Controls
+// Speed - beam rotation speed
+// Spin/Angle - canvas rotation
+// Quantity - beam splitter / number of beams
+// Size - beam width / focus
+// iWow1 - beat reactivity
+// iWow2 - glow / fog level
+// WowTrigger - center beam and strobe blast
+uniform float iCanvasAngle = 0.0;
+uniform float beamWidth;
 
 const float PI = 3.141592653589793;
 const float halfpi = PI / 2.;
-const float twopi = PI * 2.;
+const float TAU = PI * 2.;
 const float xPos1 = -0.285;
 const float xPos2 = 0.315;
 const float yCenter = 0.3;
-
-#define glow iWow2
 
 // accumulator for "Wow Trigger" effect
 float zapper = 0.0;
@@ -19,26 +27,13 @@ vec2 rotate(vec2 point, float angle) {
   return rotationMatrix * point;
 }
 
-// 2D (square) Domain repeats
-vec2 repeat2D(vec2 p, vec2 size) {
-	return mod(p + size*0.5,size) - size*0.5;
-}
-
-// polar domain repeats around coordinate origin
-// (looks like pie slices on the car)
-void modPolar(inout vec2 p, float repetitions) {
-	float angle = twopi/repetitions;
-	float a = atan(p.y, p.x) + angle/2.;
-	a = mod(a,angle) - angle/2.;
-	p = vec2(cos(a), sin(a))*length(p);
-}
-
-// 2D circle distance function
+// 2D circle signed distance function
  float circle(vec2 p, float radius){
-	return radius - length(p);
+	return length(p) - radius;
 }
 
- // rand [0,1]
+ // Probably not really that random but its
+ // distribution, whatever it be, looks nice for fog.
  float rand(vec2 p) {
  	return fract(sin(dot(p, vec2(12.543,514.123)))*4732.12);
  }
@@ -58,7 +53,7 @@ void modPolar(inout vec2 p, float repetitions) {
  float fbm(vec2 p) {
      float a = 0.5;
      float r = 0.0;
-     for (int i = 0; i < 7; i++) {
+     for (int i = 0; i < 6; i++) {
          r += a*noise(p);
          a *= 0.5;
          p *= 2.0;
@@ -70,79 +65,58 @@ void modPolar(inout vec2 p, float repetitions) {
 // emphasizing the center of the beam, and splitting it <beams> ways.
 float laser(vec2 p, vec2 offset, float angle, float beams) {
 
-   // scale the beam generator positions so they converge in a way
-   // that looks about right. (never mind pesky physics!)
-   offset *= 1./pow(iScale,0.25);
-
-   // Rotate (spin the whole beam generator)
+   // Rotate (spin the whole beam generator) around its origin
    p += offset;
    p *= mat2(cos(angle), -sin(angle),
              sin(angle), cos(angle));
 
 
     // get angle relative to current origin
+    float radius = length(p) * ((iWowTrigger) ? 1.0-beat : 1.0);
+    beams = floor(beams);
 	float theta = atan(p.x, p.y);
 
-	// sine wave used for both light and glow
-	float wave = 0.5+0.5*sin(halfpi - theta*beams);
+    // draw constant width radial line for "laser beam"
+    float bend = iWow1 * sin(21.0 * radius +  TAU * beat);
+    float pulse = iWow1 * beat;
+    float lzr =  smoothstep(beamWidth,0.0 , radius * abs(bend+sin(theta * beams / 2.0)));
 
-    // narrow the glow a little
-    float glw =  pow(wave,40./beams) / iScale;
+	// generate a bright cone for glow effect
+	float glw = max(0.0,0.5+0.5*(bend + sin(halfpi - theta*beams)));
+    glw = pow(0.9*glw,iScale/beams);
 
-    // narrow the actual laser beam (a lot!)
-    //float lzr = glw + smoothstep(0.0035,0.,1.-glw);
-    float lzr = glw + smoothstep(.15,0.,1.-glw);
+    // add circular strobe burst on iWowTrigger
+    zapper += (iWowTrigger) ? smoothstep(0.0,-0.1,circle(p, beat/4.0)) : 0.0 ;
 
-    // add part of the original wave fn for extra glow
-    // the divisor
-    zapper += (iWowTrigger) ? smoothstep(0.165,0.225,circle(p, beat/2.45)) : 0.0 ;
-	return lzr+glw;
+	return clamp(((lzr+glw) * smoothstep(0.051,-.0001,circle(p,radius))) - pulse,0.0,1.0);
 }
 
- // mix of fractal noises to simulate fog
- // elegant 2 layers + 3rd used to mix from https://www.shadertoy.com/view/7tBSR1
+ // mix of fbm noise to simulate fog
+ // 2 layers + 3rd used to mix from https://www.shadertoy.com/view/7tBSR1
+ // makes a nice, smooth fog.
 float clouds(vec2 uv) {
   vec2 t = vec2(iTime*0.5,iTime);
   float c1 = fbm(fbm(uv*3.0)*0.75+uv*3.0+t/3.0);
   float c2 = fbm(fbm(uv*2.0)*0.5+uv*7.0+t/3.0);
   float c3 = fbm(fbm(uv*10.0-t)*0.75+uv*5.0+t/6.0);
   float r = mix(c1, c2, c3*c3);
-  return r*r*r;
+  return r * r * r;
 }
 
 void mainImage( out vec4 fragColor, in vec2 fragCoord) {
-  vec2 uv = -0.5+fragCoord/max(iResolution.x,iResolution.y);
-
+  vec2 uv = -0.5+fragCoord/iResolution.x;
   uv = rotate(uv,iCanvasAngle);
 
-  if (iWow1 > 0.0) {
-    uv.x = fract(2.0 * uv.x);
-    uv = repeat2D(uv,vec2(1.0-iWow1));
-    modPolar(uv,1.0 + iWow1 * 12.0);
-  }
+  // beam+splitter combo
+  float l = laser(uv, vec2(xPos2, fract(yCenter)), iRotationAngle, iQuantity);
 
-  uv *= iScale;
-
-  // noise to modulate beam brightness
-  float n = 1.+(3.*noise(vec2(iTime*11.,iTime * 5.)));
-
-  // control beam movement in x and y
-  float beatSine = -1 + 2 * sinPhaseBeat;
-  float xOffset = energy * beatSine;
-  float yOffset = yCenter + energy * -beatSine;
-
-  // generate a beam for each end of the vehicle
-    vec2 offset  = vec2(xPos1+xOffset, fract(yOffset));
-	float l = n * laser(uv, offset, iRotationAngle, iQuantity);
-
-    offset = vec2(xPos2-xOffset, fract(yOffset));
-    l += n * laser(uv, offset, iRotationAngle, iQuantity);
-
-  // add fog, compose final color and go
+  // background fog texture
   float c = clouds(uv);
-  vec3 col = iColorRGB * c * glow;
-  col += iColorRGB * l * (c+(0.5*energy*beat));
-  col = col + zapper;  // add iWowTrigger effect
+
+  // Calculate the final color
+  // laser beam always travels through *all* the fog, even if
+  // the fog (controlled by iWow2) is turned down
+  vec3 col = iColorRGB * ((8.0 * l * c) + (c * iWow2) + zapper);
 
   // alpha is taken from the brightest color channel value.
   fragColor = vec4(col,sqrt(max(col.r,max(col.g,col.b))));

--- a/src/main/java/titanicsend/pattern/ben/Audio1.java
+++ b/src/main/java/titanicsend/pattern/ben/Audio1.java
@@ -6,67 +6,66 @@ import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.utils.Noise;
 import titanicsend.model.TEEdgeModel;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.pixelblaze.PixelblazePort;
 
 @LXCategory("Combo FG")
 public class Audio1 extends PixelblazePort {
 
-	private double energy;
-	private float scale;
-	private int electric;
-	private double t1;
-	private double waveBase;
+    private double energy;
+    private float scale;
+    private int electric;
+    private double t1;
+    private double waveBase;
 
-	private CompoundParameter energyParameter;
-	private CompoundParameter scaleParameter;
-	private DiscreteParameter electricParameter;
+    private CompoundParameter energyParameter;
+    private CompoundParameter scaleParameter;
+    private DiscreteParameter electricParameter;
 
-	public Audio1(LX lx) {
-		super(lx);
-		energyParameter = new CompoundParameter("Energy", .5, 0, 1);
-		addParameter("energy", energyParameter);
+    public Audio1(LX lx) {
+        super(lx);
+    }
 
-		scaleParameter = new CompoundParameter("Scale", 1.0, 0.2, 10);
-		addParameter("scale", scaleParameter);
+    @Override
+    public void configureControls() {
+        controls.setRange(TEControlTag.SIZE, 1.0, 0.2, 10.0); // "Scale" parameter
+        controls.setRange(TEControlTag.WOW1, 6, 1, 8);  // "Electric" parameter
+    }
 
-		electricParameter = new DiscreteParameter("Electric", 6, 1, 8);
-		addParameter("electric", electricParameter);
-	}
+    @Override
+    public void setup() {
 
-	@Override
-	public void setup() {
+    }
 
-	}
+    @Override
+    public void onPointsUpdated() {
 
-	@Override
-	public void onPointsUpdated() {
+    }
 
-	}
+    @Override
+    public void render3D(int index, float x, float y, float z) {
+        float f = triangle(z * 2 + y);
+        double beat = (triangle(x * .5 + y * .8 - waveBase + .6) - .5) * 4 * energy;
+        beat = clamp(beat, 0, 1);
 
-	@Override
-	public void render3D(int index, float x, float y, float z) {
-		float f = triangle( z*2 + y );
-		double beat = (triangle(x * .5 + y * .8 - waveBase  + .6) - .5) * 4 * energy;
-		beat = clamp(beat, 0, 1);
+        float lacunarity = 2;
+        float gain = (float) (.7 + beat / 4);
+        float ridgeOffset = (float) (.78 + beat / 20);
 
-		float lacunarity = 2;
-		float gain = (float) (.7 + beat / 4);
-		float ridgeOffset = (float) (.78 + beat / 20);
+        float a = -1 + 4 * Noise.stb_perlin_ridge_noise3(
+                (float) ((x - .5f) * .2f * scale + t1), (y - .5f) * scale, (z - .5f) * scale,
+                lacunarity, gain, ridgeOffset, electric);
 
-		float a = -1 + 4 * Noise.stb_perlin_ridge_noise3(
-				(float) ((x - .5f) * .2f * scale + t1), (y - .5f) * scale, (z - .5f) * scale,
-				lacunarity, gain, ridgeOffset, electric);
+        paint(f + a);
+        setAlpha(a);
+    }
 
-		paint(f + a);
-		setAlpha(a);
-	}
-
-	@Override
-	public void beforeRender(double deltaMs) {
-		t1 = time(.1 * 256) * 256;
-		energy = energyParameter.getValue();
-		scale = scaleParameter.getValuef();
-		electric = electricParameter.getValuei();
-		waveBase = (4 + measure() * 4) % 1;
-	}
+    @Override
+    public void beforeRender(double deltaMs) {
+        t1 = time(.1 * 256) * 256;
+        energy = getQuantity();
+        scale = (float) getSize();
+        electric = (int) getWow1();
+        waveBase = (4 + measure() * 4) % 1;
+    }
 }

--- a/src/main/java/titanicsend/pattern/ben/Audio1.java
+++ b/src/main/java/titanicsend/pattern/ben/Audio1.java
@@ -18,10 +18,6 @@ public class Audio1 extends PixelblazePort {
     private double t1;
     private double waveBase;
 
-    private CompoundParameter energyParameter;
-    private CompoundParameter scaleParameter;
-    private DiscreteParameter electricParameter;
-
     public Audio1(LX lx) {
         super(lx);
     }

--- a/src/main/java/titanicsend/pattern/ben/Xorcery.java
+++ b/src/main/java/titanicsend/pattern/ben/Xorcery.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.ben;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.pixelblaze.PixelblazePort;
 
 import static java.lang.Math.abs;
@@ -20,7 +21,12 @@ public class Xorcery extends PixelblazePort {
 		super(lx);
 	}
 
-	@Override
+    @Override
+    public void configureControls() {
+		controls.setRange(TEControlTag.SIZE,5,1,10);
+    }
+
+    @Override
 	public void setup() {
 
 	}
@@ -65,6 +71,7 @@ public class Xorcery extends PixelblazePort {
 		t2 = time(.1) * PI2;
 		t3 = time(.5);
 		t4 = time(.34) * PI2;
+		scale = getSize();
 	}
 
 	double xorf(double v1, double v2) {

--- a/src/main/java/titanicsend/pattern/ben/Xorcery.java
+++ b/src/main/java/titanicsend/pattern/ben/Xorcery.java
@@ -6,7 +6,6 @@ import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.pixelblaze.PixelblazePort;
 
 import static java.lang.Math.abs;
-import static java.lang.Math.sin;
 
 @LXCategory("Combo FG")
 public class Xorcery extends PixelblazePort {
@@ -16,6 +15,11 @@ public class Xorcery extends PixelblazePort {
 	private double t4;
 
 	private double scale = 5;
+	private double breath;
+	private double modRange;
+	private double measureWave;
+
+	private float sinT,cosT;
 
 	public Xorcery(LX lx) {
 		super(lx);
@@ -38,27 +42,27 @@ public class Xorcery extends PixelblazePort {
 
 	@Override
 	public void render3D(int index, float x, float y, float z) {
-		double m, h, v;
+		double h, v;
 
-		y += wave(measure()) * .1 + time(.1); //bounce / fall
-		// y += time(.1) //blittery waterfalls!
-		x += wave(measure()) * .2; //breathing
+		// translate so origin is at vehicle center and
+		// rotate according to spin control setting
+		//
+		x -= 0.5; y -= 0.5; z -= 0.5;
+		float outX = (cosT * x) - (sinT  * z);
+		z = (sinT * x) + (cosT * z);
+		x = outX;
 
-		m = .3 + triangle(t1) * .2; //.3 to .5
-		h = sin(t2) + wave(
-				xorf(scale * (x - .5), xorf(scale * (z - .5),scale * (y - .5))) //xor coordinates
-						/ 50 * (triangle(t3) * 10 + 4 * sin(t4)) //vary the density/detail
-						% m //variable modulus wrapping and range
-		);
-		v = (abs(h) + abs(m) + t1) % 1;
-		v = triangle(v * v);
+		y += t1 + measureWave * .05; // add a slight bounce to movement
+		x += breath * measureWave; // breathing effect
+		h = t2 + wave( xorf(scale * x, xorf(scale * z , scale * y)) / 50 * (t3 * 10 + 4 * t4) % modRange );
+
+		v = (abs(h) + modRange + t1) % 1;
+		v = triangle(v);
 		v = v * v;
 
 		//original hsv calculates teal through purple colors (.45 - .85):
 		// h = triangle(h) * .2 + triangle(x + y + z) * .2 + .45
 		// hsv(h, 1, v)
-
-
 		//for paint(), don't downscale the range
 		h = triangle(h) + triangle(x + y + z);
 		paint((float) h); //color gradient based on edge/panel
@@ -67,11 +71,19 @@ public class Xorcery extends PixelblazePort {
 
 	@Override
 	public void beforeRender(double deltaMs) {
-		t1 = time(.1);
-		t2 = time(.1) * PI2;
-		t3 = time(.5);
-		t4 = time(.34) * PI2;
+		t1 = 1.0 - time(.1);
+		t2 = Math.sin(t1 * PI2);
+		t3 = triangle(time(.5));
+		t4 = Math.sin(time(.34) * PI2);
+
 		scale = getSize();
+		breath = 0.05 + 0.3 * getWow1();
+		modRange = 0.3 + (triangle(t1) * 0.2 * getWow2());
+		measureWave = wave(measure());
+
+		double theta = (float) getRotationAngleFromSpin();
+		cosT = (float) Math.cos(theta);
+		sinT = (float) Math.sin(theta);
 	}
 
 	double xorf(double v1, double v2) {

--- a/src/main/java/titanicsend/pattern/jon/FollowThatStar.java
+++ b/src/main/java/titanicsend/pattern/jon/FollowThatStar.java
@@ -11,8 +11,6 @@ import titanicsend.pattern.yoffa.framework.PatternTarget;
 import titanicsend.pattern.yoffa.shader_engine.NativeShader;
 import titanicsend.pattern.yoffa.shader_engine.ShaderOptions;
 
-// TODO - NEEDS FULL CONVERSION TO COMMON CONTROLS
-
 @LXCategory("Combo FG")
 public class FollowThatStar extends TEPerformancePattern {
     NativeShaderPatternEffect effect;
@@ -28,12 +26,6 @@ public class FollowThatStar extends TEPerformancePattern {
             new CompoundParameter("Energy", .15, 0, 1)
                     .setDescription("Oh boy...");
 
-    protected final CompoundParameter beatScale = (CompoundParameter)
-            new CompoundParameter("BeatScale", 60, 120, 1)
-                    .setExponent(1)
-                    .setUnits(LXParameter.Units.INTEGER)
-                    .setDescription("Speed relative to beat");
-
     public FollowThatStar(LX lx) {
         super(lx);
 
@@ -43,18 +35,20 @@ public class FollowThatStar extends TEPerformancePattern {
 
         // create new effect with alpha on and no automatic
         // parameter uniforms
-
         ShaderOptions options = new ShaderOptions();
         options.useAlpha(true);
         options.useLXParameterUniforms(false);
 
-        // register common controls with the UI
-        addCommonControls();
+        // configure common controls for this pattern
+        controls.setRange(TEControlTag.QUANTITY, 5, 1, 10)
+                .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
 
-        // Add this pattern's custom controls.
-        addParameter("glow", glow);
-        addParameter("energy", energy);
-        addParameter("beatScale", beatScale);
+        controls.setRange(TEControlTag.SIZE, 0.2, 0.01, 1);
+        controls.setRange(TEControlTag.WOW1, 0.15, -0, 1);
+        controls.setRange(TEControlTag.WOW2, 100, 1, 200);
+
+        // register common controls with LX
+        addCommonControls();
 
         effect = new NativeShaderPatternEffect("followthatstar.fs",
                 PatternTarget.allPointsAsCanvas(this), options);
@@ -62,14 +56,6 @@ public class FollowThatStar extends TEPerformancePattern {
 
     @Override
     public void runTEAudioPattern(double deltaMs) {
-
-        shader.setUniform("iQuantity", 1f + (float) Math.floor(getQuantity() * 9));
-        shader.setUniform("iScale", 0.01f + (float) getSize());
-        shader.setUniform("glow", glow.getValuef());
-
-        // Sound reactivity - various brightness features are related to energy
-        float e = energy.getValuef();
-        shader.setUniform("energy", e * e);
 
         // run the shader
         effect.run(deltaMs);

--- a/src/main/java/titanicsend/pattern/jon/Phasers.java
+++ b/src/main/java/titanicsend/pattern/jon/Phasers.java
@@ -16,13 +16,6 @@ public class Phasers extends TEPerformancePattern {
     NativeShaderPatternEffect effect;
     NativeShader shader;
 
-    // Pattern-specific controls
-
-    // energy pulses brightness to the beat
-    public final CompoundParameter energy =
-            new CompoundParameter("Energy", .1, 0, .4)
-                    .setDescription("Dance!");
-
     public Phasers(LX lx) {
         super(lx);
 
@@ -34,26 +27,27 @@ public class Phasers extends TEPerformancePattern {
 
         // set parameters for common controls
 
-        // start with beam split 3 ways
-        controls.setRange(TEControlTag.QUANTITY, 3, 1, 8)
-        .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
+        // start with beam split 5 ways and spinning slowly
+        controls.setRange(TEControlTag.QUANTITY, 5, 1, 8)
+                .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
 
-        controls.setRange(TEControlTag.SIZE,1,0.5,5);
+        // Speed controls background movement speed and direction
+        controls.setRange(TEControlTag.SPEED, 0.25, -1.0, 1.0);
 
-        controls.setRange(TEControlTag.XPOS, 0, -0.5, 0.5)
-        .setRange(TEControlTag.YPOS, 0, -0.5, 0.5);
+        // Spin controls spin rate
+        controls.setRange(TEControlTag.SPIN, 0.25, -1, 1);
 
-        // Wow1 breaks the image into slices
-        controls.setRange(TEControlTag.WOW1, 0.0,0,0.9);
+        // Size controls beam width and dispersion
+        controls.setRange(TEControlTag.SIZE, 21, 40, 2);
 
-        // Wow2 is the fog brightness
+        // Wow1 controls beat reactivity
+        controls.setRange(TEControlTag.WOW1, 0.0, 0.0, 0.6);
+
+        // Wow2 is background fog brightness
         controls.setRange(TEControlTag.WOW2, 2, 0, 4);
 
         // After configuring all the common controls, register them with the UI
         addCommonControls();
-
-        // Add any extra controls used by this pattern
-        addParameter("energy", energy);
 
         // Create the underlying shader pattern
         effect = new NativeShaderPatternEffect("phasers.fs",
@@ -63,19 +57,10 @@ public class Phasers extends TEPerformancePattern {
     @Override
     public void runTEAudioPattern(double deltaMs) {
 
-        // Sound reactivity - various brightness features are related to energy
-        float e = energy.getValuef();
-        shader.setUniform("energy", e * e);
-
-        // Overriding a default uniform -- setting it in user code has priority.
-        //
-        // Here, iRotationAngle will be used to rotate the beam angle, and will be
-        // controlled by the speed control, rather than by the default spin control.
-        shader.setUniform("iRotationAngle",(float) getRotationAngleFromSpeed());
-
-        // And we'll create a new, separate uniform using the spin control to rotate
-        // the entire canvas.
-        shader.setUniform("iCanvasAngle",(float) getRotationAngleFromSpin());
+        // use the size control to control both the laser's beam size and surrounding glow
+        CompoundParameter scaleCtl = (CompoundParameter) controls.getLXControl(TEControlTag.SIZE);
+        double beamWidth = 0.005 + 0.0125 * scaleCtl.getNormalized();
+        shader.setUniform("beamWidth", (float) beamWidth);
 
         // run the shader
         effect.run(deltaMs);

--- a/src/main/java/titanicsend/pattern/pixelblaze/PBAudio1.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PBAudio1.java
@@ -8,7 +8,6 @@ public class PBAudio1 extends PixelblazePattern {
 		super(lx);
 	}
 
-	@Override
 	protected String getScriptName() {
 		return "audio1";
 	}

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
@@ -3,12 +3,13 @@ package titanicsend.pattern.pixelblaze;
 import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
 import titanicsend.pattern.TEAudioPattern;
+import titanicsend.pattern.TEPerformancePattern;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.*;
 
-public class PixelblazeParallel extends TEAudioPattern {
+public class PixelblazeParallel extends TEPerformancePattern {
   public static final int N_THREADS = 4;
   private ArrayList<Wrapper> wrappers = new ArrayList<>();
 

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
@@ -7,12 +7,13 @@ import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEAudioPattern;
+import titanicsend.pattern.TEPerformancePattern;
 
 import javax.script.ScriptException;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-public abstract class PixelblazePattern extends TEAudioPattern {
+public abstract class PixelblazePattern extends TEPerformancePattern {
   public static final int RENDER_ERROR_LOG_INTERVAL_MS = 5_000;
   private Wrapper wrapper;
   long lastLogMs = 0; //to prevent spamming the logs with script errors
@@ -44,9 +45,11 @@ public abstract class PixelblazePattern extends TEAudioPattern {
 
   public PixelblazePattern(LX lx) {
     super(lx);
+
+    addCommonControls();
+
     enableEdges = new BooleanParameter("Edges", true);
     enablePanels = new BooleanParameter("Panels", true);
-
 
     enableEdges.addListener(modelPointsListener);
     enablePanels.addListener(modelPointsListener);

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
@@ -5,13 +5,14 @@ import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEAudioPattern;
+import titanicsend.pattern.TEPerformancePattern;
 
 import java.util.ArrayList;
 
 import static java.lang.Math.PI;
 import static java.lang.Math.sin;
 
-public abstract class PixelblazePort extends TEAudioPattern {
+public abstract class PixelblazePort extends TEPerformancePattern {
 
 	public BooleanParameter enableEdges;
 	public BooleanParameter enablePanels;
@@ -20,7 +21,7 @@ public abstract class PixelblazePort extends TEAudioPattern {
 
 	//"globals"
 	public int pixelCount;
-	public long now;
+	//public long now;
 
 	//render fields
 	public LXPoint point;
@@ -28,9 +29,12 @@ public abstract class PixelblazePort extends TEAudioPattern {
 
 	public PixelblazePort(LX lx) {
 		super(lx);
+
+		configureControls();
+		addCommonControls();
+
 		enableEdges = new BooleanParameter("Edges", true);
 		enablePanels = new BooleanParameter("Panels", true);
-
 
 		enableEdges.addListener(modelPointsListener);
 		enablePanels.addListener(modelPointsListener);
@@ -45,7 +49,7 @@ public abstract class PixelblazePort extends TEAudioPattern {
 
 	private void updateLocalVars() {
 		pixelCount = modelPoints.length;
-		now = System.currentTimeMillis();
+		//now = System.currentTimeMillis();
 	}
 
 	protected LXParameterListener modelPointsListener = lxParameter -> {
@@ -73,14 +77,24 @@ public abstract class PixelblazePort extends TEAudioPattern {
 		updateLocalVars();
 		beforeRender(deltaMs);
 
+		float xOffs = (float) getXPos();
+		float yOffs = (float) -getYPos();
 		for (int i = 0; i < modelPoints.length; i++) {
 			color = 0;
 			point = modelPoints[i];
-			render3D(i, point.xn, point.yn, point.zn);
+			render3D(i, point.xn + xOffs, point.yn + yOffs, point.zn);
 			colors[point.index] = color;
 		}
 	}
 
+	/**
+	 * Called before adding common controls. Derived classes can override this to
+	 * change control ranges, response curves and other parameters if necessary.
+	 * <p></p>
+	 * If a pattern needs to add additional custom controls, it can do so by
+	 * implementing them in setup().
+	 */
+    public abstract void configureControls();
 
 	public abstract void setup();
 
@@ -105,7 +119,7 @@ public abstract class PixelblazePort extends TEAudioPattern {
 	}
 
 	public double time(double interval) {
-		return ((now / 65536.0) % interval) / interval;
+		return ((getTime() / 65.536) % interval) / interval;
 	}
 
 	public double wave(double v) {

--- a/src/main/java/titanicsend/pattern/pixelblaze/Wrapper.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/Wrapper.java
@@ -13,6 +13,7 @@ import heronarts.lx.model.LXPoint;
 import org.openjdk.nashorn.api.scripting.JSObject;
 import org.openjdk.nashorn.api.scripting.NashornScriptEngineFactory;
 import titanicsend.pattern.TEAudioPattern;
+import titanicsend.pattern.TEPerformancePattern;
 
 public class Wrapper {
 
@@ -52,19 +53,19 @@ public class Wrapper {
     return cachedScript.compiledScript;
   }
 
-  public static Wrapper fromResource(String pbClass, TEAudioPattern pattern, LXPoint[] points) throws Exception {
+  public static Wrapper fromResource(String pbClass, TEPerformancePattern pattern, LXPoint[] points) throws Exception {
     return new Wrapper(new File("resources/pixelblaze/" + pbClass + ".js"), pattern, points);
   }
 
   File file;
-  TEAudioPattern pattern;
+  TEPerformancePattern pattern;
   LXPoint[] points;
   long lastModified;
   Bindings bindings = engine.createBindings();
   String renderName;
   boolean hasError = false;
 
-  public Wrapper(File file, TEAudioPattern pattern, LXPoint[] points) throws ScriptException, IOException {
+  public Wrapper(File file, TEPerformancePattern pattern, LXPoint[] points) throws ScriptException, IOException {
     this.file = file;
     this.pattern = pattern;
     this.points = points;
@@ -88,7 +89,7 @@ public class Wrapper {
 
       bindings.put("pixelCount", points.length);
       bindings.put("__pattern", pattern);
-      bindings.put("__now", System.currentTimeMillis());
+      bindings.put("__now", pattern.getTime() * 1000.0);
 
       glueScript.eval(bindings);
       patternScript.eval(bindings);
@@ -106,13 +107,13 @@ public class Wrapper {
   public void render(double deltaMs, int[] colors) throws ScriptException, NoSuchMethodException {
     if (hasError)
       return;
-    bindings.put("__now", System.currentTimeMillis());
+    bindings.put("__now", pattern.getTime() * 1000.0);
     bindings.put("__points", points);
     bindings.put("__colors", colors);
 
     JSObject glueBeforeRender = (JSObject) bindings.get("glueBeforeRender");
     if (glueBeforeRender != null)
-      glueBeforeRender.call(null, deltaMs, System.currentTimeMillis(), points, colors);
+      glueBeforeRender.call(null, deltaMs, pattern.getTime() * 1000.0, points, colors);
     JSObject glueRender = (JSObject) bindings.get("glueRender");
     if (glueRender != null)
       glueRender.call(null);


### PR DESCRIPTION
- ```PixelblazePattern``` (javascript) &  ```PixelblazePort``` (java) patterns now support common controls.
- Some high priority Pixelblaze patterns, plus several others, have been refined and modified to work with the new controls.

Details:

**AudioTest2 (Spectrum analyzer pattern)** 
- Speed: no effect
- X/Y Offset: Yes
- Spin/Angle:  Yes, but use gently.
- Brightness: Yes
- Size: Controls overall scale
- Quantity: controls number of bands (repeated, not subdivided.)
- Wow1: Fades waveform display.  (leaving spectrum analyzer)
- Wow2: Color.  More Wow2 == more colors, more shine (and less palette compliance)
- WowTrigger: Solos waveform display in current primary color

**Phasers:**
- Speed: controls beam generator spin rate
- X/Y Offset: Yes
- Spin/Angle: Rotates canvas
- Brightness: Yes
- Size: Beam width and focus
- Quantity:  Number of beams generated by beam splitter
- Wow1: Beat reactive beam waviness.  Try it!
- Wow2: Fog intensity
- Wow Trigger: Beat reactive sweep & big flash

**Audio1:  (Use this rather than PBAudio1)**
- Color: Uses current primary-secondary gradient
- Speed: Yes
- X/Y Offset: Yes
- Spin/Angle: No
- Brightness: Yes
- Size: Scale of noise background
- Quantity: Amount of beat reactive pulse
- Wow1: Noise resolution
- Wow2: No
- WowTrigger: No

**Xorcery: (Use this rather than PBXorcery)**
- Color: Uses current primary-secondary gradient
- Speed: Yes - pattern movement and direction.  Very sensitive
- X/Y Offset: Yes, but not really useful
- Spin/Angle: Yes.
- Brightness: Yes
- Size: Scale pattern
- Quantity: No
- Wow1: Slow, beat linked "breathing" effect
- Wow2: Pattern detail modulation
- WowTrigger: No

**Follow That Star:**
- Speed: Controls star movement rate
- X/Y Offset: Yes
- Spin/Angle: Star spin speed
- Brightness: Yes
- Size: Size of stars
- Quantity:  Number of stars
- Wow1: Stars flash and dance to the beat
- Wow2: Overall glow level of stars
- Wow Trigger: No
