### PR TITLE
Add backing opacity adjustment to TE UI controls, default to 100%

### DIFF
--- a/src/main/java/titanicsend/app/TEVirtualOverlays.java
+++ b/src/main/java/titanicsend/app/TEVirtualOverlays.java
@@ -4,6 +4,8 @@ import java.util.*;
 
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.LXParameter.Units;
 import heronarts.lx.transform.LXVector;
 import heronarts.p4lx.ui.UI;
 import processing.core.PGraphics;
@@ -38,6 +40,11 @@ public class TEVirtualOverlays extends TEUIComponent {
                   .setDescription("Toggle whether to render the back of lit panels as opaque")
                   .setValue(true);
 
+  public final CompoundParameter backingOpacity =
+          new CompoundParameter("Backing Opacity", 1, 0, 1)
+                  .setUnits(Units.PERCENT_NORMALIZED)
+                  .setDescription("Sets the opacity of the panel backings, when On");
+
   public final BooleanParameter powerBoxesVisible =
           new BooleanParameter("Power boxes")
                   .setDescription("Toggle whether to show power boxes")
@@ -69,6 +76,7 @@ public class TEVirtualOverlays extends TEUIComponent {
     addParameter("panelLabelsVisible", this.panelLabelsVisible);
     addParameter("unknownPanelsVisible", this.unknownPanelsVisible);
     addParameter("opaqueBackPanelsVisible", this.opaqueBackPanelsVisible);
+    addParameter("backingOpacity", this.backingOpacity);
     addParameter("powerBoxesVisible", this.powerBoxesVisible);
     this.laserPOV = new ArrayList<>();
     for (int i = 0; i < numPOVs; i++) {
@@ -140,6 +148,8 @@ public class TEVirtualOverlays extends TEUIComponent {
     if (this.powerBoxesVisible.isOn())
       this.opaqueBackPanelsVisible.setValue(false);
 
+    final int backingOpacity = (int) (this.backingOpacity.getNormalized() * 255);
+
     beginDraw(ui, pg);
     pg.noStroke();
     pg.textSize(40);
@@ -205,7 +215,7 @@ public class TEVirtualOverlays extends TEUIComponent {
 
       if (this.opaqueBackPanelsVisible.isOn() && p.panelType.equals(TEPanelModel.LIT)) {
         LXVector[] inner = p.offsetTriangles.inner;
-        pg.fill(LXColor.rgb(0,0,0), 230);
+        pg.fill(LXColor.rgb(0,0,0), backingOpacity);
         pg.beginShape();
         pg.vertex(inner[0].x, inner[0].y, inner[0].z);
         pg.vertex(inner[1].x, inner[1].y, inner[1].z);


### PR DESCRIPTION
TE UI panel backings were partially see-through which was visually more apparent after switching to GLPointCloud mode.  Added a UI adjustment for opacity and defaulted it to full opaque.

Before, with default point size of 3:
<img width="141" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/e60cda07-300d-4856-b581-41cfb753206a">

After, with point size of 8:
<img width="160" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/0f8b6e3f-d0fb-44e4-aab7-7ae30c866a13">
![image](https://github.com/titanicsend/LXStudio-TE/assets/6582491/7a971182-2b1e-4e35-80fd-f3bf478678f4)

*It's actually still showing through a fuzz at low angles, such as the outer edges.  But at least it's a little improved.
<img width="133" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/82a7317d-3220-42ed-aead-f93e09c0b192">

