### PR TITLE
Tools for Updating FragmentShaderEffect Patterns

### DIFF
--- a/resources/pixelblaze/glue.js
+++ b/resources/pixelblaze/glue.js
@@ -80,10 +80,7 @@ function rgba(r, g, b, a) {
 }
 
 function paint(v) {
-  if (__pattern.model.isEdgePoint(point.index))
-    return __color = __pattern.getPrimaryGradientColor(v);
-  else
-    return __color = __pattern.getPrimaryGradientColor(v);
+  return __color = __pattern.getGradientColor(v);
 }
 
 function swatch(v) {
@@ -273,7 +270,6 @@ function glueRender() {
   for (i = 0; i < __points.length; i++) {
     __color = 0;
     point = __points[i];
-    if (point == __pattern.model.gapPoint) continue;
     r(i, point.xn + xOffs, point.yn + yOffs, point.zn);
     __colors[point.index] = __color;
   }

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -170,7 +170,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         /**
          * ** Solid-Color patterns should use this method **
-         * <p>
+         *
          * Returns the real-time value of the color, which may be different from what
          * getColor() returns if there are LFOs/etc being applied.
          * Offset has been applied to this color.
@@ -236,7 +236,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         /**
          * ** Gradient patterns should use this method **
-         * <p>
+         *
          * Given a value in 0..1 (and wrapped back outside that range)
          * Return a color within the selected gradient.
          * Offset is added to lerp to create a user-shiftable gradient.
@@ -486,7 +486,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          * To use the common controls, call this function from the constructor
          * of TEPerformancePattern-derived classes after configuring the default
          * controls for your pattern.
-         * <p>
+         *
          * If your pattern adds its own controls in addition to the common
          * controls, you must call addParameter() for them after calling
          * this function so the UI stays consistent across patterns.
@@ -672,7 +672,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
     /**
      * Class to support incremental rotation over variable-speed time
-     * <p>
+     *
      * The rate is tied to the engine bpm and the input time value, which is usually
      * controlled by the variable speed timer associated with the speed or spin controls.
      * (but anything with a seconds.millis timer can generate rotational angles this way.)
@@ -809,7 +809,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     /**
      * Sets the maximum rotation speed used by both getRotationAngleFromSpin() and
      * getRotationAngleFromSpeed().
-     * <p></p>
+     *
      * The default maximum radians per second is PI, which gives one complete rotation
      * every two beats at the current engine BPM.  Do not change this value unless you
      * have a specific reason for doing so.  Too high a rotation speed can cause visuals
@@ -824,14 +824,14 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
     /**
      * @return Color derived from the current setting of the color and brightness controls
-     * <p></p>
+     *
      * NOTE:  The design philosophy here is that palette colors (and the color control)
      * have precedence.
-     * <p></p>
+     *
      * Brightness modifies the current color, and is set to 1.0 (100%) by default. So
      * if you don't move the brightness control you get *exactly* the currently
      * selected color.
-     * <p></p>
+     *
      * At present, the brightness control lets you dim the current color,
      * but if you want to brighten it, you have to do that with the channel fader or
      * the color control.
@@ -842,11 +842,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
     /**
      * ** Instead of these two methods, use getGradientColor(lerp) which defers to TEColorParameter for gradient selection. **
-     * <p>
+     *
      * Suppress parent TEPattern gradient methods, force child classes
      * to choose solid color or gradient, keeping other choices
      * runtime-adjustable.
-     * <p>
+     *
      * TODO: remove these two methods from TEPattern to prevent confusion?
      */
     @Deprecated
@@ -949,7 +949,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     /**
      * <b>NOTE:</b> This control has functional overlap with color and channel fader settings, and
      * could potentially cause confusing brightness behavior.
-     * <p></p>
+     *
      * <b>It may be deprecated or removed in the future and should not be used in patterns.</b>
      *
      * @return The current value of the brightness control, by default in the range 0.0 to 1.0
@@ -973,7 +973,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     /**
      * Restarts the specified timer's elapsed time when called.
      * The timer's rate is not changed.
-     * <p>
+     *
      * This is useful for syncing a timer precisely to beats,
      * measures and other external events.
      *

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -599,7 +599,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     private final Rotor speedRotor = new Rotor();
     private final Rotor spinRotor = new Rotor();
 
-    protected TECommonControls controls;
+    public TECommonControls controls;
 
     protected FloatBuffer palette = Buffers.newDirectFloatBuffer(15);
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -39,20 +39,20 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             public String toString() {
                 return this.label;
             }
-        };
+        }
 
         public final EnumParameter<SolidColorSource> solidSource =
-            new EnumParameter<SolidColorSource>("SolidSource", SolidColorSource.FOREGROUND)
-            .setDescription("For a solid color: Whether to use global TE palette (preferred), or a static color unique to this pattern");
+                new EnumParameter<SolidColorSource>("SolidSource", SolidColorSource.FOREGROUND)
+                        .setDescription("For a solid color: Whether to use global TE palette (preferred), or a static color unique to this pattern");
 
         public final CompoundParameter color2offset =
-            new CompoundParameter("C2Offset", 0.5);
+                new CompoundParameter("C2Offset", 0.5);
 
         // GRADIENT
 
         public final EnumParameter<TEGradient> gradient =
-            new EnumParameter<TEGradient>("Gradient", TEGradient.FULL_PALETTE)
-            .setDescription("Which TEGradient to use. Full_Palette=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
+                new EnumParameter<TEGradient>("Gradient", TEGradient.FULL_PALETTE)
+                        .setDescription("Which TEGradient to use. Full_Palette=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
 
         // GRADIENT BLEND. Excluding RGB because it does play well with gradients.
 
@@ -62,8 +62,8 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
 
         public final EnumParameter<BlendMode> blendMode =
-            new EnumParameter<BlendMode>("BlendMode", BlendMode.HSV2)
-            .setDescription("Blend mode for the gradient");
+                new EnumParameter<BlendMode>("BlendMode", BlendMode.HSV2)
+                        .setDescription("Blend mode for the gradient");
 
         // OFFSET affects both Solid Colors and Gradient
 
@@ -79,19 +79,19 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         private double lastOffset = 0;
 
         public final TEColorOffsetParameter offset = (TEColorOffsetParameter)
-            new TEColorOffsetParameter("Offset") {
-                @Override
-                public LXParameter reset() {
-                    super.reset();
-                    if (solidSource.getEnum() == SolidColorSource.STATIC) {
-                        brightness.reset(100);
-                        saturation.reset(100);
-                        hue.reset();
+                new TEColorOffsetParameter("Offset") {
+                    @Override
+                    public LXParameter reset() {
+                        super.reset();
+                        if (solidSource.getEnum() == SolidColorSource.STATIC) {
+                            brightness.reset(100);
+                            saturation.reset(100);
+                            hue.reset();
+                        }
+                        return this;
                     }
-                    return this;
                 }
-            }
-            .setDescription("Allows user variation of solid color.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.");
+                        .setDescription("Allows user variation of solid color.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.");
 
         private final LXParameterListener offsetListener = (p) -> {
             double value = p.getValue();
@@ -104,7 +104,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         };
 
         public TEColorParameter(String label) {
-          this(label, 0xff000000);
+            this(label, 0xff000000);
         }
 
         public TEColorParameter(String label, int color) {
@@ -141,50 +141,51 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         /**
          * ** Solid-Color patterns should use this method **
-         *
+         * <p>
          * Returns the real-time value of the color, which may be different from what
          * getColor() returns if there are LFOs/etc being applied.
          * Offset has been applied to this color.
          */
         public int calcColor() {
             switch (this.solidSource.getEnum()) {
-            case GRADIENT:
-                // TODO: scale brightness here
-                return _getGradientColor(getOffsetf());
-            case FOREGROUND:
-                // TODO: scale brightness here
-                return _getGradientColor(getOffsetf(), TEGradient.FOREGROUND);
-            default:
-            case STATIC:
-                return LXColor.hsb(
-                    this.hue.getValue(),
-                    this.saturation.getValue(),
-                    this.brightness.getValue()
-                  );
+                case GRADIENT:
+                    // TODO: scale brightness here
+                    return _getGradientColor(getOffsetf());
+                case FOREGROUND:
+                    // TODO: scale brightness here
+                    return _getGradientColor(getOffsetf(), TEGradient.FOREGROUND);
+                default:
+                case STATIC:
+                    return LXColor.hsb(
+                            this.hue.getValue(),
+                            this.saturation.getValue(),
+                            this.brightness.getValue()
+                    );
             }
         }
 
         /**
          * Solid-Color patterns that use two colors can get
          * the second color here.
+         *
          * @return LXColor
          */
         public int calcColor2() {
-          switch (this.solidSource.getEnum()) {
-          case GRADIENT:
-              // TODO: scale brightness here
-              return _getGradientColor(getOffsetf() + color2offset.getValuef());
-          case FOREGROUND:
-              // TODO: scale brightness here
-              return _getGradientColor(getOffsetf() + color2offset.getValuef(), TEGradient.FOREGROUND);
-          default:
-          case STATIC:
-              return LXColor.hsb(
-                  this.hue.getValue() + (color2offset.getValue() * 360.),
-                  this.saturation.getValue(),
-                  this.brightness.getValue()
-                );
-          }
+            switch (this.solidSource.getEnum()) {
+                case GRADIENT:
+                    // TODO: scale brightness here
+                    return _getGradientColor(getOffsetf() + color2offset.getValuef());
+                case FOREGROUND:
+                    // TODO: scale brightness here
+                    return _getGradientColor(getOffsetf() + color2offset.getValuef(), TEGradient.FOREGROUND);
+                default:
+                case STATIC:
+                    return LXColor.hsb(
+                            this.hue.getValue() + (color2offset.getValue() * 360.),
+                            this.saturation.getValue(),
+                            this.brightness.getValue()
+                    );
+            }
         }
 
         /**
@@ -194,11 +195,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         @Override
         public int getColor() {
             switch (this.solidSource.getEnum()) {
-            case FOREGROUND:
-                return getGradientColor(0);
-            default:
-            case STATIC:
-                return super.getColor();
+                case FOREGROUND:
+                    return getGradientColor(0);
+                default:
+                case STATIC:
+                    return super.getColor();
             }
         }
 
@@ -206,10 +207,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         /**
          * ** Gradient patterns should use this method **
-         *
+         * <p>
          * Given a value in 0..1 (and wrapped back outside that range)
          * Return a color within the selected gradient.
          * Offset is added to lerp to create a user-shiftable gradient.
+         *
          * @param lerp as a frac
          * @return LXColor
          */
@@ -219,6 +221,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         /**
          * Returns absolute position within current gradient.
+         *
          * @param lerp
          * @return
          */
@@ -227,22 +230,22 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
 
         private int _getGradientColor(float lerp, TEGradient gradient) {
-          lerp = (float)LXUtils.wrapnf(lerp);
+            lerp = (float) LXUtils.wrapnf(lerp);
 
-          BlendFunction bf;
-          switch (this.blendMode.getEnum()) {
-          case HSV:
-              bf = GradientUtils.BlendMode.HSV.function;
-              break;
-          case HSV2:
-          default:
-              bf = GradientUtils.BlendMode.HSV2.function;
-          }
+            BlendFunction bf;
+            switch (this.blendMode.getEnum()) {
+                case HSV:
+                    bf = GradientUtils.BlendMode.HSV.function;
+                    break;
+                case HSV2:
+                default:
+                    bf = GradientUtils.BlendMode.HSV2.function;
+            }
 
-          return getGradientStops(gradient).getColor(
-              lerp,
-              // TEMath.trianglef(lerp / 2), // Allow wrapping      ** TODO: remove this? **
-              bf);
+            return getGradientStops(gradient).getColor(
+                    lerp,
+                    // TEMath.trianglef(lerp / 2), // Allow wrapping      ** TODO: remove this? **
+                    bf);
         }
 
         /**
@@ -250,15 +253,15 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          */
         private GradientUtils.ColorStops getGradientStops(TEGradient gradient) {
             switch (gradient) {
-            case FOREGROUND:
-                return foregroundGradient;
-            case PRIMARY:
-                return primaryGradient;
-            case SECONDARY:
-                return secondaryGradient;
-            case FULL_PALETTE:
-            default:
-                return paletteGradient;
+                case FOREGROUND:
+                    return foregroundGradient;
+                case PRIMARY:
+                    return primaryGradient;
+                case SECONDARY:
+                    return secondaryGradient;
+                case FULL_PALETTE:
+                default:
+                    return paletteGradient;
             }
         }
 
@@ -508,7 +511,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
         protected void registerColorControl() {
             color = new TEColorParameter("Color")
-                .setDescription("TE Color");
+                    .setDescription("TE Color");
             addParameter("te_color", color);
         }
 
@@ -586,6 +589,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          * Sets maximum spin rate for all patterns using this rotor.  Note that a Rotor
          * object is associated with a timer, which can be a VariableSpeedTimer.  So
          * "seconds" may be variable in duration, and can be positive or negative.
+         *
          * @param radiansPerSecond
          */
         void setMaxSpinRate(double radiansPerSecond) {
@@ -599,13 +603,17 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     private final Rotor speedRotor = new Rotor();
     private final Rotor spinRotor = new Rotor();
 
-    public TECommonControls controls;
+    protected TECommonControls controls;
 
     protected FloatBuffer palette = Buffers.newDirectFloatBuffer(15);
 
     protected TEPerformancePattern(LX lx) {
         super(lx);
         controls = new TECommonControls();
+    }
+
+    public TECommonControls getControls() {
+        return controls;
     }
 
     public void addCommonControls() {
@@ -670,6 +678,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * every two beats at the current engine BPM.  Do not change this value unless you
      * have a specific reason for doing so.  Too high a rotation speed can cause visuals
      * to become erratic.
+     *
      * @param radiansPerSecond
      */
     public void setMaxRotationSpeed(double radiansPerSecond) {
@@ -697,11 +706,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
     /**
      * ** Instead of these two methods, use getGradientColor(lerp) which defers to TEColorParameter for gradient selection. **
-     *
+     * <p>
      * Suppress parent TEPattern gradient methods, force child classes
      * to choose solid color or gradient, keeping other choices
      * runtime-adjustable.
-     * 
+     * <p>
      * TODO: remove these two methods from TEPattern to prevent confusion?
      */
     @Deprecated
@@ -722,6 +731,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
      * For patterns that consume two solid colors, use this method
      * to retrieve the 2nd color.
      * Returns a color offset in position from the first color.
+     *
      * @return
      */
     public int calcColor2() {
@@ -731,7 +741,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         float r = (float) (0xff & LXColor.red(k)) * bri;
         float g = (float) (0xff & LXColor.green(k)) * bri;
         float b = (float) (0xff & LXColor.blue(k)) * bri;
-        return LXColor.rgb((int) r,(int) g,(int) b);
+        return LXColor.rgb((int) r, (int) g, (int) b);
     }
 
     /**
@@ -881,7 +891,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         value = getSpeed() * bps;
         iTime.setScale(value);
         iTime.tick();
-        speedRotor.updateAngle(iTime.getTime(), value );
+        speedRotor.updateAngle(iTime.getTime(), value);
 
         // Gradients always need to be up to date for TEColorParameter
         updateGradients();

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -42,17 +42,17 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
 
         public final EnumParameter<SolidColorSource> solidSource =
-                new EnumParameter<SolidColorSource>("SolidSource", SolidColorSource.FOREGROUND)
-                        .setDescription("For a solid color: Whether to use global TE palette (preferred), or a static color unique to this pattern");
+            new EnumParameter<SolidColorSource>("SolidSource", SolidColorSource.FOREGROUND)
+                .setDescription("For a solid color: Whether to use global TE palette (preferred), or a static color unique to this pattern");
 
         public final CompoundParameter color2offset =
-                new CompoundParameter("C2Offset", 0.5);
+            new CompoundParameter("C2Offset", 0.5);
 
         // GRADIENT
 
         public final EnumParameter<TEGradient> gradient =
-                new EnumParameter<TEGradient>("Gradient", TEGradient.FULL_PALETTE)
-                        .setDescription("Which TEGradient to use. Full_Palette=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
+            new EnumParameter<TEGradient>("Gradient", TEGradient.FULL_PALETTE)
+                .setDescription("Which TEGradient to use. Full_Palette=entire, Foreground=Primary-Secondary, Primary=Primary-BackgroundPrimary, Secondary=Secondary-BackgroundSecondary");
 
         // GRADIENT BLEND. Excluding RGB because it does play well with gradients.
 
@@ -62,8 +62,8 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
 
         public final EnumParameter<BlendMode> blendMode =
-                new EnumParameter<BlendMode>("BlendMode", BlendMode.HSV2)
-                        .setDescription("Blend mode for the gradient");
+            new EnumParameter<BlendMode>("BlendMode", BlendMode.HSV2)
+                .setDescription("Blend mode for the gradient");
 
         // OFFSET affects both Solid Colors and Gradient
 
@@ -79,19 +79,19 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         private double lastOffset = 0;
 
         public final TEColorOffsetParameter offset = (TEColorOffsetParameter)
-                new TEColorOffsetParameter("Offset") {
-                    @Override
-                    public LXParameter reset() {
-                        super.reset();
-                        if (solidSource.getEnum() == SolidColorSource.STATIC) {
-                            brightness.reset(100);
-                            saturation.reset(100);
-                            hue.reset();
-                        }
-                        return this;
+            new TEColorOffsetParameter("Offset") {
+                @Override
+                public LXParameter reset() {
+                    super.reset();
+                    if (solidSource.getEnum() == SolidColorSource.STATIC) {
+                        brightness.reset(100);
+                        saturation.reset(100);
+                        hue.reset();
                     }
+                    return this;
                 }
-                        .setDescription("Allows user variation of solid color.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.");
+            }
+                .setDescription("Allows user variation of solid color.  If Static, adjusts hue offset. If Palette, adjusts normalized position within gradient.");
 
         private final LXParameterListener offsetListener = (p) -> {
             double value = p.getValue();
@@ -157,9 +157,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
                 default:
                 case STATIC:
                     return LXColor.hsb(
-                            this.hue.getValue(),
-                            this.saturation.getValue(),
-                            this.brightness.getValue()
+                        this.hue.getValue(),
+                        this.saturation.getValue(),
+                        this.brightness.getValue()
                     );
             }
         }
@@ -181,9 +181,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
                 default:
                 case STATIC:
                     return LXColor.hsb(
-                            this.hue.getValue() + (color2offset.getValue() * 360.),
-                            this.saturation.getValue(),
-                            this.brightness.getValue()
+                        this.hue.getValue() + (color2offset.getValue() * 360.),
+                        this.saturation.getValue(),
+                        this.brightness.getValue()
                     );
             }
         }
@@ -243,9 +243,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             }
 
             return getGradientStops(gradient).getColor(
-                    lerp,
-                    // TEMath.trianglef(lerp / 2), // Allow wrapping      ** TODO: remove this? **
-                    bf);
+                lerp,
+                // TEMath.trianglef(lerp / 2), // Allow wrapping      ** TODO: remove this? **
+                bf);
         }
 
         /**
@@ -384,11 +384,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             // copy data from previous tag
             CompoundParameter oldControl = (CompoundParameter) getLXControl(tag);
             CompoundParameter newControl = (CompoundParameter) new CompoundParameter(oldControl.getLabel(), value, v0, v1)
-                    .setDescription(oldControl.getDescription())
-                    .setNormalizationCurve(oldControl.getNormalizationCurve())
-                    .setPolarity(oldControl.getPolarity())
-                    .setExponent(oldControl.getExponent())
-                    .setUnits(oldControl.getUnits());
+                .setDescription(oldControl.getDescription())
+                .setNormalizationCurve(oldControl.getNormalizationCurve())
+                .setPolarity(oldControl.getPolarity())
+                .setExponent(oldControl.getExponent())
+                .setUnits(oldControl.getUnits());
 
             setControl(tag, newControl);
             return this;
@@ -445,73 +445,73 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             LXListenableParameter p;
 
             p = new CompoundParameter("Speed", 0.5, -4.0, 4.0)
-                    .setPolarity(LXParameter.Polarity.BIPOLAR)
-                    .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
-                    .setExponent(1.75)
-                    .setDescription("Speed");
+                .setPolarity(LXParameter.Polarity.BIPOLAR)
+                .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
+                .setExponent(1.75)
+                .setDescription("Speed");
             setControl(TEControlTag.SPEED, p);
 
             p = new CompoundParameter("xPos", 0, -1.0, 1.0)
-                    .setPolarity(LXParameter.Polarity.BIPOLAR)
-                    .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
-                    .setDescription("X Position");
+                .setPolarity(LXParameter.Polarity.BIPOLAR)
+                .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
+                .setDescription("X Position");
             setControl(TEControlTag.XPOS, p);
 
             p = new CompoundParameter("yPos", 0, -1.0, 1.0)
-                    .setPolarity(LXParameter.Polarity.BIPOLAR)
-                    .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
-                    .setDescription("Y Position");
+                .setPolarity(LXParameter.Polarity.BIPOLAR)
+                .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
+                .setDescription("Y Position");
             setControl(TEControlTag.YPOS, p);
 
             p = new CompoundParameter("Size", 1, 0.01, 5.0)
-                    .setDescription("Size");
+                .setDescription("Size");
             setControl(TEControlTag.SIZE, p);
 
             p = new CompoundParameter("Quantity", 0.5, 0, 1.0)
-                    .setDescription("Quantity");
+                .setDescription("Quantity");
             setControl(TEControlTag.QUANTITY, p);
 
             p = (CompoundParameter)
-                    new CompoundParameter("Spin", 0, -1.0, 1.0)
-                            .setPolarity(LXParameter.Polarity.BIPOLAR)
-                            .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
-                            .setExponent(2)
-                            .setDescription("Spin");
+                new CompoundParameter("Spin", 0, -1.0, 1.0)
+                    .setPolarity(LXParameter.Polarity.BIPOLAR)
+                    .setNormalizationCurve(BoundedParameter.NormalizationCurve.BIAS_CENTER)
+                    .setExponent(2)
+                    .setDescription("Spin");
 
             setControl(TEControlTag.SPIN, p);
 
             p = new CompoundParameter("Brightness", 1.0, 0.0, 1.0)
-                    .setDescription("Brightness");
+                .setDescription("Brightness");
             setControl(TEControlTag.BRIGHTNESS, p);
 
             p = new CompoundParameter("Wow1", 0, 0, 1.0)
-                    .setDescription("Wow 1");
+                .setDescription("Wow 1");
             setControl(TEControlTag.WOW1, p);
 
             p = new CompoundParameter("Wow2", 0, 0, 1.0)
-                    .setDescription("Wow 2");
+                .setDescription("Wow 2");
             setControl(TEControlTag.WOW2, p);
 
             p = new BooleanParameter("WowTrigger", false)
-                    .setMode(BooleanParameter.Mode.MOMENTARY)
-                    .setDescription("Trigger WoW effects");
+                .setMode(BooleanParameter.Mode.MOMENTARY)
+                .setDescription("Trigger WoW effects");
             setControl(TEControlTag.WOWTRIGGER, p);
 
             // in degrees for display 'cause more people think about it that way
             p = new TECommonAngleParameter("Angle", 0, -Math.PI, Math.PI)
-                    .setDescription("Static Rotation Angle")
-                    .setPolarity(LXParameter.Polarity.BIPOLAR)
-                    .setWrappable(true)
-                    .setFormatter((v) -> {
-                        return Double.toString(Math.toDegrees(v));
-                    });
+                .setDescription("Static Rotation Angle")
+                .setPolarity(LXParameter.Polarity.BIPOLAR)
+                .setWrappable(true)
+                .setFormatter((v) -> {
+                    return Double.toString(Math.toDegrees(v));
+                });
 
             setControl(TEControlTag.ANGLE, p);
         }
 
         protected void registerColorControl() {
             color = new TEColorParameter("Color")
-                    .setDescription("TE Color");
+                .setDescription("TE Color");
             addParameter("te_color", color);
         }
 

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
@@ -121,7 +121,6 @@ public abstract class PixelblazePattern extends TEPerformancePattern {
       return;
 
     try {
-      updateGradients();
       wrapper.reloadIfNecessary();
       wrapper.render(deltaMs, colors);
     } catch (ScriptException | NoSuchMethodException sx) {

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
@@ -1,5 +1,6 @@
 package titanicsend.pattern.yoffa.effect.shaders;
 
+import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
@@ -10,10 +11,12 @@ import java.awt.*;
 import java.util.*;
 
 import static heronarts.lx.utils.LXUtils.clamp;
+import static java.lang.Math.cos;
+import static java.lang.Math.sin;
+import static titanicsend.util.TEMath.multiplyVectorByMatrix;
 
 @Deprecated //we have native support for shaders now. use NativeShaderPatternEffect
 public abstract class FragmentShaderEffect extends PatternEffect {
-
     public FragmentShaderEffect(PatternTarget target) {
         super(target);
     }
@@ -22,7 +25,8 @@ public abstract class FragmentShaderEffect extends PatternEffect {
     @Override
     public void run(double deltaMS) {
         //multithreading assumes setColor is doing nothing more than updating an array
-        double durationSec = getDurationSec();
+        double durationSec = pattern.getTime();
+
         pointsToCanvas.entrySet().parallelStream().forEach(entry -> setColor(entry.getKey(),
                 getColorForPoint(entry.getKey(), entry.getValue(), durationSec)));
     }
@@ -32,13 +36,13 @@ public abstract class FragmentShaderEffect extends PatternEffect {
         boolean useZForX = canvasDimensions.getDepth() > canvasDimensions.getWidth();
         double xCoordinate = useZForX ? point.z - canvasDimensions.getMinZ() : point.x - canvasDimensions.getMinX();
 
-        double[] fragCoordinates = new double[] {
+        double[] fragCoordinates = new double[]{
                 xCoordinate,
                 point.y - canvasDimensions.getMinY()
         };
 
         double widthResolution = useZForX ? canvasDimensions.getDepth() : canvasDimensions.getWidth();
-        double[] resolution = new double[] {widthResolution, canvasDimensions.getHeight()};
+        double[] resolution = new double[]{widthResolution, canvasDimensions.getHeight()};
         double[] colorRgb = getColorForPoint(fragCoordinates, resolution, timeSec);
         //most shaders ignore alpha but optionally plumbing it through is helpful,
         // esp if we want to layer underneath it. can change black background to transparent, etc.
@@ -48,6 +52,17 @@ public abstract class FragmentShaderEffect extends PatternEffect {
                 (float) clamp(colorRgb[1], 0, 1),
                 (float) clamp(colorRgb[2], 0, 1),
                 alpha).getRGB();
+    }
+
+    /**
+     * @param color    - packed LX color
+     * @param rgbArray - a 3 or 4 element array to receive the normalized RGB or RGBA color.
+     */
+    public static void colorToRGBArray(int color, double[] rgbArray) {
+        rgbArray[0] = (double) (0xff & LXColor.red(color)) / 255;
+        rgbArray[1] = (double) (0xff & LXColor.green(color)) / 255;
+        rgbArray[2] = (double) (0xff & LXColor.blue(color)) / 255;
+        if (rgbArray.length > 3) rgbArray[3] = (double) (0xff & LXColor.alpha(color)) / 255;
     }
 
 

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/NeonSnakeShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/NeonSnakeShader.java
@@ -1,8 +1,10 @@
 package titanicsend.pattern.yoffa.effect.shaders;
 
+import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.PatternTarget;
 
 import java.util.Collection;
@@ -14,15 +16,6 @@ import static titanicsend.util.TEMath.*;
 //https://www.shadertoy.com/view/4lB3DG
 public class NeonSnakeShader extends FragmentShaderEffect {
 
-    public final CompoundParameter ySquish =
-            new CompoundParameter("ySquish", 1.3, 1, 5);
-
-    public final CompoundParameter dispersion =
-            new CompoundParameter("Dispersion", .3, .1, 1.5);
-
-    public final CompoundParameter glow =
-            new CompoundParameter("Glow", 1, .1, 1);
-
     public final BooleanParameter trebleGlow =
             new BooleanParameter("TrebleGlow", false);
 
@@ -31,37 +24,50 @@ public class NeonSnakeShader extends FragmentShaderEffect {
 
     public NeonSnakeShader(PatternTarget target) {
         super(target);
+
+        pattern.controls.setRange(TEControlTag.SIZE, 0.3, 0.2, 0.9);  // dispersion/scale
+        pattern.controls.setRange(TEControlTag.QUANTITY, 1, .5, 8);   // snake bend frequency
+        pattern.controls.setRange(TEControlTag.WOW1, 1, .1, 2);   // glow
+        pattern.controls.setRange(TEControlTag.WOW2, 0, 0, .25);    // beat reactivity
     }
 
     @Override
     protected double[] getColorForPoint(double[] fragCoordinates, double[] resolution, double timeSeconds) {
-        if (trebleGlow.getValueb()) {
-            double trebleLevel = pattern.getTrebleLevel();
-            glow.setNormalized(.25 + .75 * trebleLevel);
-        }
-        if (beatDisperse.getValueb()) {
-            dispersion.setNormalized(pattern.sinePhaseOnBeat() * .25);
-        }
 
+        // Quantity controls the snake's bend frequency
+        double bend = pattern.getQuantity();
+
+        // Wow1 controls the base glow level
+        double glow = pattern.getWow1();
+
+        // Wow2 makes the snake expand and contract a little with the beat
+        double dispersion = pattern.getSize() + pattern.getWow2() * sin(PI * pattern.getTempo().basis());
+
+        // normalize coordinates
         double[] uv = divideArrays(fragCoordinates, resolution);
-        double[] waveColor = new double[]{0, 0, 0};
+        uv[1] -= pattern.getYPos() + 0.25;  // offset y to roughly center snake vertically
+        uv = multiplyArray(3, uv); // scale pattern properly for car
 
-        uv = addToArray(-1.3, multiplyArray(2.4 * ySquish.getValue(), uv));
-        uv[1] += .1;
+        // get current calculated palette color (plus alpha, which we'll fill in later)
+        double[] waveColor = new double[4];
+        colorToRGBArray(pattern.calcColor(), waveColor);
+
+        double brightness = 0;
         for (int i = 0; i < 13; i++) {
-            uv[1] += (dispersion.getValue() * sin(uv[0] + i / 1.5 + timeSeconds));
-            double waveWidth = glow.getValue() * abs(1.0 / (150 * uv[1]));
-            waveColor = addArrays(waveColor, new double[] {
-                    waveWidth * 1.7 * sin(timeSeconds - 1.5),
-                    waveWidth,
-                    waveWidth * 1.5 * sin(timeSeconds + 1)
-            });
+            uv[1] += dispersion * sin(uv[0] + i / 1.5 + timeSeconds);
+            double waveWidth = glow * abs(1.0 / (150 * uv[1]));
+            brightness += waveWidth;
         }
+
+        // gamma correct brightness and use it as alpha
+        brightness = clamp(brightness, 0, 1);
+        waveColor[3] = brightness * brightness;
         return waveColor;
     }
 
+
     @Override
     public Collection<LXParameter> getParameters() {
-        return List.of(ySquish, dispersion, glow, trebleGlow, beatDisperse);
+        return null;
     }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
@@ -16,7 +16,6 @@ public abstract class PatternEffect {
     protected final TEPerformancePattern pattern;
     protected final Map<LXPoint, Dimensions> pointsToCanvas;
     private boolean shouldBlend;
-    private long startTime = System.currentTimeMillis();
 
 
     public PatternEffect(PatternTarget target) {
@@ -25,7 +24,6 @@ public abstract class PatternEffect {
     }
 
     public final void onActive() {
-        startTime = System.currentTimeMillis();
         onPatternActive();
     }
 
@@ -60,10 +58,6 @@ public abstract class PatternEffect {
         } else {
             colors[point.index] = color;
         }
-    }
-
-    protected double getDurationSec() {
-        return (System.currentTimeMillis() - startTime) / 1000.;
     }
 
     protected Set<LXPoint> getAllPoints() {

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
@@ -4,8 +4,6 @@ import heronarts.lx.Tempo;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.LXParameter;
-import titanicsend.pattern.TEAudioPattern;
-import titanicsend.pattern.TEPattern;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.util.Dimensions;
 


### PR DESCRIPTION
A few changes needed to simplify converting these patterns to use the common controls, plus a sample conversion of the NeonSnakeShader pattern.

This is a straightforward, very vanilla conversion, showing how to set up and use the common controls in this pattern framework.  We can add more features to this pattern later if necessary.  Controls are:

- Color: Yes
- Speed: Yes
- X/Y Offset: Y only, since the pattern moves constantly in X
- Spin/Angle:  No.
- Brightness: Yes
- Size:  Snake size
- Quantity:  No
- Wow1:  Base Glow
- Wow2:  Beat reactive snake size modulation
- Wow Trigger: No