### PR TITLE
Arrange parameters for midi surfaces

### DIFF
--- a/src/main/java/titanicsend/pattern/jon/TEControl.java
+++ b/src/main/java/titanicsend/pattern/jon/TEControl.java
@@ -1,7 +1,6 @@
 package titanicsend.pattern.jon;
 
-import heronarts.lx.parameter.LXListenableParameter;
-import titanicsend.pattern.TEPerformancePattern;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 
 /**
  * A dynamically user-configurable control, for use with the TE
@@ -9,12 +8,12 @@ import titanicsend.pattern.TEPerformancePattern;
  */
 public class TEControl {
 
-    public TEControl(LXListenableParameter ctl, _CommonControlGetter getFn) {
+    public TEControl(LXListenableNormalizedParameter ctl, _CommonControlGetter getFn) {
         this.control = ctl;
         this.getFn = getFn;
     }
 
-    public LXListenableParameter control;
+    public LXListenableNormalizedParameter control;
     public _CommonControlGetter getFn;
 
     /**


### PR DESCRIPTION
Parameter arrangement for remote (ie midi) surfaces.

Added the rumored Panic button.  Useful for getting a pattern into line fast when live-VJing.

<img width="204" alt="image" src="https://user-images.githubusercontent.com/6582491/233705128-66ab78b3-11d9-4663-ac11-08a2c45c63a9.png">
