### PR TITLE
Rework AutoVJ enabled scaffolding

### DIFF
--- a/src/main/java/titanicsend/app/autopilot/TEAutopilotMixer.java
+++ b/src/main/java/titanicsend/app/autopilot/TEAutopilotMixer.java
@@ -231,8 +231,12 @@ public class TEAutopilotMixer {
                 // TODO: maybe remove this if JSON file loading works? otherwise might end up with
                 //       two different groups on the mixer with the name "AUTO_VJ"
                 TE.log("Creating and populating AutoVJ channel set...");
-                int groupIdx = AUTO_VJ_GROUP_MIXER_IDX;
-                group = lx.engine.mixer.addGroup(groupIdx);
+                // Create empty channels to put the AutoVJ group on the 8th fader
+                while (lx.engine.mixer.channels.size() < AUTO_VJ_GROUP_MIXER_IDX) {
+                  lx.engine.mixer.addChannel()
+                      .label.setValue("---");
+                }
+                group = lx.engine.mixer.addGroup();
                 group.label.setValue(AUTO_VJ_GROUP_NAME);
                 //group.enabled.setValue(false); // turn off initially
 
@@ -319,9 +323,8 @@ public class TEAutopilotMixer {
                  * from the .lxp, and not for non-phrase channels like STROBES or TRIGGERS
                  */
                 // create channels, add to group
-                int added = 1;
                 for (TEChannelName name : TEChannelName.values()) {
-                    LXChannel c = lx.engine.mixer.addChannel(groupIdx + added);
+                    LXChannel c = lx.engine.mixer.addChannel();
                     c.label.setValue(name.toString());
 
                     for (Map.Entry<TEPatternLibrary.PhrasePatternCompositeKey, TEPatternLibrary.TEPatternRecord> e : this.library.getPatternMapping().entrySet()) {
@@ -344,7 +347,6 @@ public class TEAutopilotMixer {
                     c.addPattern(new ShaderPanelsPatternConfig.Electric(lx)); // add as dummy pattern just for testing
 
                     group.addChannel(c);
-                    added++;
                 }
                 /**
                  * End logic that needs to be replaced.

--- a/src/main/java/titanicsend/app/autopilot/TEUserInterface.java
+++ b/src/main/java/titanicsend/app/autopilot/TEUserInterface.java
@@ -1,12 +1,9 @@
 package titanicsend.app.autopilot;
 
-import heronarts.lx.LX;
-import heronarts.lx.LXComponent;
-import heronarts.lx.osc.LXOscComponent;
-import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.studio.LXStudio;
-import heronarts.p4lx.ui.component.UICheckbox;
 import heronarts.p4lx.ui.component.UICollapsibleSection;
+import heronarts.p4lx.ui.component.UISwitch;
+import titanicsend.app.TEAutopilot;
 
 /**
  * LX Studio boilerplate around adding UI components to
@@ -14,22 +11,13 @@ import heronarts.p4lx.ui.component.UICollapsibleSection;
  */
 public class TEUserInterface {
 
-    public static class AutopilotComponent extends LXComponent implements LXOscComponent {
-        public final BooleanParameter autopilotEnabledToggle =
-                new BooleanParameter("Autopilot Enabled")
-                        .setDescription("Toggle to turn on VJ autopilot mode")
-                        .setValue(false);
-        public AutopilotComponent(LX lx) {
-            super(lx);
-            addParameter("autopilotEnabledToggle", this.autopilotEnabledToggle);
-        }
-    }
-
     public static class AutopilotUISection extends UICollapsibleSection {
-        public AutopilotUISection(LXStudio.UI ui, AutopilotComponent myComponent) {
+        public AutopilotUISection(LXStudio.UI ui, TEAutopilot component) {
             super(ui, 0, 0, ui.leftPane.global.getContentWidth(), 80);
-            setTitle("Autopilot: enable?");
-            new UICheckbox(0, 0, myComponent.autopilotEnabledToggle).addToContainer(this);
+            setTitle("Autopilot");
+            new UISwitch(0, 4)
+                .setParameter(component.enabled)
+                .addToContainer(this);
         }
     }
 }

--- a/src/main/java/titanicsend/util/TE.java
+++ b/src/main/java/titanicsend/util/TE.java
@@ -14,4 +14,8 @@ public class TE {
     public static void err(String format, Object... arguments) {
         LX.error(String.format(format, arguments));
     }
+
+    public static void err(Throwable x, String message) {
+        LX.error(x, message);
+    }
 }


### PR DESCRIPTION
Cleans up some AutoVJ on/off behavior:

- Uses BooleanParameter internally for enabled flag
- Can't get out of sync with UI enabled button (previously this was a risk)
- Only attempts startup once, when enabled is changed to true
- If startup fails, does not re-attempt startup on every loop (as previously doing from loop())
- Captures startup failure without crash and prints stack trace to System error stream (red text in eclipse).
- *Should* cleanly restore AutoVJ enabled state on file save/open.
- Cleans up some UI wiring & listeners in TEApp.
- Increases UI button size.