### PR TITLE
Reduce pattern run loop entry points from two to one

### DIFF
--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -67,11 +67,16 @@ public abstract class TEAudioPattern extends TEPattern {
     }
 
     @Override
-    protected void run(double deltaMs) {
+    protected final void run(double deltaMs) {
         computeAudio(deltaMs);
         runTEAudioPattern(deltaMs);
     }
 
+    /**
+     * New main loop method.  Subclasses must implement.
+     *
+     * @param deltaMs Number of milliseconds elapsed since last invocation
+     */
     protected abstract void runTEAudioPattern(double deltaMs);
 
     /** Call computeAudio() in a TEAudioPattern's run() once per frame to
@@ -79,7 +84,7 @@ public abstract class TEAudioPattern extends TEPattern {
      *
      * @param deltaMs elapsed time since last frame, as provided in run(deltaMs)
      */
-    public void computeAudio(double deltaMs) {
+    private void computeAudio(double deltaMs) {
         // Instantaneous normalized (0..1) volume level
         volumeLevel = eq.getNormalizedf();
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -1029,7 +1029,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     protected void onWowTrigger(boolean on) {  }
 
     @Override
-    protected void run(double deltaMs) {
+    protected void runTEAudioPattern(double deltaMs) {
         // get the current tempo in beats per second
         double bps = lx.engine.tempo.bpm() / 60;
 
@@ -1065,8 +1065,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         // Gradients always need to be up to date for TEColorParameter
         updateGradients();
         expireColors();
-
-        super.run(deltaMs);
     }
 
     @Override

--- a/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
+++ b/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
@@ -1,7 +1,6 @@
 package titanicsend.pattern.jon;
 
 import heronarts.lx.LX;
-import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEPerformancePattern;
 
 /**
@@ -49,8 +48,7 @@ public abstract class DriftEnabledPattern extends TEPerformancePattern {
     }
 
     @Override
-    protected void run(double deltaMs) {
-        computeAudio(deltaMs);
+    protected void runTEAudioPattern(double deltaMs) {
         updateTranslation(deltaMs);
         super.run(deltaMs);
     }

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -35,7 +35,8 @@ public class TurbulenceLines extends DriftEnabledPattern {
     }
 
     @Override
-    public void runTEAudioPattern(double deltaMs) {
+    protected void runTEAudioPattern(double deltaMs) {
+        super.runTEAudioPattern(deltaMs);
 
         // calculate incremental transform based on elapsed time
         shader.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());


### PR DESCRIPTION
@zranger1 TEAudioPattern was adding a second run loop without disabling the first, making it possible for child classes to call the wrong one or to call computeAudio() a second time.  What do you think about this method of forcing them onto the right track?