### PR TITLE
Sending palette changes to pangolin laser via OSC

### DIFF
--- a/.lxpreferences
+++ b/.lxpreferences
@@ -1,8 +1,8 @@
 {
   "version": "0.4.2-SNAPSHOT",
   "projectFileName": "AutoVJ.lxp",
-  "windowWidth": 1505,
-  "windowHeight": 889,
+  "windowWidth": -1,
+  "windowHeight": -1,
   "windowPosX": -1,
   "windowPosY": -1,
   "uiZoom": 100,

--- a/.lxpreferences
+++ b/.lxpreferences
@@ -1,8 +1,8 @@
 {
   "version": "0.4.2-SNAPSHOT",
   "projectFileName": "AutoVJ.lxp",
-  "windowWidth": -1,
-  "windowHeight": -1,
+  "windowWidth": 1505,
+  "windowHeight": 889,
   "windowPosX": -1,
   "windowPosY": -1,
   "uiZoom": 100,

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -28,6 +28,7 @@ import java.util.Calendar;
 import java.util.function.Function;
 
 import heronarts.lx.LX;
+import heronarts.lx.LXLoopTask;
 import heronarts.lx.LXPlugin;
 import heronarts.lx.midi.surface.APC40Mk2;
 import heronarts.lx.midi.surface.MidiFighterTwister;
@@ -39,6 +40,7 @@ import heronarts.lx.pattern.texture.SparklePattern;
 import heronarts.lx.studio.LXStudio;
 import processing.core.PApplet;
 import titanicsend.app.autopilot.*;
+import titanicsend.lasercontrol.TELaserTask;
 import titanicsend.model.TEWholeModel;
 import titanicsend.output.GPOutput;
 import titanicsend.output.GrandShlomoStation;
@@ -80,6 +82,8 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
   private TEAutopilot autopilot;
   private TEOscListener oscListener;
   private TEPatternLibrary library;
+
+  private TELaserTask laserTask;
 
   @Override
   public void settings() {
@@ -282,6 +286,10 @@ public class TEApp extends PApplet implements LXPlugin, LX.ProjectListener  {
     } catch (SocketException sx) {
         sx.printStackTrace();
     }
+
+    // create our loop task for outputting data to lasers
+    this.laserTask = new TELaserTask(lx);
+    lx.engine.addLoopTask(this.laserTask);
 
     GPOutput gpOutput = new GPOutput(lx, this.gpBroadcaster);
     lx.addOutput(gpOutput);

--- a/src/main/java/titanicsend/app/TEAutopilot.java
+++ b/src/main/java/titanicsend/app/TEAutopilot.java
@@ -23,10 +23,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class TEAutopilot implements LXLoopTask, LX.ProjectListener {
     private boolean enabled = false;
 
-    // should we send OSC messages to lasers about
-    // palette changes?
-    private boolean SEND_PALETTE_TO_LASERS = false;
-
     // number of bars to fade out on various occasions
     private final int MISPREDICTED_FADE_OUT_BARS = 2;
     private final int PREV_FADE_OUT_BARS = 2;
@@ -716,16 +712,6 @@ public class TEAutopilot implements LXLoopTask, LX.ProjectListener {
             TE.log("Palette change!");
             changePaletteSwatch(false, true, 0);
             history.startPaletteTimer();
-
-            // notify lasers of this change
-            if (SEND_PALETTE_TO_LASERS) {
-                try {
-                    TEOscMessage.sendPaletteToPangolin(lx);
-                } catch (Exception e) {
-                    TE.err("Problem sending palette to Pangolin: %s", e);
-                    e.printStackTrace();
-                }
-            }
         }
 
         // add to historical log of events

--- a/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
+++ b/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
@@ -164,33 +164,12 @@ public class TEOscMessage {
      * @param address String
      * @param value int
      */
-    public static void sendOscToPangolin(LX lx, String address, int value) {
+    public static void sendOscToPangolin(LX lx, String address, int value, boolean verbose) {
         lx.engine.osc.transmitActive.setValue(true);
         lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
         lx.engine.osc.transmitPort.setValue(PangolinHost.PORT);
-        TE.log("Sending OSC to %s:%d = OSC OUT: %s %d;", PangolinHost.HOSTNAME, PangolinHost.PORT, address, value);
+        if (verbose)
+            TE.log("Sending OSC to %s:%d = OSC OUT: %s %d;", PangolinHost.HOSTNAME, PangolinHost.PORT, address, value);
         lx.engine.osc.sendMessage(address, value);
-    }
-
-    /**
-     * Call this function to send the current LX palette to Pangolin
-     * lasers via OSC.
-     *
-     * TEOscMessage is place to edit/change the address format.
-     *
-     * This method is where to change the hue calculation, or send more
-     * similar messages if desired.
-     *
-     * @param lx
-     */
-    public static void sendPaletteToPangolin(LX lx) {
-        // send hue
-        LXDynamicColor primary = lx.engine.palette.swatch.getColor(3);
-        int rgb = primary.getColor();
-        int hue = (int) (360 * LXColor.h(rgb));
-        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue);
-
-        //TODO(someone) send band difference for secondary?
-        // ...
     }
 }

--- a/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
+++ b/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
@@ -168,7 +168,7 @@ public class TEOscMessage {
         lx.engine.osc.transmitActive.setValue(true);
         lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
         lx.engine.osc.transmitPort.setValue(PangolinHost.PORT);
-        if (true)
+        if (verbose)
             TE.log("Sending OSC to %s:%d = OSC OUT: %s %d;", PangolinHost.HOSTNAME, PangolinHost.PORT, address, value);
         lx.engine.osc.sendMessage(address, value);
     }

--- a/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
+++ b/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
@@ -168,7 +168,7 @@ public class TEOscMessage {
         lx.engine.osc.transmitActive.setValue(true);
         lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
         lx.engine.osc.transmitPort.setValue(PangolinHost.PORT);
-        if (verbose)
+        if (true)
             TE.log("Sending OSC to %s:%d = OSC OUT: %s %d;", PangolinHost.HOSTNAME, PangolinHost.PORT, address, value);
         lx.engine.osc.sendMessage(address, value);
     }

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -19,6 +19,6 @@ public class TELaserTask implements LXLoopTask {
         LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(TEPattern.ColorType.PRIMARY.index);
         int rgb = primary.getColor();
         int hue = (int) (360 * LXColor.h(rgb));
-        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue);
+        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);
     }
 }

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -1,0 +1,28 @@
+package titanicsend.lasercontrol;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXLoopTask;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LXDynamicColor;
+import titanicsend.app.autopilot.TEOscMessage;
+import titanicsend.pattern.TEPattern;
+import titanicsend.util.TE;
+
+public class TELaserTask implements LXLoopTask {
+    public LX lx;
+    //public int oldPrimaryHue = -1;
+    public TELaserTask(LX lx) {
+        this.lx = lx;
+    }
+
+    @Override
+    public void loop(double deltaMs) {
+//        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(TEPattern.ColorType.PRIMARY.index);
+        int swatchIndex = this.lx.engine.palette.swatch.getIndex();
+        TE.log("Swatch index: %s", swatchIndex);
+//        int rgb = primary.getColor();
+//        int hue = (int) (360 * LXColor.h(rgb));
+//        TE.log("Sending palette: %d", hue);
+//        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue);
+    }
+}

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -19,10 +19,9 @@ public class TELaserTask implements LXLoopTask {
         // get the swatch color
         int primaryIndex = TEPattern.ColorType.PRIMARY.swatchIndex();
         LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
-        int rgb = primary.getColor();
 
         // convert to a 0 - 360 format for Pangolin
-        int hue = (int) (360 * LXColor.h(rgb));
+        int hue = (int)(primary.getHuef());
 
         // send the OSC message
         TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -3,22 +3,27 @@ package titanicsend.lasercontrol;
 import heronarts.lx.LX;
 import heronarts.lx.LXComponent;
 import heronarts.lx.LXLoopTask;
-import heronarts.lx.color.LXColor;
 import heronarts.lx.color.LXDynamicColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.BooleanParameter.Mode;
 import titanicsend.app.autopilot.TEOscMessage;
 import titanicsend.pattern.TEPattern;
-import titanicsend.util.TE;
 
 public class TELaserTask extends LXComponent implements LXLoopTask {
-    public boolean enabled = true;
-    public LX lx;
+
+    public final BooleanParameter enabled =
+        new BooleanParameter("Enabled", true)
+        .setMode(Mode.TOGGLE);
+
     public TELaserTask(LX lx) {
-        this.lx = lx;
+        super(lx);
+
+        addParameter("enabled", this.enabled);
     }
 
     @Override
     public void loop(double deltaMs) {
-        if (enabled) {
+        if (this.enabled.isOn()) {
             // get the swatch color
             int primaryIndex = TEPattern.ColorType.PRIMARY.swatchIndex();
             LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -10,19 +10,15 @@ import titanicsend.util.TE;
 
 public class TELaserTask implements LXLoopTask {
     public LX lx;
-    //public int oldPrimaryHue = -1;
     public TELaserTask(LX lx) {
         this.lx = lx;
     }
 
     @Override
     public void loop(double deltaMs) {
-//        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(TEPattern.ColorType.PRIMARY.index);
-        int swatchIndex = this.lx.engine.palette.swatch.getIndex();
-        TE.log("Swatch index: %s", swatchIndex);
-//        int rgb = primary.getColor();
-//        int hue = (int) (360 * LXColor.h(rgb));
-//        TE.log("Sending palette: %d", hue);
-//        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue);
+        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(TEPattern.ColorType.PRIMARY.index);
+        int rgb = primary.getColor();
+        int hue = (int) (360 * LXColor.h(rgb));
+        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue);
     }
 }

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -16,9 +16,15 @@ public class TELaserTask implements LXLoopTask {
 
     @Override
     public void loop(double deltaMs) {
-        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(TEPattern.ColorType.PRIMARY.index);
+        // get the swatch color
+        int primaryIndex = TEPattern.ColorType.PRIMARY.swatchIndex();
+        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
         int rgb = primary.getColor();
+
+        // convert to a 0 - 360 format for Pangolin
         int hue = (int) (360 * LXColor.h(rgb));
+
+        // send the OSC message
         TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);
     }
 }

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -21,7 +21,7 @@ public class TELaserTask implements LXLoopTask {
         LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
 
         // convert to a 0 - 360 format for Pangolin
-        int hue = (int)(primary.getHuef());
+        int hue = (int)(primary.getHue());
 
         // send the OSC message
         TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);

--- a/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -1,6 +1,7 @@
 package titanicsend.lasercontrol;
 
 import heronarts.lx.LX;
+import heronarts.lx.LXComponent;
 import heronarts.lx.LXLoopTask;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.color.LXDynamicColor;
@@ -8,7 +9,8 @@ import titanicsend.app.autopilot.TEOscMessage;
 import titanicsend.pattern.TEPattern;
 import titanicsend.util.TE;
 
-public class TELaserTask implements LXLoopTask {
+public class TELaserTask extends LXComponent implements LXLoopTask {
+    public boolean enabled = true;
     public LX lx;
     public TELaserTask(LX lx) {
         this.lx = lx;
@@ -16,14 +18,16 @@ public class TELaserTask implements LXLoopTask {
 
     @Override
     public void loop(double deltaMs) {
-        // get the swatch color
-        int primaryIndex = TEPattern.ColorType.PRIMARY.swatchIndex();
-        LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
+        if (enabled) {
+            // get the swatch color
+            int primaryIndex = TEPattern.ColorType.PRIMARY.swatchIndex();
+            LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
 
-        // convert to a 0 - 360 format for Pangolin
-        int hue = (int)(primary.getHue());
+            // convert to a 0 - 360 format for Pangolin
+            int hue = (int) (primary.getHue());
 
-        // send the OSC message
-        TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);
+            // send the OSC message
+            TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);
+        }
     }
 }


### PR DESCRIPTION
Adding a loop task for the LX engine to send OSC messages with the current palette (primary) color to the lasers. 

Message will look like the following: `/lx/color/hue < int in range [0, 360) >;`