### PR TITLE
Four More Pattern Updates

### DIFF
--- a/resources/shaders/neon_ripples.fs
+++ b/resources/shaders/neon_ripples.fs
@@ -26,7 +26,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     float t = -iTime * 4.0;
 
     // build a wave to perturb the radius of the main circular pulse
-    float d = iWow1 * beat * sin(9. * atan(uv.x,uv.y));
+    float d = iWow1 * sin(9. * atan(uv.x,uv.y));
 
     // generate circular waves
     float s = 0.5 + 0.5 * sin(t - (d+length(uv * 2.0)) * 5.0);

--- a/resources/shaders/neon_ripples.fs
+++ b/resources/shaders/neon_ripples.fs
@@ -1,18 +1,41 @@
-//fork of https://www.shadertoy.com/view/WsSXzt
+// fork of https://www.shadertoy.com/view/WsSXzt
 
-void mainImage( out vec4 fragColor, in vec2 fragCoord )
-{
+vec2 rotate(vec2 point, vec2 origin, float angle) {
+    float c = cos(angle); float s = sin(angle);
+    mat2 rotationMatrix = mat2(c, -s, s, c);
+    return origin + rotationMatrix * (point - origin);
+}
+
+// rotate (2D) a point about the origin by <angle> radians
+vec2 rotate(vec2 point, float angle) {
+    return rotate(point, vec2(0.0), angle);
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     vec2 uv = (fragCoord - 0.5 * iResolution.xy) / iResolution.y;
 
-    vec2 gv = uv * {%pixelation[50,1,100]};
+    // iWow2 controls how much the rotation speed changes w/radius,
+    // which we use later to generate a sawtooth effect
+    uv = rotate(uv,iRotationAngle + iWow2 * length(uv));
+
+    uv *= iScale;
+
+    vec2 gv = uv * 2.*iQuantity;
     gv = fract(gv) - 0.5;
 
-    float t = iTime * {%speed[5,1,10]};
+    float t = -iTime * 4.0;
 
-    float s = (sin(t - length(uv * {%layers[2,2,10]}) * 5.0) * 0.4 + 0.5) * {%width[.6,.6,1.6]};
-    float m = smoothstep(s, s - 0.05, length(gv)) + s*2.0;
+    // build a wave to perturb the radius of the main circular pulse
+    float d = iWow1 * beat * sin(9. * atan(uv.x,uv.y));
 
-    vec3 col = vec3(s, 0.0, {%color2[.5,.1,1.5]}) * m;
+    // generate circular waves
+    float s = 0.5 + 0.5 * sin(t - (d+length(uv * 2.0)) * 5.0);
 
-    fragColor = vec4(col, 1.0);
+    // draw the pixelated dots between waves
+    float m = smoothstep(s, s - 0.05, length(gv)) + s * 2.0;
+
+    vec3 col = mix(iColor2RGB,iColorRGB,s) * min(1.1,(m - (m * 0.44 * s)));
+    fragColor = vec4(col, max(col.r,max(col.g,col.b)));
 }
+
+

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -176,17 +176,6 @@ public class OrganicPatternConfig {
     }
 
     @LXCategory("Yoffa Panel Organic")
-    public static class PulseSide extends ConstructedPattern {
-        public PulseSide(LX lx) {
-            super(lx);
-        }
-        @Override
-        protected List<PatternEffect> createEffects() {
-            return List.of(new PulseEffect(PatternTarget.allPanelsAsCanvas(this)).setOrigin(0, 0, 0));
-        }
-    }
-
-    @LXCategory("Yoffa Panel Organic")
     public static class AlternatingDots extends ConstructedPattern {
         public AlternatingDots(LX lx) {
             super(lx);

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.yoffa.config;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
 import titanicsend.pattern.yoffa.effect.ShaderToyPatternEffect;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
@@ -19,10 +20,11 @@ public class ShaderEdgesPatternConfig {
         public LightBeamsEdges(LX lx) {
             super(lx);
         }
+
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("light_beams.fs",
-                    PatternTarget.allEdgesAsCanvas(this)));
+                PatternTarget.allEdgesAsCanvas(this)));
         }
     }
 
@@ -31,10 +33,26 @@ public class ShaderEdgesPatternConfig {
         public NeonRipplesEdges(LX lx) {
             super(lx);
         }
+
         @Override
         protected List<PatternEffect> createEffects() {
+            // set up parameters for the edge version of this...
+            controls.setRange(TEControlTag.SIZE, 2, 0.1, 6); // overall scale
+            controls.setValue(TEControlTag.SIZE, 2.25);
+
+            controls.setRange(TEControlTag.QUANTITY, 20, 1, 50);  // pixelation scale
+            controls.setValue(TEControlTag.QUANTITY, 8);
+
+            controls.setRange(TEControlTag.WOW1, 0, 0, 0.25);  // "wiggle" in rings
+            controls.setValue(TEControlTag.WOW1, 0.15);
+
+            controls.setRange(TEControlTag.WOW2, 0, 0, 3);  // radial rotation distortion
+            controls.setValue(TEControlTag.WOW2, 2.25);
+
+            controls.setValue(TEControlTag.SPIN, 0.05);
+
             return List.of(new NativeShaderPatternEffect("neon_ripples.fs",
-                    PatternTarget.allEdgesAsCanvas(this)));
+                PatternTarget.allEdgesAsCanvas(this)));
         }
     }
 
@@ -43,10 +61,11 @@ public class ShaderEdgesPatternConfig {
         public SpaceExplosionEdges(LX lx) {
             super(lx);
         }
+
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("space_explosion.fs",
-                    PatternTarget.allEdgesAsCanvas(this)));
+                PatternTarget.allEdgesAsCanvas(this)));
         }
     }
 
@@ -55,11 +74,12 @@ public class ShaderEdgesPatternConfig {
         public MetallicWaves(LX lx) {
             super(lx);
         }
+
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(
-                    new NativeShaderPatternEffect("metallic_wave.fs", PatternTarget.allPanelsAsCanvas(this)),
-                    new NativeShaderPatternEffect("metallic_wave.fs", PatternTarget.allEdgesAsCanvas(this))
+                new NativeShaderPatternEffect("metallic_wave.fs", PatternTarget.allPanelsAsCanvas(this)),
+                new NativeShaderPatternEffect("metallic_wave.fs", PatternTarget.allEdgesAsCanvas(this))
             );
         }
     }

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
@@ -37,7 +37,10 @@ public class ShaderEdgesPatternConfig {
         @Override
         protected List<PatternEffect> createEffects() {
             // set up parameters for the edge version of this...
-            controls.setRange(TEControlTag.SIZE, 2, 0.1, 6); // overall scale
+            controls.setRange(TEControlTag.SPEED, 0, -4, 4); // overall scale
+            controls.setValue(TEControlTag.SPEED, 0.5);
+
+            controls.setRange(TEControlTag.SIZE, 2, 6, 0.1); // overall scale
             controls.setValue(TEControlTag.SIZE, 2.25);
 
             controls.setRange(TEControlTag.QUANTITY, 20, 1, 50);  // pixelation scale

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -70,7 +70,10 @@ public class ShaderPanelsPatternConfig {
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            controls.setRange(TEControlTag.SIZE,2,0.1,6); // overall scale
+            controls.setRange(TEControlTag.SPEED, 0, -4, 4); // overall scale
+            controls.setValue(TEControlTag.SPEED, 0.5);
+
+            controls.setRange(TEControlTag.SIZE, 2, 6, 0.1); // overall scale
             controls.setRange(TEControlTag.QUANTITY,20,1,50);  // pixelation scale
             controls.setRange(TEControlTag.WOW1,0,0,0.25);  // "wiggle" in rings
             controls.setRange(TEControlTag.WOW2,0,0,3);  // radial rotation distortion

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.yoffa.config;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
 import titanicsend.pattern.yoffa.effect.ShaderToyPatternEffect;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
@@ -69,6 +70,11 @@ public class ShaderPanelsPatternConfig {
         }
         @Override
         protected List<PatternEffect> createEffects() {
+            controls.setRange(TEControlTag.SIZE,2,0.1,6); // overall scale
+            controls.setRange(TEControlTag.QUANTITY,20,1,50);  // pixelation scale
+            controls.setRange(TEControlTag.WOW1,0,0,0.25);  // "wiggle" in rings
+            controls.setRange(TEControlTag.WOW2,0,0,3);  // radial rotation distortion
+
             return List.of(new NativeShaderPatternEffect("neon_ripples.fs",
                     PatternTarget.splitPanelSections(this)));
         }

--- a/src/main/java/titanicsend/pattern/yoffa/effect/PulseEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/PulseEffect.java
@@ -2,9 +2,7 @@ package titanicsend.pattern.yoffa.effect;
 
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
-import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
-import heronarts.lx.utils.LXUtils;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
@@ -12,10 +10,6 @@ import titanicsend.pattern.yoffa.framework.PatternTarget;
 import titanicsend.util.TEMath;
 
 import java.util.Collection;
-import java.util.List;
-
-import static titanicsend.util.TEMath.clamp;
-import static titanicsend.util.TEMath.wave;
 
 public class PulseEffect extends PatternEffect {
 
@@ -27,12 +21,19 @@ public class PulseEffect extends PatternEffect {
     private double originYn = 0;
     private double originZn = 0.5;
 
+    private static final double pulseWidthBase = 0.2;
+
     public PulseEffect(PatternTarget target) {
         super(target);
         TEPerformancePattern.TECommonControls ctl = pattern.getControls();
 
-        ctl.setRange(TEControlTag.QUANTITY, 2, 2, 10);
+        ctl.setRange(TEControlTag.SPEED, 0, -2, 2);
+        ctl.setValue(TEControlTag.SPEED, 0.25);
 
+        ctl.setRange(TEControlTag.SIZE, 3, 12, 0.7);
+
+        ctl.setRange(TEControlTag.WOW2, 0, 0, 15);
+        ctl.setUnits(TEControlTag.WOW2, LXParameter.Units.INTEGER);
     }
 
     public PulseEffect setOrigin(double xn, double yn, double zn) {
@@ -42,42 +43,65 @@ public class PulseEffect extends PatternEffect {
         return this;
     }
 
-    // This is shamelessly stolen from Jeff's ArtStandards class with some tweaked inputs/parameters
-    // We could abstract it out, but I didn't want to disrupt his wonderful template
-    // I also expect them to diverge as they are tweaked more, so I don't hate the duplication as of now
+    // quantize an input value in the range [0,1] into one of the
+    // specified number of level bins.  If number of bins is zero,
+    // return the value untouched.
+    double posterize(double n, double levels) {
+        double result;
+        if (levels == 0) {
+            result = n;
+        } else {
+            levels += 1; // helps limit black in palettes that have a lot of it
+            result = Math.floor(n * levels) / levels;
+            // average w/original color to blend the band edges a little
+            result = (result + result + n) / 3;
+        }
+        return result;
+    }
+
     @Override
     public void run(double deltaMs) {
-        double energy = pattern.getWow1();
         double zOrigin = originZn + pattern.getXPos();
         double yOrigin = originYn + pattern.getYPos();
-        double beat = pattern.getTempo().basis();
-        double measure = pattern.measure();
 
-        // set us up to respond to large treble events
-        double scaledTrebleRatio = clamp((pattern.getTrebleRatio() - 1) / 0.15,0,1);
-        scaledTrebleRatio *= scaledTrebleRatio;
+        double energy = pattern.getWow1();
+        double levels = Math.floor(pattern.getWow2());
+
+        double scale = pattern.getSize();
+        double pulseWidth = pulseWidthBase / scale;
+
+        // getGradientColor does not yet support brightness from the control
+        double masterBri = pattern.getBrightness();
+
+        // make sure beat pulse follows the direction of the waves.
+        double beat = pattern.getTempo().basis();
+        beat = (Math.signum(pattern.getSpeed()) >= 0) ? beat : 1 - beat;
+
+        double beatPulse = energy * 40 * (1 - beat);
+
+        double t1 = pattern.getTime();
 
         for (LXPoint point : getAllPoints()) {
-            double distanceFromCenter = TEMath.distance(point.xn, point.yn, point.zn, originXn, yOrigin, zOrigin);
+            double d1 = TEMath.distance(point.xn, point.yn, point.zn, originXn, yOrigin, zOrigin);
+            double dist = d1 * scale;
 
-            int color = pattern.getGradientColor((float)
-                (pattern.getQuantity() * distanceFromCenter - measure) % 1);
+            // dark sparkles - moving beat wave controlled by Wow1
+            double beatWave = Math.abs(d1 - beat);
+            beatWave = (beatWave > pulseWidth) ? 0 :
+                energy * 40 * (1.0 - beatWave);
+
+            // straightforward radial gradient, with color posterization
+            double index = posterize(Math.abs(t1 + dist) % 1, levels);
+            int color = pattern.getGradientColor((float) index);
 
             double hue = LXColor.h(color);
-            double saturation = LXColor.s(color);
-            double brightness = LXColor.b(color);
+            double saturation = TEMath.clamp(LXColor.s(color) - beatWave, 0, 100);
+            double brightness = masterBri * TEMath.clamp(LXColor.b(color) - beatPulse, 0, 100);
 
-            double dist = 2.0 * distanceFromCenter - scaledTrebleRatio;
-            double alphaWave = wave(dist);
-            double satWave = (0.86 - dist) * scaledTrebleRatio * Math.random();
-
-            saturation = Math.max(0.0, saturation - (energy * 100 * satWave * satWave));
-
-            setColor(point, LXColor.hsba(
+            setColor(point, LXColor.hsb(
                 hue,
                 saturation,
-                (brightness + (35 * (1.0 - (2 * distanceFromCenter - beat)))) % 100,
-                alphaWave * 255
+                brightness
             ));
         }
     }


### PR DESCRIPTION
Updates for four (really two) more patterns:

### NeonRipplesEdges, NeonRipples
NeonRipplesEdges is the high priority pattern here.  Since they share a shader, NeonRipples got an update too. It might wind up getting some use as well now.

The original version of this pattern just generated circular pulses with a pixelated border.  A lot of its drama came from its fixed, bright "neon" colors.  The new (palette compliant) version does a bit more to make the edge pattern more exciting.  To see what's really going on, look at NeonRipples first.

Wow1 controls deformation of the circular pulse waves as a function of angle, Wow2 controls the change in rotation rate as a function of radius.  TL;DR - Wow1 lets you turn the circles into flowers.  Wow2 changes the flowers into shark fins or saw blades.

- Speed: Yes
- X/Y Offset: Yes, controls "drift" speed and directrion
- Spin/Angle: Yes
- Brightness: Yes
- Size: Overall Scale
- Quantity: Size and density of the pixelated region
- Wow1: Beat reactive "Flowers"
- Wow2:  "Sawtooth"
- WowTrigger: No

### PulseCenter, PulseSide
One of TE's first effects, I didn't change this one a lot. It's a nice, simple beat reactive pattern. The only difference between PulseCenter and PulseSide is the origin point of the pulses.

Test with audio for best results.

- Speed: Yes
- X/Y Offset: Yes
- Spin/Angle: No
- Brightness: Yes
- Size: No
- Quantity: Number of rings in the pulse field
- Wow1: Audio reactive static "fizz" on mid-high frequencies.
- Wow2: No
- WowTrigger: No