### PR TITLE
Update WaterPanels and WaterEdges Patterns

### DIFF
--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -2,6 +2,8 @@ package titanicsend.pattern.yoffa.config;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import heronarts.lx.parameter.CompoundParameter;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.will.shaders.*;
 import titanicsend.pattern.yoffa.effect.*;
 import titanicsend.pattern.yoffa.effect.shaders.*;
@@ -94,6 +96,13 @@ public class OrganicPatternConfig {
         }
         @Override
         protected List<PatternEffect> createEffects() {
+
+            // set ranges for common controls
+            getControls().setRange(TEControlTag.QUANTITY, 0,1,4); // tiling
+            getControls().setRange(TEControlTag.SIZE, 1,0.5,3);     // scale
+            getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)
+            getControls().setRange(TEControlTag.WOW2, 0.005,0.001,0.01); // intensity 2
+
             return List.of(new WaterShader(PatternTarget.allPanelsAsCanvas(this)));
         }
     }
@@ -105,6 +114,13 @@ public class OrganicPatternConfig {
         }
         @Override
         protected List<PatternEffect> createEffects() {
+
+            // set ranges for common controls
+            getControls().setRange(TEControlTag.QUANTITY, 0,1,4); // tiling
+            getControls().setRange(TEControlTag.SIZE, 1,0.5,3);     // scale
+            getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)
+            getControls().setRange(TEControlTag.WOW2, 0.005,0.001,0.01); // intensity 2
+
             return List.of(new WaterShader(PatternTarget.allEdgesAsCanvas(this)));
         }
     }

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -98,6 +98,9 @@ public class OrganicPatternConfig {
         protected List<PatternEffect> createEffects() {
 
             // set ranges for common controls
+            getControls().setRange(TEControlTag.SPEED, 0,-2,2); // Speed
+            getControls().setValue(TEControlTag.SPEED, 0.5);
+
             getControls().setRange(TEControlTag.QUANTITY, 0,1,4); // tiling
             getControls().setRange(TEControlTag.SIZE, 1,0.5,3);     // scale
             getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)
@@ -116,6 +119,9 @@ public class OrganicPatternConfig {
         protected List<PatternEffect> createEffects() {
 
             // set ranges for common controls
+            getControls().setRange(TEControlTag.SPEED, 0,-4,4); // Speed
+            getControls().setValue(TEControlTag.SPEED, 0.5);
+
             getControls().setRange(TEControlTag.QUANTITY, 0,1,4); // tiling
             getControls().setRange(TEControlTag.SIZE, 1,0.5,3);     // scale
             getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
@@ -19,6 +19,7 @@ import static titanicsend.util.TEMath.*;
 @Deprecated //we have native support for shaders now. use NativeShaderPatternEffect
 public abstract class FragmentShaderEffect extends PatternEffect {
     double[][] rotationMatrix;
+    double[] translationFromControls = new double[2];
     int color1 = 0;
     int color2 = 0;
 
@@ -37,6 +38,8 @@ public abstract class FragmentShaderEffect extends PatternEffect {
         color2 = pattern.calcColor2();
 
         double angle = -pattern.getRotationAngleFromSpin();
+        translationFromControls[0] = pattern.getXPos();
+        translationFromControls[1] = pattern.getYPos();
 
         rotationMatrix = new double[][]{
                 {cos(angle), -sin(angle)},
@@ -75,6 +78,10 @@ public abstract class FragmentShaderEffect extends PatternEffect {
         double[] p1 = subtractArrays(point, origin);
         p1 = multiplyVectorByMatrix(p1, rotationMatrix);
         return addArrays(p1, origin);
+    }
+
+    public double[] translate(double[] point) {
+        return addArrays(point,translationFromControls);
     }
 
     public int calcColor() {

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/WaterShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/WaterShader.java
@@ -13,22 +13,8 @@ import static titanicsend.util.TEMath.*;
 //https://www.shadertoy.com/view/MdlXz8
 public class WaterShader extends FragmentShaderEffect {
 
-    public final CompoundParameter tile =
-            new CompoundParameter("Tiling", 0, 1, 4)
-                    .setDescription("");
-
-    public final CompoundParameter speed =
-            new CompoundParameter("Speed", 0.1, 0.1, 10)
-                    .setDescription("");
-
-    public final CompoundParameter intensity =
-            new CompoundParameter("Inten1", 5, 1, 20)
-                    .setDescription("Intensity");
-
-    public final CompoundParameter intensity2 =
-            new CompoundParameter("Inten2", .005, .001, .010)
-                    .setDescription("Intensity but like different though");
     private static final double TAU = 6.28318530718;
+    private static final double[] origin = new double[]{0.5, 0.25};
 
     public WaterShader(PatternTarget target) {
         super(target);
@@ -36,25 +22,30 @@ public class WaterShader extends FragmentShaderEffect {
 
     @Override
     protected double[] getColorForPoint(double[] fragCoordinates, double[] resolution, double timeSeconds) {
-        double time = (timeSeconds * .5+23.0) * 0.25;
-        // uv should be the 0-1 uv of texture...
-        double[] uv = divideArrays(fragCoordinates, resolution);
 
-        double[] p = addToArray(-250, mod(multiplyArray(tile.getValue() * TAU, uv), tile.getValue() * TAU));
+        // normalize coords to 0 to 1 range, then do the translate, scale, rotate thing.
+        double[] uv = divideArrays(fragCoordinates, resolution);
+        uv = translate(uv);
+        uv = multiplyArray(pattern.getSize(), uv);
+        uv = rotate2D(uv, origin);
+
+        double tileFactor = TAU * pattern.getQuantity();
+        double[] p = addToArray(-250, mod(multiplyArray(tileFactor, uv), TAU));
         double[] i = new double[]{p[0], p[1]};
         double c = 1.0;
-        double inten = intensity2.getValue();
+        double inten = pattern.getWow2();
+        double time = timeSeconds * 0.5;
 
-        for (int n = 0; n < intensity.getValue(); n++)
-        {
-            double t = time * (speed.getValue() - (3.5 / (n+1)));
+        for (int n = 0; n < pattern.getWow1(); n++) {
+            double t = time * (1.0 - (3.5 / (n+1)));
             i = addArrays(p, new double[]{cos(t - i[0]) + sin(t + i[1]), sin(t - i[1]) + cos(t + i[0])});
-            c += 1.0/vectorLength(new double[]{p[0] / (sin(i[0]+t)/inten),p[1] / (cos(i[1]+t)/inten)});
+            c += 1.0 / vectorLength(new double[]{p[0] / (sin(i[0] + t) / inten), p[1] / (cos(i[1] + t) / inten)});
         }
-        c /= intensity.getValue();
-        c = 1.17-pow(c, 1.4);
+        c /= pattern.getWow1();
+        c = 1.17 - pow(c, 1.4);
         double colourValue = pow(abs(c), 8.0);
         double[] colour = new double[]{colourValue, colourValue, colourValue};
+
         colour = clamp(addArrays(colour, new double[]{0.0, 0.35, 0.5}), 0.0, 1.0);
 
         return colour;
@@ -62,6 +53,6 @@ public class WaterShader extends FragmentShaderEffect {
 
     @Override
     public Collection<LXParameter> getParameters() {
-        return List.of(tile, speed, intensity, intensity2);
+        return null;
     }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/WaterShader.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/WaterShader.java
@@ -26,8 +26,13 @@ public class WaterShader extends FragmentShaderEffect {
         // normalize coords to 0 to 1 range, then do the translate, scale, rotate thing.
         double[] uv = divideArrays(fragCoordinates, resolution);
         uv = translate(uv);
-        uv = multiplyArray(pattern.getSize(), uv);
         uv = rotate2D(uv, origin);
+        double scale = pattern.getSize();
+        uv = multiplyArray(scale, uv);
+
+        // set coord system origin so we stay centered while zooming w/size control
+        uv[0] -= origin[0] * scale;
+        uv[1] -= origin[1] * scale;
 
         double tileFactor = TAU * pattern.getQuantity();
         double[] p = addToArray(-250, mod(multiplyArray(tileFactor, uv), TAU));
@@ -43,10 +48,13 @@ public class WaterShader extends FragmentShaderEffect {
         }
         c /= pattern.getWow1();
         c = 1.17 - pow(c, 1.4);
-        double colourValue = pow(abs(c), 8.0);
-        double[] colour = new double[]{colourValue, colourValue, colourValue};
 
-        colour = clamp(addArrays(colour, new double[]{0.0, 0.35, 0.5}), 0.0, 1.0);
+        double colourValue = 0.5+pow(abs(c), 8.0);
+
+        double[] colour = new double[4];
+        colorToRGBArray(calcColor(), colour);
+        colour = clamp(multiplyArray(colourValue,colour),0.0,1.0);
+        colour[3] = max(colour[0],max(colour[1],colour[2]));
 
         return colour;
     }


### PR DESCRIPTION
They both use the same shader.  Controls are:
- Speed: Yes
- X/Y Offset: Yes
- Spin/Angle: Yes
- Brightness: Yes
- Size: Overall scale
- Quantity: Tile repeat factor
- Wow1: Iterations (old intensity 1)
- Wow2: Intensity 2
- WowTrigger: No

(To get the high contrast wavy snake line effect, set Wow1 as low as possible, and Wow2 to nearly 0.  Now try spinning, or scaling for... more snakes!)