### PR TITLE
Rename color methods

### DIFF
--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -91,7 +91,7 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
   /*
    * Color methods
    */
-
+  @Deprecated
   public LinkedColorParameter registerColor(String label, String path, ColorType colorType, String description) {
     LinkedColorParameter lcp = new LinkedColorParameter(label)
             .setDescription(description);
@@ -122,6 +122,7 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
    * @param lerp as a frac
    * @return LXColor
    */
+  @Deprecated
   public int getPrimaryGradientColor(float lerp) {
     /* HSV2 mode wraps returned colors around the color wheel via the shortest
      * hue distance. In other words, we usually want a gradient to go from yellow
@@ -138,6 +139,7 @@ public abstract class TEPattern extends LXModelPattern<TEWholeModel> {
    * @param lerp
    * @return
    */
+  @Deprecated
   public int getSecondaryGradientColor(float lerp) {
     /* HSV2 mode wraps returned colors around the color wheel via the shortest
      * hue distance. In other words, we usually want a gradient to go from yellow

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -691,7 +691,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * but if you want to brighten it, you have to do that with the channel fader or
      * the color control.
      */
-    public int getCurrentColor() {
+    public int calcColor() {
         return TEColor.setBrightness(controls.color.calcColor(), (float) getBrightness());
     }
 
@@ -704,12 +704,14 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * 
      * TODO: remove these two methods from TEPattern to prevent confusion?
      */
+    @Deprecated
     @Override
     public int getPrimaryGradientColor(float lerp) {
         LX.error("Use getGradientColor() instead");
         return TEColor.setBrightness(super.getPrimaryGradientColor(lerp), (float) getBrightness());
     }
 
+    @Deprecated
     @Override
     public int getSecondaryGradientColor(float lerp) {
         LX.error("Use getGradientColor() instead");
@@ -722,7 +724,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * Returns a color offset in position from the first color.
      * @return
      */
-    public int getCurrentColor2() {
+    public int calcColor2() {
         int k = controls.color.calcColor2();
         float bri = (float) getBrightness();
 
@@ -737,7 +739,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * for brightness.  This is used by the OpenGL renderer, which has
      * a unified mechanism for handling brightness.
      */
-    public int getCurrentColorControlValue() {
+    public int getColor() {
         return controls.color.calcColor();
     }
 

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -46,7 +46,7 @@ public class SpiralDiamonds extends TEPerformancePattern {
         float cosT2 = (float) Math.cos(t2);
         float sinT2 = (float) Math.sin(t2);
 
-        int color = getCurrentColor();
+        int color = calcColor();
         double squareocity = getQuantity();
 
          for (LXPoint point : model.panelPoints) {

--- a/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
+++ b/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
@@ -266,7 +266,7 @@ public class TESparklePattern extends TEPerformancePattern {
     public void runTEAudioPattern(double deltaMs) {
         engine.run(deltaMs, model);
         int i = 0;
-        int color = getCurrentColor();
+        int color = calcColor();
         for (LXPoint p : model.points) {
             colors[p.index] =
                     LXColor.multiply(color, LXColor.gray(LXUtils.clamp(engine.outputLevels[i++], 0, 100)));

--- a/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
@@ -16,7 +16,7 @@ public class TESolidPattern extends TEPerformancePattern {
 
   @Override
   protected void runTEAudioPattern(double deltaMs) {
-    int color1 = getCurrentColor();
+    int color1 = calcColor();
     
     for (LXPoint p : getModel().getPoints()) {
       colors[p.index] = color1;      

--- a/src/main/java/titanicsend/pattern/mike/Checkers.java
+++ b/src/main/java/titanicsend/pattern/mike/Checkers.java
@@ -41,8 +41,8 @@ public class Checkers extends TEPerformancePattern {
 
   @Override
   protected void runTEAudioPattern(double deltaMs) {
-    int color1 = getCurrentColor();
-    int color2 = getCurrentColor2();
+    int color1 = calcColor();
+    int color2 = calcColor2();
 
     for (Map.Entry<TEPanelModel, Integer> entry : this.panelGroup.entrySet()) {
       TEPanelModel panel = entry.getKey();

--- a/src/main/java/titanicsend/pattern/tom/BouncingDots.java
+++ b/src/main/java/titanicsend/pattern/tom/BouncingDots.java
@@ -40,7 +40,7 @@ public class BouncingDots extends TEPerformancePattern {
     protected void runTEAudioPattern(double deltaMs) {
         float phase = this.phase.getValuef();
 
-        int dotColor = getCurrentColor();
+        int dotColor = calcColor();
         int dotWidth = (int)(getSize());
         for (TEEdgeModel edge : model.edgesById.values()) {
             int target = (int) (edge.size * phase);

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/PatternControlData.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/PatternControlData.java
@@ -79,10 +79,10 @@ public class PatternControlData {
     }
 
     public int getCurrentColor() {
-        return parent.getCurrentColor();
+        return parent.calcColor();
     }
 
-    public int getCurrentColorControlValue() { return parent.getCurrentColorControlValue(); }
+    public int getCurrentColorControlValue() { return parent.getColor(); }
 
     public FloatBuffer getCurrentPalette() { return parent.getCurrentPalette();}
 


### PR DESCRIPTION
Refactored the main color methods to match current LX framework naming:
`calcColor()` -> instead of `getCurrentColor()`.  This is the main one, gets "final" color, ie post-brightness.
`getColor()` -> instead of `getCurrentColorControlValue()`.  This is "pre-modification" color, ie pre-brightness.

Added `@deprecated` warnings to old gradient methods to discourage accidental use.