### PR TITLE
Clean up pattern list in UI for performance

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -52,6 +52,7 @@ import titanicsend.model.justin.ViewCentral;
 import titanicsend.output.GPOutput;
 import titanicsend.output.GrandShlomoStation;
 import titanicsend.pattern.TEEdgeTestPattern;
+import titanicsend.pattern.TEMidiFighter64DriverPattern;
 import titanicsend.pattern.TEPanelTestPattern;
 import titanicsend.pattern.ben.*;
 import titanicsend.pattern.jeff.*;
@@ -183,6 +184,7 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.registry.addPattern(PBFireworkNova.class);
     lx.registry.addPattern(PixelblazeParallel.class);
     lx.registry.addPattern(SimplexPosterized.class);
+    lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
     lx.registry.addPattern(TESparklePattern.class);
     lx.registry.addPattern(TurbulenceLines.class);
     lx.registry.addPattern(TriangleNoise.class);
@@ -218,7 +220,7 @@ public class TEApp extends PApplet implements LXPlugin {
 
     // Nonfunctional - need work or additional hardware that will not be at EDC
     // lx.registry.addPattern(HandTracker.class);
-    // lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
+
     // "ShaderToyPattern" in ShaderPanelsPatternConfig.java
 
     // Useful for test, but might turn the car black in performance

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -38,6 +38,7 @@ import heronarts.lx.LX;
 import heronarts.lx.LXPlugin;
 import heronarts.lx.pattern.LXPattern;
 import heronarts.lx.pattern.color.GradientPattern;
+import heronarts.lx.pattern.form.PlanesPattern;
 import heronarts.lx.pattern.texture.NoisePattern;
 import heronarts.lx.pattern.texture.SparklePattern;
 import heronarts.lx.studio.LXStudio;
@@ -51,24 +52,19 @@ import titanicsend.model.justin.ViewCentral;
 import titanicsend.output.GPOutput;
 import titanicsend.output.GrandShlomoStation;
 import titanicsend.pattern.TEEdgeTestPattern;
-import titanicsend.pattern.TEMidiFighter64DriverPattern;
 import titanicsend.pattern.TEPanelTestPattern;
 import titanicsend.pattern.ben.*;
-import titanicsend.pattern.cesar.*;
 import titanicsend.pattern.jeff.*;
 import titanicsend.pattern.jon.*;
 import titanicsend.pattern.justin.TEGradientPattern;
 import titanicsend.pattern.justin.TESolidPattern;
 import titanicsend.pattern.mike.*;
 import titanicsend.pattern.pixelblaze.*;
-import titanicsend.pattern.tmc.*;
 import titanicsend.pattern.tom.*;
 import titanicsend.pattern.will.PowerDebugger;
 import titanicsend.pattern.yoffa.config.OrganicPatternConfig;
 import titanicsend.pattern.yoffa.config.ShaderEdgesPatternConfig;
 import titanicsend.pattern.yoffa.effect.BeaconEffect;
-import titanicsend.pattern.yoffa.media.BasicImagePattern;
-import titanicsend.pattern.yoffa.media.ReactiveHeartPattern;
 import titanicsend.ui.UITEPerformancePattern;
 import titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig;
 import titanicsend.util.TE;
@@ -167,7 +163,6 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.registry.addPattern(ArcEdges.class);
     lx.registry.addPattern(BassLightning.class);
     lx.registry.addPattern(BouncingDots.class);
-    lx.registry.addPattern(Bubbles.class);
     lx.registry.addPattern(Checkers.class);
     lx.registry.addPattern(EdgeFall.class);
     lx.registry.addPattern(EdgeKITT.class);
@@ -188,22 +183,16 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.registry.addPattern(PBFireworkNova.class);
     lx.registry.addPattern(PixelblazeParallel.class);
     lx.registry.addPattern(SimplexPosterized.class);
-    lx.registry.addPattern(SolidEdge.class);
-    lx.registry.addPattern(SolidPanel.class);
     lx.registry.addPattern(TESparklePattern.class);
     lx.registry.addPattern(TurbulenceLines.class);
     lx.registry.addPattern(TriangleNoise.class);
     lx.registry.addPattern(SpiralDiamonds.class);
     lx.registry.addPattern(PulsingTriangles.class);
-    lx.registry.addPattern(HandTracker.class);
     lx.registry.addPattern(Fire.class);
-    lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
     lx.registry.addPattern(TESolidPattern.class);
     lx.registry.addPattern(TEGradientPattern.class);
 
     // Patterns that will not aspire to art direction standards
-    lx.registry.addPattern(BasicImagePattern.class);
-    lx.registry.addPattern(ReactiveHeartPattern.class);
 
     // Examples for teaching and on-boarding developers
     lx.registry.addPattern(BasicRainbowPattern.class);
@@ -212,9 +201,33 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.registry.addPattern(TempoReactiveEdge.class);
     lx.registry.addPattern(ArtStandards.class);
     lx.registry.addEffect(titanicsend.effect.EdgeSieve.class);
-    lx.registry.addEffect(titanicsend.effect.Kaleidoscope.class);
     lx.registry.addEffect(titanicsend.effect.NoGapEffect.class);
     lx.registry.addEffect(BeaconEffect.class);
+
+
+    // TODO - The following patterns were removed from the UI prior to EDC 2023 to keep
+    // TODO - them from being accidentally activated during a performance.
+    // TODO - update/fix as needed!
+
+    // Nonfunctional - throws exception on load
+    // lx.registry.addPattern(ReactiveHeartPattern.class);
+    // lx.registry.addPattern(SolidPanel.class);
+    // lx.registry.addPattern(SolidEdge.class);
+    // lx.registry.addPattern(BasicImagePattern.class);
+    // lx.registry.addPattern(Bubbles.class);
+
+    // Nonfunctional - need work or additional hardware that will not be at EDC
+    // lx.registry.addPattern(HandTracker.class);
+    // lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
+    // "ShaderToyPattern" in ShaderPanelsPatternConfig.java
+
+    // Useful for test, but might turn the car black in performance
+    lx.registry.removePattern(PlanesPattern.class);  // remove pattern added automatically by LX.
+
+    // Frame Rate Killers
+    // lx.registry.addEffect(titanicsend.effect.Kaleidoscope.class);
+    // "StarryOutrun" in OrganicPatternConfig.java
+
 
     @SuppressWarnings("unchecked")
     Function<Class<?>, Class<LXPattern>[]> patternGetter =

--- a/src/main/java/titanicsend/pattern/jeff/Smoke.java
+++ b/src/main/java/titanicsend/pattern/jeff/Smoke.java
@@ -21,7 +21,7 @@ import titanicsend.pattern.TEAudioPattern;
  *   - Cache everything; compute everything at the highest level (least frequent)
  */
 
-@LXCategory("Combo FG")
+@LXCategory("TE Examples")
 public class Smoke extends TEAudioPattern {
     public final LinkedColorParameter color =
             registerColor("Color", "color", ColorType.PRIMARY,

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -2,7 +2,6 @@ package titanicsend.pattern.yoffa.config;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
-import heronarts.lx.parameter.CompoundParameter;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.will.shaders.*;
 import titanicsend.pattern.yoffa.effect.*;
@@ -10,7 +9,6 @@ import titanicsend.pattern.yoffa.effect.shaders.*;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
 import titanicsend.pattern.yoffa.framework.PatternTarget;
-import titanicsend.pattern.yoffa.effect.shaders.OutrunGridShader;
 import titanicsend.pattern.yoffa.media.BasicVideoPatternEffect;
 
 import java.util.List;
@@ -18,6 +16,7 @@ import java.util.List;
 @SuppressWarnings("unused")
 public class OrganicPatternConfig {
 
+    /*  Removed from UI - see TEApp.java for details.
     @LXCategory("Yoffa Panel Combo")
     public static class StarryOutrun extends ConstructedPattern {
         public StarryOutrun(LX lx) {
@@ -33,6 +32,7 @@ public class OrganicPatternConfig {
             );
         }
     }
+   */
 
     @LXCategory("Yoffa Panel Shader")
     public static class RainbowSwirlPanels extends ConstructedPattern {

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
@@ -4,7 +4,6 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
-import titanicsend.pattern.yoffa.effect.ShaderToyPatternEffect;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
 import titanicsend.pattern.yoffa.framework.PatternTarget;

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -6,17 +6,16 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.NativeShaderPatternEffect;
-import titanicsend.pattern.yoffa.effect.ShaderToyPatternEffect;
 import titanicsend.pattern.yoffa.framework.ConstructedPattern;
 import titanicsend.pattern.yoffa.framework.PatternEffect;
 import titanicsend.pattern.yoffa.framework.PatternTarget;
-import titanicsend.pattern.yoffa.shader_engine.ShaderOptions;
 
 import java.util.List;
 
 @SuppressWarnings("unused")
 public class ShaderPanelsPatternConfig {
 
+    /* Removed from UI - see TEApp.java for details.
     @LXCategory("Native Shaders Panels")
     public static class ShaderToyPattern extends ConstructedPattern {
         public ShaderToyPattern(LX lx) {
@@ -28,6 +27,8 @@ public class ShaderPanelsPatternConfig {
             return List.of(new ShaderToyPatternEffect(PatternTarget.splitPanelSections(this)));
         }
     }
+
+    */
 
     //multiple
     @LXCategory("Native Shaders Panels")
@@ -233,7 +234,7 @@ public class ShaderPanelsPatternConfig {
         }
     }
 
-    @LXCategory("Test")
+    @LXCategory("Native Shaders Panels")
     public static class AudioTest2 extends ConstructedPattern {
         public AudioTest2(LX lx) {
             super(lx);


### PR DESCRIPTION
Went through the pattern list and cleaned up everything that might cause an exception, a performance issue, or a black car during a show.   Patterns moved and removed are listed in a commented section of TEApp.java, so we can go back and fix them as necessary.

### Here's what got changed, and why:

**Pattern Broken - Throws Exceptions**
- ReactiveHeart 
- SolidPanel 
- SolidEdge 
- BasicImage 
- Bubbles

**Not Currently Functional**

- HandTracker - not functional w/o extra hardware
- ShaderToy -  Not supporting random internet imports for now. 
- Planes - may be useful for test, but can turn the car black

Frame Rate Killers

- Kaleidoscope effect: huge impact on framerate -- drops mine to about 17 
- StarryOutrun - demo made w/two Java shader ports.  Frame rate killer.


### Additional Notes:

**Video Patterns:**
 These actually work if people want to provide videos and use them, but no controls, no reactivity. 

**Moved:**
- AudioTest2 pattern from Test category to Native Shaders Panels so it can be reached w/ less scrolling.  It isn't actually a test program anymore, but I can't rename it w/o breaking AutoVJ.
- Original Smoke pattern moved from Combo FG to TE Examples. It is a nice example of performance optimization of a complex Java pattern.  I'd highly recommed pattern authors take a look at this code. But it is still not quite fast enough for regular use. And we now have SmokeShader for use in perfomance.

**Unfinished Patterns:**
 (Basically everything  not flagged "done" in Notion)  These patterns work, and possibly have useful visuals, but they're non-palette compliant and don't work with the common controls.  Still, might be good for occasional use.
