### PR TITLE
Remove redundant updateGradients() calls

### DIFF
--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
@@ -54,7 +54,6 @@ public class PixelblazeParallel extends TEPerformancePattern {
     if (wrappers.size() == 0)
       return;
     try {
-      updateGradients();
       ArrayList<Future<Void>> futures = new ArrayList<>(wrappers.size());
       for (Wrapper wrapper : wrappers) {
         futures.add(es.submit((Callable<Void>) () -> {

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
@@ -72,7 +72,6 @@ public abstract class PixelblazePort extends TEPerformancePattern {
 
 
     public void runTEAudioPattern(double deltaMs) {
-        updateGradients();
         updateLocalVars();
         beforeRender(deltaMs);
 


### PR DESCRIPTION
... in classes extending TEPerformancePattern.

Simple cleanup.  Classes now inheriting from `TEPerformancePattern` no longer need to call `updateGradients()` themselves.