### PR TITLE
Change public methods to protected

### DIFF
--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -79,7 +79,7 @@ public abstract class TEAudioPattern extends TEPattern {
      *
      * @param deltaMs elapsed time since last frame, as provided in run(deltaMs)
      */
-    public void computeAudio(double deltaMs) {
+    protected void computeAudio(double deltaMs) {
         // Instantaneous normalized (0..1) volume level
         volumeLevel = eq.getNormalizedf();
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -839,7 +839,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     }
 
     @Override
-    public void onActive() {
+    protected void onActive() {
       // Finally safe to assume a channel has been assigned
       this.controls.viewParameter.link();
       super.onActive();


### PR DESCRIPTION
Fix error in main, `TEPerformancePattern.onActive()` need to be `protected`.

Also change `TEAudioPattern.computeAudio()` to `protected`, doesn't seem like it needs to be `public`.