### PR TITLE
Fix pattern references in .lxps for moved patterns

### DIFF
--- a/Projects/AUTO_VJ_TEMPLATE.lxp
+++ b/Projects/AUTO_VJ_TEMPLATE.lxp
@@ -3267,7 +3267,7 @@
               },
               {
                 "id": 30203,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "modulationControlsExpanded": true,
@@ -6014,7 +6014,7 @@
               },
               {
                 "id": 35028,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "modulationControlsExpanded": true,

--- a/Projects/AutoVJ Jeff Asymmetry.lxp
+++ b/Projects/AutoVJ Jeff Asymmetry.lxp
@@ -3090,7 +3090,7 @@
               },
               {
                 "id": 30203,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -4745,7 +4745,7 @@
               },
               {
                 "id": 35028,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -6155,7 +6155,7 @@
               },
               {
                 "id": 44871,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$BasicElectricEdges",
+                "class": "titanicsend.pattern.jon.ElectricEdges",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/AutoVJ_filtered.lxp
+++ b/Projects/AutoVJ_filtered.lxp
@@ -2873,7 +2873,7 @@
               },
               {
                 "id": 30203,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -4596,7 +4596,7 @@
               },
               {
                 "id": 35028,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/Debugging.lxp
+++ b/Projects/Debugging.lxp
@@ -645,7 +645,7 @@
               },
               {
                 "id": 47446,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$BasicElectricEdges",
+                "class": "titanicsend.pattern.jon.ElectricEdges",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/OSC.lxp
+++ b/Projects/OSC.lxp
@@ -2070,7 +2070,7 @@
               },
               {
                 "id": 30203,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -3952,7 +3952,7 @@
               },
               {
                 "id": 35028,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/Tergel.lxp
+++ b/Projects/Tergel.lxp
@@ -2981,7 +2981,7 @@
               },
               {
                 "id": 30203,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,
@@ -4825,7 +4825,7 @@
               },
               {
                 "id": 35028,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,

--- a/Projects/Yoffa.lxp
+++ b/Projects/Yoffa.lxp
@@ -810,7 +810,7 @@
             "patterns": [
               {
                 "id": 806,
-                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$Electric",
+                "class": "titanicsend.pattern.jon.Electric",
                 "internal": {
                   "modulationColor": 0,
                   "expanded": true,


### PR DESCRIPTION
Fixes the broken pattern references in .lxp project files.  A couple patterns were moved around when they were updated to the new base class.

Includes the one that was failing on AutoVJ start (loading from AUTOVJ_TEMPLATE.lxp).