### PR TITLE
Get around exceptions + LX error boxes on startup

### DIFF
--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Titanic's End" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="titanicsend.app.TEApp" />
     <module name="LXStudio-TE" />
     <option name="PROGRAM_PARAMETERS" value="vehicle AutoVJ.lxp" />

--- a/README.md
+++ b/README.md
@@ -146,11 +146,9 @@ Either go to https://adoptium.net/installation/ or, on a Mac with Homebrew, `bre
    ```shell
    mvn clean package  # Packaging creates the JAR and cleaning is optional
    ```
-2. Execute the JAR (Note that the version number may be different — The version
-   as of this document revision is 0.2.0-SNAPSHOT — substitute the correct
-   version as necessary):
+2. Execute the JAR:
    ```shell
-   java -jar target/LXStudio-TE-0.2.0-SNAPSHOT-jar-with-dependencies.jar vehicle Vehicle.lxp
+   java -jar target/LXStudio-TE-*-jar-with-dependencies.jar vehicle Vehicle.lxp
    ```
 3. If the Temurin JDK isn't your default Java, then you can use the full path,
    for example:
@@ -160,11 +158,9 @@ Either go to https://adoptium.net/installation/ or, on a Mac with Homebrew, `bre
 4. Use Maven to execute the program instead of the `java` command:
    ```shell
    mvn clean compile  # Cleaning and compiling is optional, depending on your needs
-   mvn exec:java@Main -Dexec.args="vehicle Vehicle.lxp"
+   mvn exec:java@Main # loads default Vehicle.lxp
+   mvn exec:java@Main -Dexec.args="vehicle AutoVJ.lxp" # explicit project example
    ```
-
-   Fun fact: The "Main" target isn't defined in the POM to have arguments, but
-   it could, in which case you wouldn't need the `vehicle Vehicle.lxp` args.
 
 ### Potential issues
 

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,8 @@
                         <configuration>
                             <mainClass>titanicsend.app.TEApp</mainClass>
                             <arguments>
+                                <argument>vehicle</argument>
+                                <argument>Vehicle.lxp</argument>
                             </arguments>
                             <stopUnresponsiveDaemonThreads>true</stopUnresponsiveDaemonThreads>
                             <systemProperties>

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -180,11 +180,13 @@ public abstract class TEPattern extends LXPattern {
   
   // Compare to LXLayeredComponent's clearColors(), which is declared final.
   public void clearPixels() {
-    for (LXPoint point : this.model.points) {
-      if (this.modelTE.isGapPoint(point)) {
-        colors[this.modelTE.getGapPointIndex()] = GAP_PIXEL_COLOR;
-      } else {
-        colors[point.index] = TEColor.TRANSPARENT;
+    if (colors != null) {
+      for (LXPoint point : this.model.points) {
+        if (this.modelTE.isGapPoint(point)) {
+          colors[this.modelTE.getGapPointIndex()] = GAP_PIXEL_COLOR;
+        } else {
+          colors[point.index] = TEColor.TRANSPARENT;
+        }
       }
     }
   }

--- a/src/main/java/titanicsend/pattern/alex/ResizeableScreen.java
+++ b/src/main/java/titanicsend/pattern/alex/ResizeableScreen.java
@@ -92,6 +92,10 @@ public class ResizeableScreen extends TEPattern implements UIDeviceControls<Resi
     }
 
     private void paint(double deltaMs) {
+        if (colors == null) {
+            LX.log("ResizableScreen::paint() was called, but this.colors is null (probably new LX version startup), skipping.");
+            return;
+        }
         int color = this.color.calcColor();
 
         for (LXPoint point : this.screen.screenGrid) {

--- a/src/main/java/titanicsend/pattern/jeff/SignalDebugger.java
+++ b/src/main/java/titanicsend/pattern/jeff/SignalDebugger.java
@@ -70,23 +70,37 @@ public class SignalDebugger extends TEPattern implements UIDeviceControls<Signal
     private List<List<ChainedEdge>> activeEdgeRoutes = List.of();
     private List<String> activePanelIds = List.of();
 
+    // lazy load this pattern only if used
+    private boolean loaded = false;
+
     public SignalDebugger(LX lx) {
         super(lx);
-
-        loadChains();
-        loadPanelData();
-
-        allControllers = new LinkedList<>();
-        allControllers.addAll(controllerVertexToEdgeRoutes.keySet());
-        allControllers.addAll(controllerVertexToPanelIds.keySet());
-        Collections.sort(allControllers);
-
-        cycleAllParameter.setRange(0, allControllers.size());
 
         addParameter("vertexSelect", vertexSelectParameter);
         addParameter("edgeId", edgeIdParameter);
         addParameter("cycleAll", cycleAllParameter);
         addParameter("showLowPri", showLowPriParameter);
+    }
+
+    private void load() {
+        loadChains();
+        loadPanelData();
+
+        allControllers = new ArrayList<>();
+        allControllers.addAll(controllerVertexToEdgeRoutes.keySet());
+        allControllers.addAll(controllerVertexToPanelIds.keySet());
+        Collections.sort(allControllers);
+
+        cycleAllParameter.setRange(0, allControllers.size());
+        this.loaded = true;
+    }
+
+    @Override
+    protected void onActive() {
+        if (!this.loaded) {
+            load();
+        }
+        super.onActive();
     }
 
     public void run(double deltaMs) {
@@ -184,7 +198,7 @@ public class SignalDebugger extends TEPattern implements UIDeviceControls<Signal
             File f = new File("resources/vehicle/panel_signal_paths.tsv");
             s = new Scanner(f);
         } catch (FileNotFoundException e) {
-            throw new Error("edge_signal_paths.tsv not found");
+            throw new Error("panel_signal_paths.tsv not found");
         }
 
         String headerLine = s.nextLine();

--- a/src/main/java/titanicsend/pattern/will/PowerDebugger.java
+++ b/src/main/java/titanicsend/pattern/will/PowerDebugger.java
@@ -48,6 +48,9 @@ public class PowerDebugger extends TEPattern implements UIDeviceControls<PowerDe
     private HashMap<String, Double> panelJboxTotalCurrent; // panel + powerbox -> total current from pow to panel
     private HashMap<String, Double> panelTotalCurrent; // panelID -> total current
 
+    // lazy load this pattern only if used
+    private boolean loaded = false;
+
 
     // powerbox -> sum of LEDs
     private HashMap<String, Double> pow2totalLEDs;
@@ -70,8 +73,6 @@ public class PowerDebugger extends TEPattern implements UIDeviceControls<PowerDe
         panelJboxTotalCurrent = new HashMap<>();
 
         powerboxIDsList = new ArrayList<>();
-
-        load();
     }
 
     /**
@@ -316,6 +317,16 @@ public class PowerDebugger extends TEPattern implements UIDeviceControls<PowerDe
         Collections.sort(powerboxIDsList);
 
         powerboxSelect.setRange(0, powerboxIDsSet.size());
+
+        this.loaded = true;
+    }
+
+    @Override
+    protected void onActive() {
+        if (!loaded) {
+            load();
+        }
+        super.onActive();
     }
 
     @Override


### PR DESCRIPTION
Updated Note: Should've mentioned before, this is mostly for my own education, and I made some guesses / could be all kinds of wrong, happy to scrap some to all of it :) Thanks for looking!

Hello! Amazing work! Was getting some error exceptions and message boxes on running, pasted below. Switched to lazy loading for those patterns, plus saw this [note](https://github.com/titanicsend/LXStudio-TE/blob/c26a6cfa992d7bb0512e58b4f68501d8cf302c9e/src/main/java/titanicsend/pattern/TEPattern.java#L78) re: colors array not existing at instantiation for newer LXS versions, so added check

```
Caused by: java.lang.Error: resources/vehicle/power_assignments.tsv not found below /private/tmp/LXStudio-TE
	at titanicsend.model.TEWholeModel.loadFilePrivate(TEWholeModel.java:171)
	at titanicsend.model.TEWholeModel.loadFile(TEWholeModel.java:176)
	at titanicsend.pattern.will.PowerDebugger.load(PowerDebugger.java:219)
	at titanicsend.pattern.will.PowerDebugger.<init>(PowerDebugger.java:74)
Caused by: java.lang.Error: edge_signal_paths.tsv not found
	at titanicsend.pattern.jeff.SignalDebugger.loadChains(SignalDebugger.java:143)
	at titanicsend.pattern.jeff.SignalDebugger.<init>(SignalDebugger.java:76)
```
And many like this for SolidPanel, Bubbles, ResizeableScreen:
```
Caused by: java.lang.NullPointerException: Cannot store to int array because "this.colors" is null
	at titanicsend.pattern.alex.ResizeableScreen.paint(ResizeableScreen.java:98)
	at titanicsend.pattern.alex.ResizeableScreen.sizeAndPaintScreen(ResizeableScreen.java:118)
	at titanicsend.pattern.alex.ResizeableScreen.<init>(ResizeableScreen.java:128)
```