### PR TITLE
TEColorParameter and custom ui

### DIFF
--- a/Projects/Belcher_color.lxp
+++ b/Projects/Belcher_color.lxp
@@ -1,0 +1,3243 @@
+{
+  "version": "0.4.2-SNAPSHOT",
+  "timestamp": 1681849292132,
+  "model": {
+    "id": 2,
+    "class": "heronarts.lx.structure.LXStructure",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true
+    },
+    "parameters": {
+      "label": "LX",
+      "syncModelFile": false
+    },
+    "children": {}
+  },
+  "engine": {
+    "id": 1,
+    "class": "heronarts.lx.LXEngine",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true
+    },
+    "parameters": {
+      "label": "Engine",
+      "multithreaded": true,
+      "channelMultithreaded": false,
+      "networkMultithreaded": false,
+      "framesPerSecond": 60.0,
+      "speed": 1.0,
+      "performanceMode": false
+    },
+    "children": {
+      "palette": {
+        "id": 5,
+        "class": "heronarts.lx.color.LXPalette",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette",
+          "transitionEnabled": true,
+          "transitionTimeSecs": 0.1,
+          "transitionMode": 0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 1800.0,
+          "autoCycleCursor": 9,
+          "triggerSwatchCycle": false,
+          "expandedPerformance": true
+        },
+        "children": {
+          "swatch": {
+            "id": 6,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWv",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 7,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 43784,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 43786,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 9.0
+                },
+                "children": {}
+              },
+              {
+                "id": 43788,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 77.25000762939453,
+                  "primary/hue": 256.0,
+                  "secondary/brightness": 76.66666412353516,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 43790,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 27.000001907348633,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        },
+        "swatches": [
+          {
+            "id": 13222,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Pink",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 13223,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13225,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13227,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 75.83333587646484,
+                  "secondary/hue": 51.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13229,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13231,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 99.16666412353516,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 13200,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "YelOrn",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 13201,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13203,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13205,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 74.0,
+                  "primary/hue": 40.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 33.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13207,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13209,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 99.16666412353516,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 10315,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "IceOlate",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 10316,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10318,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10320,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 61.00000087171793,
+                  "primary/hue": 192.58998466096818,
+                  "secondary/brightness": 58.33328628540039,
+                  "secondary/saturation": 70.83333587646484,
+                  "secondary/hue": 195.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10322,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10324,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 99.16666412353516,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 13244,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "BluePurp",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 13245,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13247,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13249,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 62.49992370605469,
+                  "primary/saturation": 66.66666412353516,
+                  "primary/hue": 192.00001525878906,
+                  "secondary/brightness": 70.83332824707031,
+                  "secondary/saturation": 59.16666793823242,
+                  "secondary/hue": 192.00001525878906
+                },
+                "children": {}
+              },
+              {
+                "id": 13251,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13253,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 99.16666412353516,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 10905,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "PlumIce",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 10906,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10908,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 294.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10910,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 40.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 294.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 10912,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10914,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 54.166664123535156,
+                  "primary/hue": 66.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 10478,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "IceGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 10479,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10481,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10483,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 61.00000087171793,
+                  "primary/hue": 192.58998466096818,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10485,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 47.0,
+                  "primary/hue": 258.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 28.333335876464844,
+                  "secondary/hue": 273.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10487,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 10337,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "IceYelGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 10338,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10340,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10342,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 10344,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 20.833328247070312,
+                  "primary/hue": 225.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 288.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10346,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 54.166664123535156,
+                  "primary/hue": 66.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 11202,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "GreenRod",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 11203,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11205,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11207,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 95.49999237060547,
+                  "primary/saturation": 80.83333587646484,
+                  "primary/hue": 78.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 82.5,
+                  "secondary/hue": 96.00000762939453
+                },
+                "children": {}
+              },
+              {
+                "id": 11209,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 99.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 98.33333587646484,
+                  "secondary/hue": 72.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11211,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 39.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 11354,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "SunWave",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 11355,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11357,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11359,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.83333206176758,
+                  "primary/hue": 204.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 85.0,
+                  "secondary/hue": 210.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11361,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 273.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 300.0
+                },
+                "children": {}
+              },
+              {
+                "id": 11363,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 27.000001907348633,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 13117,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWv",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 13118,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13120,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13122,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 9.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13124,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 77.25000762939453,
+                  "primary/hue": 256.0,
+                  "secondary/brightness": 76.66666412353516,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 13126,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 27.000001907348633,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 12880,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWvDyn",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 12881,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12883,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12885,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 38.33333206176758,
+                  "secondary/hue": 330.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12887,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 78.91667175292969,
+                  "primary/hue": 249.0,
+                  "secondary/brightness": 44.9999885559082,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 12889,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 27.000001907348633,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 10020,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Sunset",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 10021,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 2,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 67.5,
+                  "primary/hue": 324.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10023,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 2,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 98.33333587646484,
+                  "primary/hue": 324.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10025,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 69.33331298828125,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10027,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 63.33330154418945,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 10029,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 64.0,
+                  "primary/hue": 229.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 36178,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-13",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 36179,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36181,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36183,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 71.66666412353516,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 59.99995040893555,
+                  "secondary/saturation": 58.333335876464844,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36185,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 98.33333587646484,
+                  "primary/hue": 219.0,
+                  "secondary/brightness": 38.3332633972168,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36187,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 36267,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-14",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 36268,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36270,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36272,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 56.66666793823242,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36274,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 62.5,
+                  "primary/hue": 174.0,
+                  "secondary/brightness": 64.16655731201172,
+                  "secondary/saturation": 70.0,
+                  "secondary/hue": 186.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36276,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 36382,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-15",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 36383,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36385,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36387,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 30.0,
+                  "primary/hue": 300.0,
+                  "secondary/brightness": 61.6666145324707,
+                  "secondary/saturation": 59.16666793823242,
+                  "secondary/hue": 303.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36389,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 68.333251953125,
+                  "primary/saturation": 73.33332824707031,
+                  "primary/hue": 318.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 40.833335876464844,
+                  "secondary/hue": 312.0
+                },
+                "children": {}
+              },
+              {
+                "id": 36391,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 37121,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-16",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 37122,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 37124,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 186.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 37126,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 89.01960754394531,
+                  "primary/saturation": 97.5,
+                  "primary/hue": 159.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 68.08334350585938,
+                  "secondary/hue": 90.0
+                },
+                "children": {}
+              },
+              {
+                "id": 37128,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 62.30385208129883,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 165.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              },
+              {
+                "id": 37130,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 39.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 38102,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-17",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 38103,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38105,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38107,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 58.333335876464844,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 49.99996566772461,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 180.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38109,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 84.99995422363281,
+                  "secondary/saturation": 61.66666793823242,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38111,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 38139,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-18",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 38140,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38142,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38144,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 198.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38146,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 77.5,
+                  "primary/hue": 216.00001525878906,
+                  "secondary/brightness": 66.66657257080078,
+                  "secondary/saturation": 69.16666412353516,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38148,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 38150,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-19",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 38151,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38153,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38155,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 192.00001525878906,
+                  "secondary/brightness": 62.49994659423828,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 195.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38157,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 212.99998474121094,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 48.333335876464844,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38159,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 38785,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-20",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 38786,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 183.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38788,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38790,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 342.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38792,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 51.66666793823242,
+                  "primary/hue": 333.0,
+                  "secondary/brightness": 66.66656494140625,
+                  "secondary/saturation": 55.83333206176758,
+                  "secondary/hue": 324.0
+                },
+                "children": {}
+              },
+              {
+                "id": 38794,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 75.83333587646484,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        ]
+      },
+      "tempo": {
+        "id": 9,
+        "class": "heronarts.lx.Tempo",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Tempo",
+          "clockSource": 0,
+          "period": 491.8032786885246,
+          "bpm": 122.0,
+          "tap": false,
+          "nudgeUp": false,
+          "nudgeDown": false,
+          "beatsPerMeasure": 4,
+          "trigger": false,
+          "enabled": true
+        },
+        "children": {
+          "nudge": {
+            "id": 10,
+            "class": "heronarts.lx.modulator.LinearEnvelope",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "LENV",
+              "running": false,
+              "trigger": false,
+              "loop": false,
+              "tempoSync": false,
+              "tempoMultiplier": 5,
+              "tempoLock": true
+            },
+            "children": {},
+            "basis": 0.0
+          }
+        }
+      },
+      "clips": {
+        "id": 11,
+        "class": "heronarts.lx.clip.LXClipEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "focusedClip": 0.0,
+          "numScenes": 5,
+          "snapshotTransitionEnabled": false,
+          "snapshotTransitionTimeSecs": 5.0,
+          "clipViewGridOffset": 0,
+          "clipViewExpanded": false,
+          "scene-1": false,
+          "scene-2": false,
+          "scene-3": false,
+          "scene-4": false,
+          "scene-5": false,
+          "scene-6": false,
+          "scene-7": false,
+          "scene-8": false,
+          "scene-9": false,
+          "scene-10": false,
+          "scene-11": false,
+          "scene-12": false,
+          "scene-13": false,
+          "scene-14": false,
+          "scene-15": false,
+          "scene-16": false,
+          "scene-17": false,
+          "scene-18": false,
+          "scene-19": false,
+          "scene-20": false,
+          "scene-21": false,
+          "scene-22": false,
+          "scene-23": false,
+          "scene-24": false,
+          "scene-25": false,
+          "scene-26": false,
+          "scene-27": false,
+          "scene-28": false,
+          "scene-29": false,
+          "scene-30": false,
+          "scene-31": false,
+          "scene-32": false,
+          "scene-33": false,
+          "scene-34": false,
+          "scene-35": false,
+          "scene-36": false,
+          "scene-37": false,
+          "scene-38": false,
+          "scene-39": false,
+          "scene-40": false,
+          "scene-41": false,
+          "scene-42": false,
+          "scene-43": false,
+          "scene-44": false,
+          "scene-45": false,
+          "scene-46": false,
+          "scene-47": false,
+          "scene-48": false,
+          "scene-49": false,
+          "scene-50": false,
+          "scene-51": false,
+          "scene-52": false,
+          "scene-53": false,
+          "scene-54": false,
+          "scene-55": false,
+          "scene-56": false,
+          "scene-57": false,
+          "scene-58": false,
+          "scene-59": false,
+          "scene-60": false,
+          "scene-61": false,
+          "scene-62": false,
+          "scene-63": false,
+          "scene-64": false,
+          "scene-65": false,
+          "scene-66": false,
+          "scene-67": false,
+          "scene-68": false,
+          "scene-69": false,
+          "scene-70": false,
+          "scene-71": false,
+          "scene-72": false,
+          "scene-73": false,
+          "scene-74": false,
+          "scene-75": false,
+          "scene-76": false,
+          "scene-77": false,
+          "scene-78": false,
+          "scene-79": false,
+          "scene-80": false,
+          "scene-81": false,
+          "scene-82": false,
+          "scene-83": false,
+          "scene-84": false,
+          "scene-85": false,
+          "scene-86": false,
+          "scene-87": false,
+          "scene-88": false,
+          "scene-89": false,
+          "scene-90": false,
+          "scene-91": false,
+          "scene-92": false,
+          "scene-93": false,
+          "scene-94": false,
+          "scene-95": false,
+          "scene-96": false,
+          "scene-97": false,
+          "scene-98": false,
+          "scene-99": false,
+          "scene-100": false,
+          "scene-101": false,
+          "scene-102": false,
+          "scene-103": false,
+          "scene-104": false,
+          "scene-105": false,
+          "scene-106": false,
+          "scene-107": false,
+          "scene-108": false,
+          "scene-109": false,
+          "scene-110": false,
+          "scene-111": false,
+          "scene-112": false,
+          "scene-113": false,
+          "scene-114": false,
+          "scene-115": false,
+          "scene-116": false,
+          "scene-117": false,
+          "scene-118": false,
+          "scene-119": false,
+          "scene-120": false,
+          "scene-121": false,
+          "scene-122": false,
+          "scene-123": false,
+          "scene-124": false,
+          "scene-125": false,
+          "scene-126": false,
+          "scene-127": false,
+          "scene-128": false
+        },
+        "children": {}
+      },
+      "mixer": {
+        "id": 12,
+        "class": "heronarts.lx.mixer.LXMixerEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Mixer",
+          "crossfader": 0.5196850393700787,
+          "crossfaderBlendMode": 1,
+          "focusedChannel": 0,
+          "focusedChannelAux": 0,
+          "cueA": false,
+          "cueB": false,
+          "auxA": false,
+          "auxB": false,
+          "viewCondensed": false
+        },
+        "children": {
+          "master": {
+            "id": 20,
+            "class": "heronarts.lx.mixer.LXMasterBus",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true
+            },
+            "parameters": {
+              "label": "Master",
+              "arm": false,
+              "selected": false
+            },
+            "children": {},
+            "effects": [],
+            "clips": []
+          }
+        },
+        "channels": [
+          {
+            "id": 43733,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Color Examples",
+              "arm": false,
+              "selected": true,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "fader": 1.0,
+              "crossfadeGroup": 0,
+              "blendMode": 0,
+              "midiMonitor": false,
+              "midiChannel": 16,
+              "viewEnabled": false,
+              "viewSelector": "edge",
+              "viewNormalization": 0,
+              "compositeMode": 0,
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false
+            },
+            "children": {},
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 44269,
+                "class": "titanicsend.pattern.justin.TESolidPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "TESolidPattern",
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 84.16666412353516,
+                  "te_color/hue": 183.0,
+                  "te_color/solidSource": 1,
+                  "te_color/gradient": 0,
+                  "te_color/blendMode": 1,
+                  "te_color/offset": 0.023622047244091365,
+                  "te_color/color2offset": 0.5,
+                  "te_speed": 3.4420792349632023E-4,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 44270,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              },
+              {
+                "id": 44280,
+                "class": "titanicsend.pattern.justin.TEGradientPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "TEGradientPattern",
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "te_color/brightness": 0.0,
+                  "te_color/saturation": 0.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/gradient": 0,
+                  "te_color/blendMode": 1,
+                  "te_color/offset": 0.14173228346456535,
+                  "te_color/color2offset": 0.5,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.3937007874015741,
+                  "te_ypos": 0.49606299212598515,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 44281,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              },
+              {
+                "id": 44291,
+                "class": "titanicsend.pattern.mike.Checkers",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Checkers",
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "te_color/brightness": 0.0,
+                  "te_color/saturation": 0.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/gradient": 0,
+                  "te_color/blendMode": 1,
+                  "te_color/offset": 0.0,
+                  "te_color/color2offset": 0.5,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 44292,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              }
+            ]
+          }
+        ]
+      },
+      "modulation": {
+        "id": 21,
+        "class": "heronarts.lx.modulation.LXModulationEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Modulation"
+        },
+        "children": {},
+        "modulators": [],
+        "modulations": [],
+        "triggers": []
+      },
+      "output": {
+        "id": 22,
+        "class": "heronarts.lx.LXEngine$Output",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Output",
+          "enabled": false,
+          "brightness": 1.0,
+          "fps": 0.0,
+          "gamma": 1.0,
+          "gammaMode": 1
+        },
+        "children": {}
+      },
+      "snapshots": {
+        "id": 24,
+        "class": "heronarts.lx.snapshot.LXSnapshotEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Snapshots",
+          "recallMixer": true,
+          "recallModulation": true,
+          "recallPattern": true,
+          "recallEffect": true,
+          "recallOutput": true,
+          "channelMode": 0,
+          "missingChannelMode": 0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "autoCycleCursor": -1,
+          "triggerSnapshotCycle": false
+        },
+        "children": {},
+        "snapshots": []
+      },
+      "midi": {
+        "id": 25,
+        "class": "heronarts.lx.midi.LXMidiEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "computerKeyboardEnabled": false,
+          "computerKeyboardOctave": 5,
+          "computerKeyboardVelocity": 5
+        },
+        "children": {},
+        "inputs": [
+          {
+            "name": "Midi Fighter Twister",
+            "channel": false,
+            "control": false,
+            "sync": false
+          }
+        ],
+        "surfaces": [
+          {
+            "name": "Midi Fighter Twister",
+            "settings": {
+              "knobClickMode": 0,
+              "focusMode": 0
+            },
+            "state": {
+              "currentBank": 0,
+              "isAux": false
+            }
+          }
+        ],
+        "mapping": []
+      },
+      "audio": {
+        "id": 26,
+        "class": "heronarts.lx.audio.LXAudioEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Audio",
+          "enabled": true,
+          "mode": 0,
+          "expandedPerformance": true
+        },
+        "children": {
+          "input": {
+            "id": 27,
+            "class": "heronarts.lx.audio.LXAudioInput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Input",
+              "device": 0
+            },
+            "children": {}
+          },
+          "output": {
+            "id": 28,
+            "class": "heronarts.lx.audio.LXAudioOutput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Output",
+              "file": "",
+              "trigger": false,
+              "looping": false,
+              "play": false
+            },
+            "children": {}
+          },
+          "meter": {
+            "id": 29,
+            "class": "heronarts.lx.audio.GraphicMeter",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Meter",
+              "running": true,
+              "trigger": false,
+              "gain": 0.0,
+              "range": 48.0,
+              "attack": 10.0,
+              "release": 100.0,
+              "slope": 4.5,
+              "band-1": 0.0,
+              "band-2": 0.0,
+              "band-3": 0.0,
+              "band-4": 0.0,
+              "band-5": 0.0,
+              "band-6": 0.0,
+              "band-7": 0.0,
+              "band-8": 0.0,
+              "band-9": 0.0,
+              "band-10": 0.0,
+              "band-11": 0.0,
+              "band-12": 0.0,
+              "band-13": 0.0,
+              "band-14": 0.0,
+              "band-15": 0.0,
+              "band-16": 0.0
+            },
+            "children": {}
+          }
+        }
+      },
+      "osc": {
+        "id": 30,
+        "class": "heronarts.lx.osc.LXOscEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "OSC",
+          "receiveHost": "0.0.0.0",
+          "receivePort": 3030,
+          "receiveActive": false,
+          "transmitHost": "localhost",
+          "transmitPort": 3131,
+          "transmitActive": false,
+          "logInput": false,
+          "logOutput": false
+        },
+        "children": {}
+      },
+      "autopilot": {
+        "id": 31,
+        "class": "titanicsend.app.autopilot.TEUserInterface$AutopilotComponent",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true
+        },
+        "parameters": {
+          "label": "Autopilot",
+          "autopilotEnabledToggle": false
+        },
+        "children": {}
+      }
+    }
+  },
+  "externals": {
+    "ui": {
+      "audioExpanded": true,
+      "paletteExpanded": true,
+      "cameraExpanded": true,
+      "modulatorExpanded": {},
+      "preview": {
+        "mode": 0,
+        "animation": false,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 1.0,
+        "phiLock": true,
+        "centerPoint": false,
+        "camera": {
+          "active": false,
+          "radius": 1.348889685827276E7,
+          "theta": -1.5305855814367533,
+          "phi": -0.06185252591967583,
+          "x": 2255849.2623291016,
+          "y": 5053059.60546875,
+          "z": 207717.87439727783
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 1.348889685827276E7,
+            "theta": -1.5305855814367533,
+            "phi": -0.06185252591967583,
+            "x": 2255849.2623291016,
+            "y": 5053059.60546875,
+            "z": 207717.87439727783
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 0,
+        "pointCloud": {
+          "pointSize": 3.0
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "planes": 1,
+          "size": 10,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0
+        }
+      }
+    }
+  }
+}

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -49,6 +49,8 @@ import titanicsend.pattern.ben.*;
 import titanicsend.pattern.cesar.*;
 import titanicsend.pattern.jeff.*;
 import titanicsend.pattern.jon.*;
+import titanicsend.pattern.justin.TEGradientPattern;
+import titanicsend.pattern.justin.TESolidPattern;
 import titanicsend.pattern.mike.*;
 import titanicsend.pattern.pixelblaze.*;
 import titanicsend.pattern.tmc.*;
@@ -59,6 +61,7 @@ import titanicsend.pattern.yoffa.config.ShaderEdgesPatternConfig;
 import titanicsend.pattern.yoffa.effect.BeaconEffect;
 import titanicsend.pattern.yoffa.media.BasicImagePattern;
 import titanicsend.pattern.yoffa.media.ReactiveHeartPattern;
+import titanicsend.ui.UITEPerformancePattern;
 import titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig;
 import titanicsend.util.TE;
 
@@ -180,6 +183,8 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     lx.registry.addPattern(HandTracker.class);
     lx.registry.addPattern(Fire.class);
     lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
+    lx.registry.addPattern(TESolidPattern.class);
+    lx.registry.addPattern(TEGradientPattern.class);
 
     // Patterns that will not aspire to art direction standards
     lx.registry.addPattern(BasicImagePattern.class);
@@ -348,6 +353,8 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     // Here is where you may modify the initial settings of the UI before it is fully
     // built. Note that this will not be called in headless mode. Anything required
     // for headless mode should go in the raw initialize method above.
+
+    ((LXStudio.Registry)lx.registry).addUIDeviceControls(UITEPerformancePattern.class);
   }
 
   public void onUIReady(LXStudio lx, LXStudio.UI ui) {

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -4,7 +4,6 @@ import heronarts.lx.LX;
 import heronarts.lx.Tempo;
 import heronarts.lx.audio.GraphicMeter;
 import heronarts.lx.color.GradientUtils;
-import heronarts.lx.color.LXColor;
 import heronarts.lx.color.LinkedColorParameter;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.pattern.LXModelPattern;
@@ -23,12 +22,11 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
   private final TEPanelModel sua;
   private final TEPanelModel sdc;
 
-  // TE Gradient types
   public enum TEGradient {
     FULL_PALETTE("Full Palette"),
-    FOREGROUND("Foreground"),
     PRIMARY("Primary"),
-    SECONDARY("Secondary");
+    SECONDARY("Secondary"),
+    FOREGROUND("Foreground");
 
     public final String label;
 
@@ -43,12 +41,12 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
   };
 
   // Whole palette gradient across all 5 stops. Usually starts and ends with black.
-  protected GradientUtils.ColorStops paletteGradient = new GradientUtils.ColorStops();
-  protected GradientUtils.ColorStops foregroundGradient = new GradientUtils.ColorStops();
-  protected GradientUtils.ColorStops primaryGradient = new GradientUtils.ColorStops();
-  protected GradientUtils.ColorStops secondaryGradient = new GradientUtils.ColorStops();
+  protected GradientUtils.ColorStops paletteGradient = new GradientUtils.ColorStops();     // [X] [X] [X] [X] [X]  All five color entries
+  protected GradientUtils.ColorStops primaryGradient = new GradientUtils.ColorStops();     // [X] [ ] [X] [ ] [ ]  Background primary -> Primary
+  protected GradientUtils.ColorStops secondaryGradient = new GradientUtils.ColorStops();   // [ ] [ ] [ ] [X] [X]  Background secondary -> Secondary
+  protected GradientUtils.ColorStops foregroundGradient = new GradientUtils.ColorStops();  // [ ] [ ] [X] [X] [ ]  Primary -> Secondary
 
-  // See https://docs.google.com/document/d/16FGnQ8jopCGwQ0qZizqILt3KYiLo0LPYkDYtnYzY7gI/edit
+  // See TE Art Direction Standards: https://docs.google.com/document/d/16FGnQ8jopCGwQ0qZizqILt3KYiLo0LPYkDYtnYzY7gI/edit
   public enum ColorType {
     // These are 1-based UI indices; to get to a 0-based palette swatch index, subtract 1
     BACKGROUND(1), // Background color - should usually be black or transparent
@@ -77,17 +75,22 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
     this.sua = this.model.panelsById.get("SUA");
     this.sdc = this.model.panelsById.get("SDC");
 
+    this.primaryGradient.setNumStops(3);
+    this.secondaryGradient.setNumStops(3);
     this.foregroundGradient.setNumStops(3);
-    this.primaryGradient.setNumStops(2);
-    this.secondaryGradient.setNumStops(2);
     updateGradients();
+  }
+
+  @Override
+  public void onInactive() {
+    clearPixels();
+    super.onInactive();
   }
 
 
   /*
    * Color methods
    */
-
 
   public LinkedColorParameter registerColor(String label, String path, ColorType colorType, String description) {
     LinkedColorParameter lcp = new LinkedColorParameter(label)
@@ -102,10 +105,12 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
   // palette changes are known and transitions are smooth
   protected void updateGradients() {
     paletteGradient.setPaletteGradient(lx.engine.palette, 0, lx.engine.palette.swatch.colors.size());
-    primaryGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.BACKGROUND.swatchIndex()));
-    primaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
-    secondaryGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY_BACKGROUND.swatchIndex()));
-    secondaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
+    primaryGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
+    primaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.BACKGROUND.swatchIndex()));
+    primaryGradient.stops[2].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
+    secondaryGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
+    secondaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY_BACKGROUND.swatchIndex()));
+    secondaryGradient.stops[2].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
     foregroundGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
     foregroundGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
     foregroundGradient.stops[2].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -23,8 +23,28 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
   private final TEPanelModel sua;
   private final TEPanelModel sdc;
 
+  // TE Gradient types
+  public enum TEGradient {
+    FULL_PALETTE("Full Palette"),
+    FOREGROUND("Foreground"),
+    PRIMARY("Primary"),
+    SECONDARY("Secondary");
+
+    public final String label;
+
+    private TEGradient(String label) {
+      this.label = label;
+    }
+
+    @Override
+    public String toString() {
+      return this.label;
+    }
+  };
+
   // Whole palette gradient across all 5 stops. Usually starts and ends with black.
   protected GradientUtils.ColorStops paletteGradient = new GradientUtils.ColorStops();
+  protected GradientUtils.ColorStops foregroundGradient = new GradientUtils.ColorStops();
   protected GradientUtils.ColorStops primaryGradient = new GradientUtils.ColorStops();
   protected GradientUtils.ColorStops secondaryGradient = new GradientUtils.ColorStops();
 
@@ -57,6 +77,7 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
     this.sua = this.model.panelsById.get("SUA");
     this.sdc = this.model.panelsById.get("SDC");
 
+    this.foregroundGradient.setNumStops(3);
     this.primaryGradient.setNumStops(2);
     this.secondaryGradient.setNumStops(2);
     updateGradients();
@@ -85,6 +106,9 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
     primaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
     secondaryGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY_BACKGROUND.swatchIndex()));
     secondaryGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
+    foregroundGradient.stops[0].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
+    foregroundGradient.stops[1].set(lx.engine.palette.getSwatchColor(ColorType.SECONDARY.swatchIndex()));
+    foregroundGradient.stops[2].set(lx.engine.palette.getSwatchColor(ColorType.PRIMARY.swatchIndex()));
   }
 
   /**

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -279,26 +279,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
     }
 
-    /**
-     * ** Use TEColorParameter instead of these methods. **
-     *
-     * Suppress parent TEPattern gradient methods, force child classes
-     * to choose solid color or gradient, keeping other choices
-     * runtime-adjustable.
-     */
-
-    @Override
-    public final int getPrimaryGradientColor(float lerp) {
-        LX.error("Use TEColorParameter.getGradientColor() instead");
-        return 0;
-    }
-
-    @Override
-    public final int getSecondaryGradientColor(float lerp) {
-        LX.error("Use TEColorParameter.getGradientColor() instead");
-        return 0;
-    }
-
     // Explicitly keep this available for now
     @Override
     public int getSwatchColor(ColorType type) {
@@ -715,13 +695,24 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         return TEColor.setBrightness(controls.color.calcColor(), (float) getBrightness());
     }
 
+    /**
+     * ** Instead of these two methods, use getGradientColor(lerp) which defers to TEColorParameter for gradient selection. **
+     *
+     * Suppress parent TEPattern gradient methods, force child classes
+     * to choose solid color or gradient, keeping other choices
+     * runtime-adjustable.
+     * 
+     * TODO: remove these two methods from TEPattern to prevent confusion?
+     */
     @Override
     public int getPrimaryGradientColor(float lerp) {
+        LX.error("Use getGradientColor() instead");
         return TEColor.setBrightness(super.getPrimaryGradientColor(lerp), (float) getBrightness());
     }
 
     @Override
     public int getSecondaryGradientColor(float lerp) {
+        LX.error("Use getGradientColor() instead");
         return TEColor.setBrightness(super.getSecondaryGradientColor(lerp), (float) getBrightness());
     }
 
@@ -750,7 +741,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         return controls.color.calcColor();
     }
 
-    public int getCurrentGradient(float lerp) {
+    public int getGradientColor(float lerp) {
         return controls.color.getGradientColor(lerp);
     }
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -65,7 +65,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         public final CompoundParameter offset = (CompoundParameter)
             new CompoundParameter("Offset")
-            .setDescription("Allows user variation in single-color mode.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.").setNormalized(.5);
+            .setDescription("Allows user variation in single-color mode.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.");
 
 
         public TEColorParameter(String label) {

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -52,7 +52,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         public final EnumParameter<TEGradient> gradient =
             new EnumParameter<TEGradient>("Gradient", TEGradient.FULL_PALETTE)
-            .setDescription("Which TEGradient to use. Full_Pallete=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
+            .setDescription("Which TEGradient to use. Full_Palette=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
 
         // GRADIENT BLEND. Excluding RGB because it does play well with gradients.
 

--- a/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
@@ -1,0 +1,171 @@
+/**
+ * This pattern is derived directly from the LX GradientPattern:
+ * https://github.com/heronarts/LX/blob/master/src/main/java/heronarts/lx/pattern/color/GradientPattern.java
+ * 
+ * Copyright 2016- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package titanicsend.pattern.justin;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import heronarts.lx.transform.LXParameterizedMatrix;
+import heronarts.lx.utils.LXUtils;
+import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.jon.TEControlTag;
+
+@LXCategory(LXCategory.COLOR)
+public class TEGradientPattern extends TEPerformancePattern {
+
+  private final LXParameterizedMatrix transform = new LXParameterizedMatrix();
+  
+  private interface CoordinateFunction {
+    float getCoordinate(LXPoint p, float normalized, float offset);
+  }
+
+  public static enum CoordinateMode {
+
+    NORMAL("Normal", (p, normalized, offset) ->  {
+      return normalized - offset;
+    }),
+
+    CENTER("Center", (p, normalized, offset) -> {
+      return 2 * Math.abs(normalized - (.5f + offset * .5f));
+    }),
+
+    RADIAL("Radial", (p, normalized, offset) -> {
+      return p.rcn - offset;
+    });
+
+    public final String name;
+    public final CoordinateFunction function;
+    public final CoordinateFunction invert;
+
+    private CoordinateMode(String name, CoordinateFunction function) {
+      this.name = name;
+      this.function = function;
+      this.invert = (p, normalized, offset) -> { return function.getCoordinate(p, normalized, offset) - 1; };
+    }
+
+    @Override
+    public String toString() {
+      return this.name;
+    }
+  }
+  
+  public final EnumParameter<CoordinateMode> xMode =
+    new EnumParameter<CoordinateMode>("X Mode", CoordinateMode.NORMAL)
+    .setDescription("Which coordinate mode the X-dimension uses");
+
+  public final EnumParameter<CoordinateMode> yMode =
+    new EnumParameter<CoordinateMode>("Y Mode", CoordinateMode.NORMAL)
+    .setDescription("Which coordinate mode the Y-dimension uses");
+
+  public final EnumParameter<CoordinateMode> zMode =
+    new EnumParameter<CoordinateMode>("Z Mode", CoordinateMode.NORMAL)
+    .setDescription("Which coordinate mode the Z-dimension uses");
+
+
+
+  public TEGradientPattern(LX lx) {
+    super(lx);
+    
+    // Lock in the ranges in case the defaults change upstream
+    this.controls.setRange(TEControlTag.SIZE, 1, 0.1, 5);
+    this.controls.setRange(TEControlTag.XPOS, 0, -1, 1);
+    this.controls.setRange(TEControlTag.YPOS, 0, -1, 1);
+    this.controls.setRange(TEControlTag.WOW1, 0, -1, 1);
+    this.controls.setRange(TEControlTag.WOW2, 0, 0, 360);
+    
+    ((LXListenableNormalizedParameter)controls.getLXControl(TEControlTag.WOW2)).setWrappable(true);
+    
+    addCommonControls();
+  }
+  
+  @Override
+  protected void runTEAudioPattern(double deltaMs) {
+    float size = (float) getSize();
+    
+    float xAmount = (float) getWow1();
+    float yAmount = (float) getYPos();
+    float zAmount = (float) getXPos();
+
+    final float total = Math.abs(xAmount) + Math.abs(yAmount) + Math.abs(zAmount);
+    if (total > 1) {
+      xAmount /= total;
+      yAmount /= total;
+      zAmount /= total;
+    }
+
+    final float xOffset = 0;  // this.xOffset.getValuef();
+    final float yOffset = 0;  // this.yOffset.getValuef();
+    final float zOffset = 0;  // this.zOffset.getValuef();
+
+    final CoordinateMode xMode = this.xMode.getEnum();
+    final CoordinateMode yMode = this.yMode.getEnum();
+    final CoordinateMode zMode = this.zMode.getEnum();
+
+    final CoordinateFunction xFunction = (xAmount < 0) ? xMode.invert : xMode.function;
+    final CoordinateFunction yFunction = (yAmount < 0) ? yMode.invert : yMode.function;
+    final CoordinateFunction zFunction = (zAmount < 0) ? zMode.invert : zMode.function;
+
+    // TODO: rotation not working
+    // TODO: size scaling not working
+    double pitch = -getRotationAngleFromSpin();
+    double roll = Math.toRadians(-getWow2());
+    this.transform.update(matrix -> {
+      matrix
+        .translate(.5f, .5f, .5f)
+        .rotateZ((float)roll)
+        .rotateX((float)pitch)
+        //.rotateY((float) Math.toRadians(-this.yaw.getValue()))
+        .scale(size)
+        .translate(-.5f, -.5f, -.5f);
+    });
+
+    for (LXPoint p : model.points) {
+      final float xn =
+        p.xn * this.transform.m11 +
+        p.yn * this.transform.m12 +
+        p.zn * this.transform.m13 +
+        this.transform.m14;
+
+      final float yn =
+        p.xn * this.transform.m21 +
+        p.yn * this.transform.m22 +
+        p.zn * this.transform.m23 +
+        this.transform.m24;
+
+      final float zn =
+        p.xn * this.transform.m31 +
+        p.yn * this.transform.m32 +
+        p.zn * this.transform.m33 +
+        this.transform.m34;
+
+      float lerp = LXUtils.clampf(
+          xAmount * xFunction.getCoordinate(p, xn, xOffset) +
+          yAmount * yFunction.getCoordinate(p, yn, yOffset) +
+          zAmount * zFunction.getCoordinate(p, zn, zOffset),
+          0, 1
+        );
+      colors[p.index] = getCurrentGradient(lerp);
+    }
+  }
+}

--- a/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
@@ -165,7 +165,7 @@ public class TEGradientPattern extends TEPerformancePattern {
           zAmount * zFunction.getCoordinate(p, zn, zOffset),
           0, 1
         );
-      colors[p.index] = getCurrentGradient(lerp);
+      colors[p.index] = getGradientColor(lerp);
     }
   }
 }

--- a/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
@@ -1,0 +1,26 @@
+package titanicsend.pattern.justin;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.model.LXPoint;
+import titanicsend.pattern.TEPerformancePattern;
+
+@LXCategory(LXCategory.COLOR)
+public class TESolidPattern extends TEPerformancePattern {
+
+  public TESolidPattern(LX lx) {
+    super(lx);
+    
+    addCommonControls();
+  }
+
+  @Override
+  protected void runTEAudioPattern(double deltaMs) {
+    int color1 = getCurrentColor();
+    
+    for (LXPoint p : getModel().getPoints()) {
+      colors[p.index] = color1;      
+    }
+  }
+
+}

--- a/src/main/java/titanicsend/pattern/mike/Checkers.java
+++ b/src/main/java/titanicsend/pattern/mike/Checkers.java
@@ -2,29 +2,21 @@ package titanicsend.pattern.mike;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
-import heronarts.lx.color.LXColor;
-import heronarts.lx.color.LinkedColorParameter;
 import heronarts.lx.model.LXPoint;
 import titanicsend.model.TEPanelModel;
-import titanicsend.pattern.TEPattern;
+import titanicsend.pattern.TEPerformancePattern;
 
 import java.util.*;
 
 @LXCategory("TE Examples")
-public class Checkers extends TEPattern {
-
-  public final LinkedColorParameter oddColor =
-          registerColor("Odd", "odd", ColorType.PRIMARY,
-                  "Color of the odd panels");
-
-  public final LinkedColorParameter evenColor =
-          registerColor("Even", "even", ColorType.SECONDARY,
-                  "Color of the even panels");
+public class Checkers extends TEPerformancePattern {
 
   private final HashMap<TEPanelModel, Integer> panelGroup;
 
   public Checkers(LX lx) {
     super(lx);
+
+    addCommonControls();
 
     this.panelGroup = new HashMap<>();
     List<TEPanelModel> queue = new ArrayList<>(model.panelsById.values());
@@ -47,9 +39,10 @@ public class Checkers extends TEPattern {
     }
   }
 
-  public void run(double deltaMs) {
-    int color0 = this.oddColor.calcColor();
-    int color1 = this.evenColor.calcColor();
+  @Override
+  protected void runTEAudioPattern(double deltaMs) {
+    int color0 = getCurrentColor();
+    int color1 = getCurrentColor2();
 
     for (Map.Entry<TEPanelModel, Integer> entry : this.panelGroup.entrySet()) {
       TEPanelModel panel = entry.getKey();
@@ -62,4 +55,5 @@ public class Checkers extends TEPattern {
     }
     this.updateVirtualColors(deltaMs);
   }
+
 }

--- a/src/main/java/titanicsend/pattern/mike/Checkers.java
+++ b/src/main/java/titanicsend/pattern/mike/Checkers.java
@@ -41,13 +41,13 @@ public class Checkers extends TEPerformancePattern {
 
   @Override
   protected void runTEAudioPattern(double deltaMs) {
-    int color0 = getCurrentColor();
-    int color1 = getCurrentColor2();
+    int color1 = getCurrentColor();
+    int color2 = getCurrentColor2();
 
     for (Map.Entry<TEPanelModel, Integer> entry : this.panelGroup.entrySet()) {
       TEPanelModel panel = entry.getKey();
       int panelGroup = entry.getValue();
-      int rgb = panelGroup == 0 ? color0 : color1;
+      int rgb = panelGroup == 0 ? color1 : color2;
       for (LXPoint point : panel.points) {
         if (model.isGapPoint(point)) continue;
         colors[point.index] = rgb;

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
@@ -152,7 +152,7 @@ public abstract class PixelblazePort extends TEPerformancePattern {
     }
 
     public int paint(float v) {
-        return color = getPrimaryGradientColor(v);
+        return color = getGradientColor(v);
     }
 
     public void setAlpha(float v) {

--- a/src/main/java/titanicsend/pattern/yoffa/effect/PulseEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/PulseEffect.java
@@ -53,7 +53,7 @@ public class PulseEffect extends PatternEffect {
             double distanceFromCenter = originXn == null ? point.rn :
                     TEMath.distance(point.xn, point.yn, point.zn, originXn, originYn, originZn);
 
-            int baseColor = pattern.getPrimaryGradientColor((float) (2 * (distanceFromCenter - pattern.measure())));
+            int baseColor = pattern.getGradientColor((float) (2 * (distanceFromCenter - pattern.measure())));
 
             double hue = LXColor.h(baseColor);
             double saturation = LXColor.s(baseColor);

--- a/src/main/java/titanicsend/ui/UITEColorControl.java
+++ b/src/main/java/titanicsend/ui/UITEColorControl.java
@@ -1,0 +1,36 @@
+/**
+ * This file is mainly a copy of Heron Art's P4LX from:
+ * https://github.com/heronarts/P4LX/blob/master/src/main/java/heronarts/p4lx/ui/component/UIColorControl.java
+ * ...It was modified slightly for TE.
+ * 
+ * Copyright 2017- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package titanicsend.ui;
+
+import heronarts.p4lx.ui.UIFocus;
+import heronarts.p4lx.ui.component.UIKnob;
+import titanicsend.pattern.TEPerformancePattern.TEColorParameter;
+
+public class UITEColorControl extends UITEColorPicker implements UIFocus {
+
+  public UITEColorControl(float x, float y, TEColorParameter color) {
+    super(x, y, UIKnob.WIDTH, UIKnob.HEIGHT, color);
+    setDeviceMode(true);
+    setCorner(Corner.TOP_RIGHT);
+  }
+}

--- a/src/main/java/titanicsend/ui/UITEColorPicker.java
+++ b/src/main/java/titanicsend/ui/UITEColorPicker.java
@@ -1,0 +1,476 @@
+/**
+ * This file is mainly a copy Heron Art's P4LX UIColorPicker:
+ * https://github.com/heronarts/P4LX/blob/master/src/main/java/heronarts/p4lx/ui/component/UIColorPicker.java
+ * ...Additional controls were added at the bottom for TE.
+ * 
+ * This file could be simplified in the future with a few changes
+ * to the restrictions in UIColorPicker.
+ * 
+ * 
+ * Copyright 2017- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package titanicsend.ui;
+
+import processing.core.PConstants;
+import processing.core.PGraphics;
+import processing.event.KeyEvent;
+import processing.event.MouseEvent;
+import titanicsend.pattern.TEPerformancePattern.TEColorParameter;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.command.LXCommand;
+import heronarts.lx.parameter.LXParameterListener;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.pattern.UIGradientPattern.UIPaletteGradient;
+import heronarts.lx.utils.LXUtils;
+import heronarts.p4lx.ui.UI;
+import heronarts.p4lx.ui.UI2dComponent;
+import heronarts.p4lx.ui.UI2dContainer;
+import heronarts.p4lx.ui.UIFocus;
+import heronarts.p4lx.ui.UITimerTask;
+import heronarts.p4lx.ui.component.UIButton;
+import heronarts.p4lx.ui.component.UIDoubleBox;
+import heronarts.p4lx.ui.component.UIKnob;
+import heronarts.p4lx.ui.component.UILabel;
+import heronarts.p4lx.ui.component.UIParameterControl;
+import heronarts.p4lx.ui.component.UISlider;
+
+public class UITEColorPicker extends UI2dComponent {
+
+  public enum Corner {
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_RIGHT,
+    BOTTOM_LEFT
+  };
+
+  private Corner corner = Corner.BOTTOM_RIGHT;
+
+  private TEColorParameter color;
+
+  private UITEColorOverlay uiColorOverlay = null;
+
+  private boolean enabled = true;
+
+  private int drawColor = 0xff000000;
+
+  private boolean deviceMode = false;
+
+  public UITEColorPicker(TEColorParameter color) {
+    this(UIKnob.WIDTH, UIKnob.WIDTH, color);
+  }
+
+  public UITEColorPicker(float w, float h, TEColorParameter color) {
+    this(0, 0, w, h, color);
+  }
+
+  public UITEColorPicker(float x, float y, float w, float h, TEColorParameter color) {
+    this(x, y, w, h, color, false);
+  }
+
+  protected UITEColorPicker(float x, float y, float w, float h, TEColorParameter color, boolean isDynamic) {
+    super(x, y, w, h);
+    setColor(color);
+
+    // Redraw with color in real-time, if modulated
+    if (!isDynamic) {
+      setDescription(UIParameterControl.getDescription(color));
+      addLoopTask(new UITimerTask(30, UITimerTask.Mode.FPS) {
+        @Override
+        protected void run() {
+          setDrawColor(color.calcColor());
+        }
+      });
+    }
+  }
+
+  protected void setDrawColor(int drawColor) {
+    if (this.drawColor != drawColor) {
+      this.drawColor = drawColor;
+      redraw();
+    }
+  }
+
+  public UITEColorPicker setEnabled(boolean enabled) {
+    this.enabled = enabled;
+    return this;
+  }
+
+  protected UITEColorPicker setDeviceMode(boolean deviceMode) {
+    this.deviceMode = deviceMode;
+    return this;
+  }
+
+  private final LXParameterListener redrawSwatch = (p) -> {
+    if (this.uiColorOverlay != null) {
+      this.uiColorOverlay.swatch.redraw();
+    }
+  };
+
+  protected UITEColorOverlay buildColorOverlay(UI ui) {
+    return new UITEColorOverlay(ui);
+  }
+
+  public UITEColorPicker setCorner(Corner corner) {
+    this.corner = corner;
+    return this;
+  }
+
+  void setColor(TEColorParameter color) {
+    if (this.color != null) {
+      this.color.removeListener(this.redrawSwatch);
+    }
+    this.color = color;
+    if (color != null) {
+      color.addListener(this.redrawSwatch);
+      redrawSwatch.onParameterChanged(color);
+    } else {
+      setDrawColor(LXColor.BLACK);
+    }
+  }
+
+  @Override
+  public void onDraw(UI ui, PGraphics pg) {
+    pg.stroke(ui.theme.getControlBorderColor());
+    pg.fill(this.drawColor);
+    if (this.deviceMode) {
+      pg.rect(UIKnob.KNOB_MARGIN, 0, UIKnob.KNOB_SIZE, UIKnob.KNOB_SIZE);
+      UIParameterControl.drawParameterLabel(ui, pg, this, (this.color != null) ? this.color.getLabel() : "-");
+    } else {
+      pg.rect(0, 0, this.width, this.height);
+    }
+  }
+
+  protected void hideOverlay() {
+    getUI().hideContextOverlay();
+  }
+
+  private void showOverlay() {
+    final float overlap = 6;
+
+    if (this.uiColorOverlay == null) {
+      this.uiColorOverlay = buildColorOverlay(getUI());
+    }
+
+    switch (this.corner) {
+    case BOTTOM_LEFT:
+      this.uiColorOverlay.setPosition(this, overlap - this.uiColorOverlay.getWidth(), this.height - overlap);
+      break;
+    case BOTTOM_RIGHT:
+      this.uiColorOverlay.setPosition(this, this.width - overlap, this.height - overlap);
+      break;
+    case TOP_LEFT:
+      this.uiColorOverlay.setPosition(this, overlap - this.uiColorOverlay.getWidth(), overlap - this.uiColorOverlay.getHeight());
+      break;
+    case TOP_RIGHT:
+      this.uiColorOverlay.setPosition(this, this.width - overlap, overlap - this.uiColorOverlay.getHeight());
+      break;
+    }
+
+    getUI().showContextOverlay(this.uiColorOverlay);
+  }
+
+  @Override
+  public void onMousePressed(MouseEvent mouseEvent, float mx, float my) {
+    if (this.enabled) {
+      consumeMousePress();
+      showOverlay();
+    }
+    super.onMousePressed(mouseEvent, mx, my);
+  }
+
+  @Override
+  public void onKeyPressed(KeyEvent keyEvent, char keyChar, int keyCode) {
+    if (this.enabled) {
+      if (keyCode == java.awt.event.KeyEvent.VK_ENTER || keyCode == java.awt.event.KeyEvent.VK_SPACE) {
+        consumeKeyEvent();
+        showOverlay();
+      } else if (keyCode == java.awt.event.KeyEvent.VK_ESCAPE) {
+        if ((this.uiColorOverlay != null) && (this.uiColorOverlay.isVisible())) {
+          consumeKeyEvent();
+          hideOverlay();
+        }
+      }
+    }
+    super.onKeyPressed(keyEvent, keyChar, keyCode);
+  }
+
+  
+  protected class UITEColorOverlay extends UI2dContainer {
+
+    private final UISwatch swatch;
+    private final UI2dComponent color1;
+    private final UI2dComponent color2;
+
+    UITEColorOverlay(UI ui) {
+      this(ui, 304, color instanceof TEColorParameter ? 60 : 8);
+    }
+
+    UITEColorOverlay(UI ui, float width, float extraHeight) {
+      super(0, 0, width, UISwatch.HEIGHT + extraHeight);
+
+      setBackgroundColor(UI.get().theme.getDeviceBackgroundColor());
+      setBorderColor(UI.get().theme.getControlBorderColor());
+      setBorderRounding(6);
+
+      this.swatch = new UISwatch();
+      this.swatch.addToContainer(this);
+
+      float xp = this.swatch.getX() + this.swatch.getWidth();
+      float yp = 16;
+      final UIDoubleBox hueBox = (UIDoubleBox) new UIDoubleBox(xp, yp, 56, color.hue).addToContainer(this);
+      new UILabel(xp, yp + 16, 56, "Hue").setTextAlignment(PConstants.CENTER).addToContainer(this);
+
+      yp += 40;
+
+      final UIDoubleBox satBox = (UIDoubleBox) new UIDoubleBox(xp, yp, 56, color.saturation).addToContainer(this);
+      new UILabel(xp, yp + 16, 56, "Sat").setTextAlignment(PConstants.CENTER).addToContainer(this);
+
+      yp += 40;
+
+      final UIDoubleBox brtBox = (UIDoubleBox) new UIDoubleBox(xp, yp, 56, color.brightness).addToContainer(this);
+      new UILabel(xp, yp + 16, 56, "Bright").setTextAlignment(PConstants.CENTER).addToContainer(this);
+
+      // Horizontal break
+      new UI2dComponent(12, 140, 280, 1) {}
+      .setBorderColor(ui.theme.getDarkBackgroundColor())
+      .addToContainer(this);
+
+      
+      // Special for TEColorParameter
+
+      // Solid color
+      UI2dContainer.newHorizontalContainer(16, 4,
+        new UILabel(58, 12, "Solid Color:").setFont(ui.theme.getControlFont()),
+        new UIButton(108, 16, color.solidSource)    
+      )
+      .setPosition(12, 148)
+      .addToContainer(this);
+
+      // Gradient
+      UI2dContainer.newHorizontalContainer(16, 4,
+          new UILabel(58, 12, "Gradient:").setFont(ui.theme.getControlFont()),
+          new UIButton(68, 16, color.gradient),
+          new UIButton(36, 16, color.blendMode)
+        )
+      .setPosition(12, 171)
+      .addToContainer(this);
+      
+      // Offset
+      new UIKnob(184, 147, color.offset).addToContainer(this);
+
+      // Solid color preview
+      UI2dContainer.newHorizontalContainer(16, 1,
+          color1 = new UI2dComponent(0, 0, 16, 16) {}
+            .setBorderColor(ui.theme.getControlBorderColor())
+            .setBackgroundColor(color.calcColor())
+            .setBorderRounding(4),
+          new UISlider(UISlider.Direction.HORIZONTAL, 30, 16, color.color2offset)
+            .setShowLabel(false),
+          color2 = new UI2dComponent(0, 0, 16, 16) {}
+            .setBorderColor(ui.theme.getControlBorderColor())
+            .setBackgroundColor(color.calcColor2())
+            .setBorderRounding(4)
+        )
+        .setPosition(228, 148)
+        .addToContainer(this);
+      
+      addListener(color, p -> {
+        color1.setBackgroundColor(color.calcColor());
+        color2.setBackgroundColor(color.calcColor2());        
+      });
+
+      // Gradient preview
+      new UIPaletteGradient((LXStudio.UI)ui, color, 64, 16)
+      .setPosition(228, 171)
+      .addToContainer(this);
+      
+      color.solidSource.addListener((p) -> {
+        boolean isLinked = color.solidSource.getEnum() != TEColorParameter.SolidColorSource.STATIC;
+        swatch.setEnabled(!isLinked);
+        hueBox.setEnabled(!isLinked);
+        satBox.setEnabled(!isLinked);
+        brtBox.setEnabled(!isLinked);
+      }, true);
+    }
+    
+    private class UISwatch extends UI2dComponent implements UIFocus {
+
+      private static final float PADDING = 8;
+
+      private static final float GRID_X = PADDING;
+      private static final float GRID_Y = PADDING;
+
+      private static final float GRID_WIDTH = 120;
+      private static final float GRID_HEIGHT = 120;
+
+      private static final float BRIGHT_SLIDER_X = 140;
+      private static final float BRIGHT_SLIDER_Y = PADDING;
+      private static final float BRIGHT_SLIDER_WIDTH = 16;
+      private static final float BRIGHT_SLIDER_HEIGHT = GRID_HEIGHT;
+
+      private static final float WIDTH = BRIGHT_SLIDER_X + BRIGHT_SLIDER_WIDTH + 2*PADDING;
+      private static final float HEIGHT = GRID_HEIGHT + 2*PADDING;
+
+      private boolean enabled = true;
+
+      public UISwatch() {
+        super(4, 4, WIDTH, HEIGHT);
+        color.addListener((p) -> { redraw(); });
+        setFocusCorners(false);
+      }
+
+      private void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+      }
+
+      @Override
+      public void onDraw(UI ui, PGraphics pg) {
+
+        float hue = color.hue.getBaseValuef();
+        float saturation = color.saturation.getBaseValuef();
+        float brightness = color.brightness.getBaseValuef();
+
+        // Main color grid
+        for (int x = 0; x < GRID_WIDTH; ++x) {
+          for (int y = 0; y < GRID_HEIGHT; ++y) {
+            pg.stroke(LXColor.hsb(
+              360 * (x / GRID_WIDTH),
+              100 * (1 - y / GRID_HEIGHT),
+              brightness
+            ));
+            pg.point(GRID_X + x, GRID_Y + y);
+          }
+        }
+
+        // Brightness slider
+        for (int y = 0; y < BRIGHT_SLIDER_HEIGHT; ++y) {
+          pg.stroke(LXColor.hsb(hue, saturation, 100 - 100 * (y / BRIGHT_SLIDER_HEIGHT)));
+          pg.line(BRIGHT_SLIDER_X, BRIGHT_SLIDER_Y + y, BRIGHT_SLIDER_X + BRIGHT_SLIDER_WIDTH - 1, BRIGHT_SLIDER_Y + y);
+        }
+
+        // Color square
+        pg.noFill();
+        pg.stroke(brightness < 50 ? 0xffffffff : 0xff000000);
+        pg.ellipseMode(PConstants.CORNER);
+        pg.ellipse(
+          GRID_X + hue / 360 * GRID_WIDTH,
+          GRID_Y + (1 - saturation / 100) * GRID_HEIGHT,
+          4,
+          4
+        );
+
+        // Brightness triangle
+        pg.fill(0xffcccccc);
+        pg.noStroke();
+
+        pg.beginShape(PConstants.TRIANGLES);
+        float xp = BRIGHT_SLIDER_X;
+        float yp = BRIGHT_SLIDER_Y + (1 - brightness / 100) * BRIGHT_SLIDER_HEIGHT;
+        pg.vertex(xp, yp);
+        pg.vertex(xp - 6, yp - 4);
+        pg.vertex(xp - 6, yp + 4);
+
+        pg.vertex(xp + BRIGHT_SLIDER_WIDTH, yp);
+        pg.vertex(xp + BRIGHT_SLIDER_WIDTH + 6, yp + 4);
+        pg.vertex(xp + BRIGHT_SLIDER_WIDTH + 6, yp - 4);
+
+      }
+
+      private boolean draggingBrightness = false;
+      private LXCommand.Parameter.SetValue setBrightness = null;
+      private LXCommand.Parameter.SetColor setColor = null;
+
+      @Override
+      public void onMousePressed(MouseEvent mouseEvent, float mx, float my) {
+        if (!this.enabled) {
+          return;
+        }
+
+        this.setBrightness = null;
+        this.setColor = null;
+        if (this.draggingBrightness = (mx > GRID_X + GRID_WIDTH)) {
+          this.setBrightness = new LXCommand.Parameter.SetValue(color.brightness, color.brightness.getBaseValue());
+        } else {
+          this.setColor = new LXCommand.Parameter.SetColor(color);
+          setHueSaturation(mx, my);
+        }
+      }
+
+      @Override
+      public void onMouseReleased(MouseEvent mouseEvent, float mx, float my) {
+        this.setBrightness = null;
+        this.setColor = null;
+      }
+
+      private void setHueSaturation(float mx, float my) {
+        mx = LXUtils.clampf(mx - GRID_X, 0, GRID_WIDTH);
+        my = LXUtils.clampf(my - GRID_Y, 0, GRID_WIDTH);
+        double hue = mx / GRID_WIDTH * 360;
+        double saturation = 100 - my / GRID_HEIGHT * 100;
+        getLX().command.perform(this.setColor.update(hue, saturation));
+      }
+
+      @Override
+      public void onMouseDragged(MouseEvent mouseEvent, float mx, float my, float dx, float dy) {
+        if (!this.enabled) {
+          return;
+        }
+        if (this.draggingBrightness) {
+          if (dy != 0) {
+            float brightness = color.brightness.getBaseValuef();
+            brightness = LXUtils.clampf(brightness - 100 * dy / BRIGHT_SLIDER_HEIGHT, 0, 100);
+            getLX().command.perform(this.setBrightness.update(brightness));
+          }
+        } else {
+          setHueSaturation(mx, my);
+        }
+      }
+
+      @Override
+      public void onKeyPressed(KeyEvent keyEvent, char keyChar, int keyCode) {
+        if (!this.enabled) {
+          return;
+        }
+        float inc = keyEvent.isShiftDown() ? 10 : 2;
+        if (keyCode == java.awt.event.KeyEvent.VK_UP) {
+          consumeKeyEvent();
+          getLX().command.perform(new LXCommand.Parameter.SetValue(color.saturation,
+            LXUtils.clampf(color.saturation.getBaseValuef() + inc, 0, 100)
+          ));
+        } else if (keyCode == java.awt.event.KeyEvent.VK_DOWN) {
+          consumeKeyEvent();
+          getLX().command.perform(new LXCommand.Parameter.SetValue(color.saturation,
+            LXUtils.clampf(color.saturation.getBaseValuef() - inc, 0, 100)
+          ));
+        } else if (keyCode == java.awt.event.KeyEvent.VK_LEFT) {
+          consumeKeyEvent();
+          getLX().command.perform(new LXCommand.Parameter.SetValue(color.hue,
+            LXUtils.clampf(color.hue.getBaseValuef() - 3*inc, 0, 360)
+          ));
+        } else if (keyCode == java.awt.event.KeyEvent.VK_RIGHT) {
+          consumeKeyEvent();
+          getLX().command.perform(new LXCommand.Parameter.SetValue(color.hue,
+            LXUtils.clampf(color.hue.getBaseValuef() + 3*inc, 0, 360)
+          ));
+        }
+      }
+
+    }
+    
+  }
+}

--- a/src/main/java/titanicsend/ui/UITEColorPicker.java
+++ b/src/main/java/titanicsend/ui/UITEColorPicker.java
@@ -118,6 +118,7 @@ public class UITEColorPicker extends UI2dComponent {
   private final LXParameterListener redrawSwatch = (p) -> {
     if (this.uiColorOverlay != null) {
       this.uiColorOverlay.swatch.redraw();
+      this.uiColorOverlay.swatchDimmer.redraw();
     }
   };
 
@@ -212,7 +213,10 @@ public class UITEColorPicker extends UI2dComponent {
   
   protected class UITEColorOverlay extends UI2dContainer {
 
+    private static final int PADDING = 12;
+
     private final UISwatch swatch;
+    private final UI2dComponent swatchDimmer;
     private final UI2dComponent color1;
     private final UI2dComponent color2;
 
@@ -246,19 +250,24 @@ public class UITEColorPicker extends UI2dComponent {
       new UILabel(xp, yp + 16, 56, "Bright").setTextAlignment(PConstants.CENTER).addToContainer(this);
 
       // Horizontal break
-      new UI2dComponent(12, 140, 280, 1) {}
+      new UI2dComponent(PADDING, 140, this.width - 2*PADDING, 1) {}
       .setBorderColor(ui.theme.getDarkBackgroundColor())
       .addToContainer(this);
 
       
       // Special for TEColorParameter
 
+      // Gray overlay for swatch when not using STATIC source
+      swatchDimmer = new UILabel(PADDING, PADDING-1, this.width - 2*PADDING, 130)
+      .setBackgroundColor(LXColor.rgba(75,75,75,200))
+      .addToContainer(this);
+
       // Solid color
       UI2dContainer.newHorizontalContainer(16, 4,
         new UILabel(58, 12, "Solid Color:").setFont(ui.theme.getControlFont()),
         new UIButton(108, 16, color.solidSource)    
       )
-      .setPosition(12, 148)
+      .setPosition(PADDING, 148)
       .addToContainer(this);
 
       // Gradient
@@ -267,7 +276,7 @@ public class UITEColorPicker extends UI2dComponent {
           new UIButton(68, 16, color.gradient),
           new UIButton(36, 16, color.blendMode)
         )
-      .setPosition(12, 171)
+      .setPosition(PADDING, 171)
       .addToContainer(this);
       
       // Offset
@@ -300,11 +309,12 @@ public class UITEColorPicker extends UI2dComponent {
       .addToContainer(this);
       
       color.solidSource.addListener((p) -> {
-        boolean isLinked = color.solidSource.getEnum() != TEColorParameter.SolidColorSource.STATIC;
-        swatch.setEnabled(!isLinked);
-        hueBox.setEnabled(!isLinked);
-        satBox.setEnabled(!isLinked);
-        brtBox.setEnabled(!isLinked);
+        boolean isStatic = color.solidSource.getEnum() == TEColorParameter.SolidColorSource.STATIC;
+        swatch.setEnabled(isStatic);
+        hueBox.setEnabled(isStatic);
+        satBox.setEnabled(isStatic);
+        brtBox.setEnabled(isStatic);
+        swatchDimmer.setVisible(!isStatic);
       }, true);
     }
     

--- a/src/main/java/titanicsend/ui/UITEPerformancePattern.java
+++ b/src/main/java/titanicsend/ui/UITEPerformancePattern.java
@@ -1,0 +1,68 @@
+package titanicsend.ui;
+
+import java.util.Arrays;
+import java.util.List;
+
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.BoundedFunctionalParameter;
+import heronarts.lx.parameter.BoundedParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXNormalizedParameter;
+import heronarts.lx.studio.ui.device.UIDevice;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+import heronarts.p4lx.ui.UI2dContainer.Layout;
+import heronarts.p4lx.ui.component.UIKnob;
+import heronarts.p4lx.ui.component.UISwitch;
+import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.TEPerformancePattern.TEColorParameter;
+import titanicsend.pattern.TEPerformancePattern.TEColorParameter.TEColorOffsetParameter;
+
+/**
+ * Device UI for TEPerformancePattern
+ * 
+ * Adds special UI control for TEColorParameter. 
+ * Parameters are arranged in columns of 4 to line up with the MidiFighterTwister.
+ * 
+ * Based on UIDeviceControl with components from J.Belcher's Rubix project.
+ */
+public class UITEPerformancePattern implements UIDeviceControls<TEPerformancePattern> {
+
+  @Override
+  public void buildDeviceControls(heronarts.lx.studio.LXStudio.UI ui, UIDevice uiDevice, TEPerformancePattern device) {
+    uiDevice.setLayout(Layout.NONE);
+    uiDevice.setChildSpacing(2);
+
+    List<LXNormalizedParameter> params = Arrays.asList(device.getRemoteControls());
+
+    int ki = 0;
+    int col = 0;
+    for (LXNormalizedParameter param : params) {
+      if (ki == 16) {
+        ki = 0;
+        col++;
+      }          
+      float x = (ki % 4) * (UIKnob.WIDTH + 2) + (col * ((4 * (UIKnob.WIDTH + 2) + 15) + 2));
+      float y = -3 + (ki / 4) * (UIKnob.HEIGHT);
+      if (param instanceof TEColorOffsetParameter) {
+        new UITEColorControl(x, y, (TEColorParameter) param.getParentParameter())
+        .addToContainer(uiDevice);      
+      } else if (param instanceof BoundedParameter || param instanceof DiscreteParameter || param instanceof BoundedFunctionalParameter) {
+        new UIKnob(x, y)
+        .setParameter(param)
+        .addToContainer(uiDevice);
+      } else if (param instanceof BooleanParameter) {
+        new UISwitch(x, y)
+        .setParameter(param)
+        .addToContainer(uiDevice);
+      } else if (param == null) {
+        // Leave a space
+      } else {
+        // Hey developer: probably added a type in isEligibleControlParameter() that wasn't handled down here.
+        throw new RuntimeException("Cannot generate control, unsupported pattern parameter type: " + param.getClass());
+      }
+
+      ++ki;
+    }
+    uiDevice.setContentWidth((col + 1) * (4 * (UIKnob.WIDTH + 2) + 15) - 15 - 2);
+  }
+}


### PR DESCRIPTION
New TEColorParameter gives patterns 3 ways to consume color, wrapped in one convenient parameter:
- Solid color
- Two solid colors
- Gradient

Open Belcher_color.lxp to see example patterns of each.

It’s easiest to use with a midi controller attached… a knob mapped to this parameter turns the subparameter “Offset”.  Offset shifts the solid colors as well as the gradient.  If you don’t have a midi controller just click on the parameter and drag Offset with the mouse.

Includes a custom UI for TEPerformancePattern (knobs visually line up with the MidiFighterTwister), and a custom overlay UI for the new color parameter.

Added [the beginning of] a TE-specific Gradient pattern and a TESolidPattern as examples.  And modified @raldi 's Checkers pattern for a two-color example.