### PR TITLE
New noise patterns, Round 1

### DIFF
--- a/resources/shaders/simplex_posterized.fs
+++ b/resources/shaders/simplex_posterized.fs
@@ -1,0 +1,161 @@
+// Posterized simplex noise shader for Titanic's ENd
+//
+// Uses the Ashima Arts 2D/3D/4D simplex noise generator
+//
+// Copyright (C) 2011 Ashima Arts. All rights reserved.
+// Distributed under the MIT License. See LICENSE file.
+// https://github.com/ashima/webgl-noise
+//
+
+vec3 mod289(vec3 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 mod289(vec4 x) {
+    return x - floor(x * (1.0 / 289.0)) * 289.0;
+}
+
+vec4 permute(vec4 x) {
+    return mod289(((x * 34.0) + 1.0) * x);
+}
+
+vec4 taylorInvSqrt(vec4 r)
+{
+    return 1.79284291400159 - 0.85373472095314 * r;
+}
+
+float snoise(vec3 v)
+{
+    const vec2 C = vec2(1.0 / 6.0, 1.0 / 3.0);
+    const vec4 D = vec4(0.0, 0.5, 1.0, 2.0);
+
+    // First corner
+    vec3 i = floor(v + dot(v, C.yyy));
+    vec3 x0 = v - i + dot(i, C.xxx);
+
+    // Other corners
+    vec3 g = step(x0.yzx, x0.xyz);
+    vec3 l = 1.0 - g;
+    vec3 i1 = min(g.xyz, l.zxy);
+    vec3 i2 = max(g.xyz, l.zxy);
+
+    //   x0 = x0 - 0.0 + 0.0 * C.xxx;
+    //   x1 = x0 - i1  + 1.0 * C.xxx;
+    //   x2 = x0 - i2  + 2.0 * C.xxx;
+    //   x3 = x0 - 1.0 + 3.0 * C.xxx;
+    vec3 x1 = x0 - i1 + C.xxx;
+    vec3 x2 = x0 - i2 + C.yyy; // 2.0*C.x = 1/3 = C.y
+    vec3 x3 = x0 - D.yyy;      // -1.0+3.0*C.x = -0.5 = -D.y
+
+    // Permutations
+    i = mod289(i);
+    vec4 p = permute(permute(permute(
+                                 i.z + vec4(0.0, i1.z, i2.z, 1.0))
+                             + i.y + vec4(0.0, i1.y, i2.y, 1.0))
+                     + i.x + vec4(0.0, i1.x, i2.x, 1.0));
+
+    // Gradients: 7x7 points over a square, mapped onto an octahedron.
+    // The ring size 17*17 = 289 is close to a multiple of 49 (49*6 = 294)
+    float n_ = 0.142857142857; // 1.0/7.0
+    vec3 ns = n_ * D.wyz - D.xzx;
+
+    vec4 j = p - 49.0 * floor(p * ns.z * ns.z);  //  mod(p,7*7)
+
+    vec4 x_ = floor(j * ns.z);
+    vec4 y_ = floor(j - 7.0 * x_);    // mod(j,N)
+
+    vec4 x = x_ * ns.x + ns.yyyy;
+    vec4 y = y_ * ns.x + ns.yyyy;
+    vec4 h = 1.0 - abs(x) - abs(y);
+
+    vec4 b0 = vec4(x.xy, y.xy);
+    vec4 b1 = vec4(x.zw, y.zw);
+
+    //vec4 s0 = vec4(lessThan(b0,0.0))*2.0 - 1.0;
+    //vec4 s1 = vec4(lessThan(b1,0.0))*2.0 - 1.0;
+    vec4 s0 = floor(b0) * 2.0 + 1.0;
+    vec4 s1 = floor(b1) * 2.0 + 1.0;
+    vec4 sh = -step(h, vec4(0.0));
+
+    vec4 a0 = b0.xzyw + s0.xzyw * sh.xxyy;
+    vec4 a1 = b1.xzyw + s1.xzyw * sh.zzww;
+
+    vec3 p0 = vec3(a0.xy, h.x);
+    vec3 p1 = vec3(a0.zw, h.y);
+    vec3 p2 = vec3(a1.xy, h.z);
+    vec3 p3 = vec3(a1.zw, h.w);
+
+    //Normalise gradients
+    vec4 norm = taylorInvSqrt(vec4(dot(p0, p0), dot(p1, p1), dot(p2, p2), dot(p3, p3)));
+    p0 *= norm.x;
+    p1 *= norm.y;
+    p2 *= norm.z;
+    p3 *= norm.w;
+
+    // Mix final noise value
+    vec4 m = max(0.6 - vec4(dot(x0, x0), dot(x1, x1), dot(x2, x2), dot(x3, x3)), 0.0);
+    m = m * m;
+    return 42.0 * dot(m * m, vec4(dot(p0, x0), dot(p1, x1),
+                                  dot(p2, x2), dot(p3, x3)));
+}
+
+//END ASHIMA NOISE ///////////////////////////////////////////
+
+const float levels = 5.0;
+const float cutoff = 0.05;
+
+// build 2D rotation matrix
+mat2 rotate2D(float a) {
+    return mat2(cos(a), -sin(a), sin(a), cos(a));
+}
+
+// generate 4 octave noise field
+float noiseField(vec2 uv, float t) {
+    float noise = 0.0;
+    float scale = 1.0;
+    float div = 0.0;
+
+    for (int i = 1; i <= 4; i++) {
+        noise += snoise(vec3(uv * scale, t)) * 1. / scale;
+        div += 1. / scale;
+        scale *= 2.0;
+    }
+
+    noise = 0.5 + noise / div;
+    return pow(noise,iQuantity);
+}
+
+// quantize input values into <levels> bins, with
+// values below <cutoff> assigned to zero
+float quantize(float n) {
+    float d = (n - cutoff) / (1. - cutoff);
+    d = floor(d * levels) / levels;
+    return d;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    // Note that we override default translate behavior
+    // for this shader, since a static offset isn't very useful,
+    // we use x and y offsets to set movement direction vectors
+    vec2 uv = fragCoord+(iTranslate * iResolution);
+
+    // normalize, scale, rotate
+    uv = (uv - 0.5 * iResolution.xy) / iResolution.x;
+    uv *= iScale;
+    uv = uv * rotate2D(-iRotationAngle);
+
+    uv -= iTranslate;
+
+    float field = noiseField(uv,iTime * 0.5);
+    float noise = quantize(field);
+
+    // Wow1 controls the mix of noise field vs. posterized noise.  The color gradient
+    // also gets progressively quantized as Wow1 increases.
+    noise = mix(1.15 * field, noise, iWow1);
+    float gradient = mix(noise,mod((noise * levels),2.0),iWow1);
+
+    // Wow2 controls the mix of foreground color vs. gradient
+    vec3 col = mix(iColorRGB, mix(iColorRGB, iColor2RGB,gradient), iWow2);
+
+    fragColor = vec4(col, noise);
+}

--- a/resources/shaders/turbulent_noise_lines.fs
+++ b/resources/shaders/turbulent_noise_lines.fs
@@ -1,0 +1,76 @@
+const float PI = 3.1415926;
+const float TAU = 2.0 * PI;
+
+// circle function from nimitz @ ShaderToy
+// returns distance from a point to a cirular pulse
+float circle(vec2 p) {
+    float r = length(p);
+    r = log(sqrt(r));
+    return abs(mod(r * 4., TAU) - PI) * 3. + .5;
+}
+
+// build 2D rotation matrix
+mat2 rotate2D(float a) {
+    return mat2(cos(a), -sin(a), sin(a), cos(a));
+}
+
+float hash(vec2 uv) {
+    return fract(12345. * sin(dot(uv, vec2(12.34, 56.78))));
+}
+
+// simple value noise generator
+float noise(vec2 uv) {
+    vec2 f = fract(uv);
+    f = f * f * (3. - 2. * f);
+    vec2 p = floor(uv);
+    float res = mix(mix(hash(p), hash(p + vec2(1., 0.)), f.x),
+                    mix(hash(p + vec2(0., 1.)), hash(p + vec2(1., 1.)), f.x),
+                    f.y);
+    return res;
+}
+
+// several octaves of value noise make a cloudy-looking turbulent field
+float turbulenceNoise(vec2 uv) {
+    float k = 4.0;
+
+    uv = rotate2D(k + 0.00001 * iTime) * uv * 3. + 0.2 * iTime;
+    float res = 0.;
+    float c = 0.5;
+
+    for (int i = 0; i < 8; i++) {
+        res += c * noise(uv);
+        c /= 2.;
+        uv = rotate2D(k + 0.00001 * iTime) * k * uv + k + iTime;
+    }
+
+    return res;
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+
+    // normalize, scale, rotate
+    vec2 uv = (fragCoord.xy - 0.5 * iResolution.xy) / iResolution.x;
+    uv *= iScale;
+    uv = uv * rotate2D(-iRotationAngle);
+
+    float res = turbulenceNoise(uv);
+    uv = rotate2D(1.5 * noise(uv * 5. + 0.1 * iTime)) * uv;
+
+    // Quantity controls the density of the lines derived from the noise field
+    float line = smoothstep(0., 1., abs(sin(iQuantity * uv.x * uv.y) + res));
+    line = smoothstep(0., 1., line);
+
+    // Wow Trigger runs the TE special dual ring pulse generator, which draws only on
+    // the wavy lines (and not on the background fog.)
+    if (iWowTrigger) {
+        uv /= exp(beat * PI);
+        line *= max(line,3.0 / pow(abs(2.1 - circle(uv)),0.75));
+    }
+
+    // Wow1 controls the mix of lines vs. noise field background
+    float bri = mix(1.5 * res, line, iWow1);
+    // Wow2 controls the mix of foreground color vs. gradient
+    vec3 col = bri * mix(iColorRGB, mix(iColor2RGB, iColorRGB,smoothstep(0.1,0.8, bri * bri)), iWow2);
+
+    fragColor = vec4(col, max(col.r, max(col.g, col.b)));
+}

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -172,6 +172,7 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.registry.addPattern(XorceryDiamonds.class);
     lx.registry.addPattern(PBFireworkNova.class);
     lx.registry.addPattern(PixelblazeParallel.class);
+    lx.registry.addPattern(SimplexPosterized.class);
     lx.registry.addPattern(SolidEdge.class);
     lx.registry.addPattern(SolidPanel.class);
     lx.registry.addPattern(TESparklePattern.class);

--- a/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
+++ b/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
@@ -1,0 +1,82 @@
+package titanicsend.pattern.jon;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
+import titanicsend.pattern.yoffa.framework.PatternTarget;
+import titanicsend.pattern.yoffa.shader_engine.NativeShader;
+
+@LXCategory("Noise")
+public class SimplexPosterized extends TEPerformancePattern {
+
+    /**
+     * Class to support smooth incremental canvas movement over variable-speed time.
+     * This lets individual shaders override xOffs/yOffs control behavior and
+     * use these controls to set a direction vector for patterns where
+     * that makes sense.
+     * <p>
+     * This rate is based on the real-time clock and is independent of the
+     * speed control.
+     */
+    protected class CanvasTranslator {
+
+        protected double xOffset = 0;
+        protected double yOffset = 0;
+
+        void updateTranslation(double deltaMs) {
+            // calculate change in position since last frame.
+            xOffset += getXPos() * deltaMs / 1000.;
+            yOffset += getYPos() * deltaMs / 1000.;
+        }
+
+        void reset() {
+            xOffset = 0;
+            yOffset = 0;
+        }
+    }
+
+    NativeShaderPatternEffect effect;
+    NativeShader shader;
+
+    CanvasTranslator drift = new CanvasTranslator();
+
+    public SimplexPosterized(LX lx) {
+        super(lx);
+
+        // common controls setup
+        controls.setRange(TEControlTag.SPEED, 0, -4, 4);
+        controls.setValue(TEControlTag.SPEED, 0.5);
+
+        controls.setRange(TEControlTag.SIZE, 5, 2, 9);
+        controls.setRange(TEControlTag.QUANTITY, 1.5, 3, 0.5);
+
+        // register common controls with LX
+        addCommonControls();
+
+        effect = new NativeShaderPatternEffect("simplex_posterized.fs",
+            PatternTarget.allPointsAsCanvas(this));
+    }
+
+    @Override
+    public void runTEAudioPattern(double deltaMs) {
+        drift.updateTranslation(deltaMs);
+
+        // calculate incremental transform based on elapsed time
+        shader.setUniform("iTranslate", (float) drift.xOffset, (float) drift.yOffset);
+
+        // run the shader
+        effect.run(deltaMs);
+    }
+
+    @Override
+    // THIS IS REQUIRED if you're not using ConstructedPattern!
+    // Initialize the NativeShaderPatternEffect and retrieve the native shader object
+    // from it when the pattern becomes active
+    public void onActive() {
+        super.onActive();
+        effect.onActive();
+        shader = effect.getNativeShader();
+    }
+
+}

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.yoffa.config;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
 import titanicsend.pattern.yoffa.effect.ShaderToyPatternEffect;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
@@ -267,4 +268,23 @@ public class ShaderPanelsPatternConfig {
         }
     }
 
+    @LXCategory("Noise")
+    public static class TurbulenceLines extends ConstructedPattern {
+        public TurbulenceLines(LX lx) {
+            super(lx);
+        }
+        @Override
+        protected List<PatternEffect> createEffects() {
+
+            // common controls setup
+            controls.setRange(TEControlTag.SPEED, 0,-4, 4);
+            controls.setValue(TEControlTag.SPEED,0.5);
+            controls.setRange(TEControlTag.SIZE, 1,0.4, 1.5);
+            controls.setRange(TEControlTag.QUANTITY,200,50, 600);
+            controls.setValue(TEControlTag.WOW1,0.6);
+
+            return List.of(new NativeShaderPatternEffect("turbulent_noise_lines.fs",
+                PatternTarget.allPanelsAsCanvas(this)));
+        }
+    }
 }


### PR DESCRIPTION
These two patterns show the general direction I'm taking with noise.  Rather than writing one gigantic noise pattern to rule them all, I'm doing an assortment of small, high performance patterns, with features that work with the specific type and appearance of the noise.

When testing, please be sure to turn off any LX modulators that are active on the channel. No problem using them in production if necessary, but they do tend to ~~stomp~~ obscure pattern detail.

### Turbulence Lines
Generates a value noise based turbulence field, then uses the field to draw sinuous, organic-looking lines.  Wow1 controls the noise field/line mix, Wow2 controls the foreground color/gradient mix.

Wow trigger fires a double pulse on the beat that lights the lines (not the background fog), so you can turn the lines way down in the mix, and they will be revealed as the pulse passes.

- Speed: Yes
- X/Y Offset: Yes
- Spin/Angle: Yes
- Brightness: Yes
- Size: Overall scale
- Quantity: Line density
- Wow1: Noise field/wavy line mix
- Wow2: Foreground color/gradient mix
- WowTrigger: Radial double pulse on the beat

### Simplex Posterized
Generates a cloudy simplex noise field which you can color with the current gradient, and "Posterize" - quantize to a small number of brightness levels - for a cartoon-like look.

Since static x and y offset are not useful for this sort of pattern, they are instead used to control "drift" - x and y movement speed.

Wow1 controls the posterization level, Wow2 controls the foreground color/gradient mix.

- Speed: Yes
- X/Y Offset: Yes, controls "drift" speed and directrion
- Spin/Angle: Yes
- Brightness: Yes
- Size: Overall scale
- Quantity: Noise field density
- Wow1: Posterization level
- Wow2: Foreground color/gradient mix
- WowTrigger: No