### PR TITLE
Add per-channel color swatch selection

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -48,6 +48,7 @@ import titanicsend.lasercontrol.TELaserTask;
 import titanicsend.lx.APC40Mk2;
 import titanicsend.lx.MidiFighterTwister;
 import titanicsend.model.TEWholeModel;
+import titanicsend.model.justin.ColorCentral;
 import titanicsend.model.justin.ViewCentral;
 import titanicsend.output.GPOutput;
 import titanicsend.output.GrandShlomoStation;
@@ -88,9 +89,11 @@ public class TEApp extends PApplet implements LXPlugin {
 
   private TELaserTask laserTask;
   
+  private ColorCentral colorCentral;
   private ViewCentral viewCentral;
 
   // Global feature on/off switches for troubleshooting
+  public static final boolean ENABLE_COLOR_CENTRAL = true;
   public static final boolean ENABLE_VIEW_CENTRAL = true;
   public static final boolean DELAY_FILE_OPEN_TO_FIRST_ENGINE_LOOP = true;
 
@@ -310,6 +313,9 @@ public class TEApp extends PApplet implements LXPlugin {
     GPOutput gpOutput = new GPOutput(lx, this.gpBroadcaster);
     lx.addOutput(gpOutput);
     
+    // Add special per-channel swatch control.  Do not try this at home.
+    this.colorCentral = new ColorCentral(lx);
+
     // Add special view controller
     this.viewCentral = new ViewCentral(lx);
   }

--- a/src/main/java/titanicsend/model/justin/ChannelExtension.java
+++ b/src/main/java/titanicsend/model/justin/ChannelExtension.java
@@ -20,6 +20,7 @@
 
 package titanicsend.model.justin;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,7 +137,11 @@ public abstract class ChannelExtension<T extends LXComponent> extends LXComponen
   public T get(LXAbstractChannel channel) {
     return items.get(channel);
   }
-  
+
+  public Collection<T> getAll() {
+    return items.values();
+  }
+
   @Override
   public void dispose() {
     this.lx.engine.mixer.removeListener(this.mixerListener);

--- a/src/main/java/titanicsend/model/justin/ColorCentral.java
+++ b/src/main/java/titanicsend/model/justin/ColorCentral.java
@@ -1,0 +1,190 @@
+/**
+ * Licensing Notes (JKB)
+ *
+ * As this is a variation of ViewCentral:
+ * The expected permanent home for this concept and its derivatives is the LX Studio
+ * software library or a LX Studio / Chromatik extension distributed by JKB.
+ *
+ * Due to time constraints, doing a first release of this code in either
+ * of the above code bases would add too much delay to be usable
+ * for the immediate TE events.
+ *
+ * It is acknowledged that by releasing the code here, the TE code base may
+ * continue to use this original version in perpetuity.
+ * It is also the stated intent that the long-term license for this code
+ * and its derivatives will be the LX Studio Software License and
+ * Distribution Agreement (http://lx.studio/license), or another license
+ * as determined by the author. 
+ *
+ * @author Justin Belcher <jkbelcher@gmail.com>
+ */
+
+package titanicsend.model.justin;
+
+import java.util.ArrayList;
+import java.util.List;
+import heronarts.lx.LX;
+import heronarts.lx.LXModelComponent;
+import heronarts.lx.color.LXPalette;
+import heronarts.lx.color.LXSwatch;
+import heronarts.lx.mixer.LXAbstractChannel;
+import heronarts.lx.parameter.LXParameterListener;
+import titanicsend.app.TEApp;
+
+public class ColorCentral extends ChannelExtension<titanicsend.model.justin.ColorCentral.ColorPerChannel> implements LXPalette.Listener {
+
+  /*
+   * Static
+   */
+  static public final boolean ENABLED = TEApp.ENABLE_COLOR_CENTRAL;
+  
+  static public final int CURRENT_SWATCH_INDEX = -1;
+
+  static public interface ColorCentralListener {
+    abstract public void ColorCentralLoaded();
+  }
+
+  // Static central reference keeps imports looking clean
+  private static ColorCentral current;
+  public static ColorCentral get() {
+    return current;
+  }
+
+  public static boolean isLoaded() {
+    return current != null;
+  }
+
+  static private final List<ColorCentralListener> listenersOnce = new ArrayList<ColorCentralListener>();
+
+  static public void listenOnce(ColorCentralListener listener) {
+    listenersOnce.add(listener);
+  }
+
+  static private void notifyListeners() {
+    for (int i = listenersOnce.size()-1; i>=0; --i) {
+      listenersOnce.remove(i).ColorCentralLoaded();
+    }
+  }
+
+  /*
+   * Non-static
+   */
+
+  protected List<SwatchDefinition> swatches;
+
+  public ColorCentral(LX lx) {
+    super(lx);
+    current = this;
+
+    this.lx.engine.palette.addListener(this);
+
+    notifyListeners();
+  }
+
+  /**
+   * Called by parent constructor before current channels are added
+   */
+  @Override
+  protected void initialize() {
+    createSwatchDefinitions();
+  }
+  
+  private void createSwatchDefinitions() {
+    if (this.swatches == null) {
+      this.swatches = new ArrayList<SwatchDefinition>();
+    } else {
+      this.swatches.clear();
+    }
+
+    // 1) Top Level, view=off
+    this.swatches.add(new SwatchDefinition("CURRENT", CURRENT_SWATCH_INDEX));
+
+    // Global off switch for feature
+    if (!ColorCentral.ENABLED) {
+      return;
+    }
+
+    // 2) All other swatches in the global palette
+    int i = 0;
+    for (LXSwatch s : this.lx.engine.palette.swatches) {
+      this.swatches.add(new SwatchDefinition(s.getLabel(), i++));
+    }
+  }
+  
+  @Override
+  protected ColorPerChannel createItem(LXAbstractChannel channel) {
+    return new ColorPerChannel(this.lx);
+  }
+
+  public LXSwatch getSwatch(SwatchDefinition swatchDefinition) {
+    if (swatchDefinition.index == CURRENT_SWATCH_INDEX) {
+      return this.lx.engine.palette.swatch;
+    } else {
+      if (swatchDefinition.index >= this.lx.engine.palette.swatches.size()) {
+        return this.lx.engine.palette.swatches.get(this.lx.engine.palette.swatches.size() - 1);
+      }
+      return this.lx.engine.palette.swatches.get(swatchDefinition.index);
+    }
+  }
+
+  // LXPalette.Listener methods
+
+  @Override
+  public void swatchAdded(LXPalette palette, LXSwatch swatch) {
+    // Quick hack solution.  Improve later.
+    createSwatchDefinitions();
+  }
+
+  @Override
+  public void swatchRemoved(LXPalette palette, LXSwatch swatch) {
+    // Quick hack solution.  Improve later.
+    createSwatchDefinitions();
+  }
+
+  @Override
+  public void swatchMoved(LXPalette palette, LXSwatch swatch) {
+    // TODO: update parameters to follow their selected swatch
+  }
+
+  @Override
+  public void dispose() {
+    this.lx.engine.palette.removeListener(this);
+    super.dispose();
+  }
+
+  /**
+   * One of these will be created per LX channel.
+   * A list of all instances is maintained by the ViewCentral class.
+   */
+  public class ColorPerChannel extends LXModelComponent {
+
+    public final SwatchParameter selectedSwatch;
+    
+    private final LXParameterListener selectedSwatchListener = (p) -> {
+      onSelectedSwatchChanged();
+    };
+
+    protected ColorPerChannel(LX lx) {
+      super(lx);
+
+      this.selectedSwatch = new SwatchParameter("Swatch", getSwatches());
+      addParameter("view", this.selectedSwatch);      
+      this.selectedSwatch.addListener(selectedSwatchListener);
+    }
+
+    private SwatchDefinition[] getSwatches() {
+      // No custom entries here as there are with ViewCentral.
+      return swatches.toArray(new SwatchDefinition[0]);
+    }
+    
+    protected void onSelectedSwatchChanged() {
+      
+    }
+    
+    @Override
+    public void dispose() {
+      this.selectedSwatch.removeListener(selectedSwatchListener);
+      super.dispose();
+    }
+  }
+}

--- a/src/main/java/titanicsend/model/justin/ColorCentral.java
+++ b/src/main/java/titanicsend/model/justin/ColorCentral.java
@@ -29,6 +29,7 @@ import heronarts.lx.color.LXPalette;
 import heronarts.lx.color.LXSwatch;
 import heronarts.lx.mixer.LXAbstractChannel;
 import heronarts.lx.parameter.LXParameterListener;
+import heronarts.lx.studio.LXStudio;
 import titanicsend.app.TEApp;
 
 public class ColorCentral extends ChannelExtension<titanicsend.model.justin.ColorCentral.ColorPerChannel> implements LXPalette.Listener {
@@ -113,7 +114,7 @@ public class ColorCentral extends ChannelExtension<titanicsend.model.justin.Colo
   
   @Override
   protected ColorPerChannel createItem(LXAbstractChannel channel) {
-    return new ColorPerChannel(this.lx);
+    return new ColorPerChannel(this.lx, channel);
   }
 
   public LXSwatch getSwatch(SwatchDefinition swatchDefinition) {
@@ -164,8 +165,11 @@ public class ColorCentral extends ChannelExtension<titanicsend.model.justin.Colo
       onSelectedSwatchChanged();
     };
 
-    protected ColorPerChannel(LX lx) {
+    private LXAbstractChannel channel;
+
+    protected ColorPerChannel(LX lx, LXAbstractChannel channel) {
       super(lx);
+      this.channel = channel;
 
       this.selectedSwatch = new SwatchParameter("Swatch", getSwatches());
       addParameter("view", this.selectedSwatch);      
@@ -178,7 +182,9 @@ public class ColorCentral extends ChannelExtension<titanicsend.model.justin.Colo
     }
     
     protected void onSelectedSwatchChanged() {
-      
+      if (this.lx instanceof LXStudio) {
+        ((LXStudio) lx).ui.setMouseoverHelpText(channel.getLabel() + "   Swatch:  " + this.selectedSwatch.getObject());
+      }
     }
     
     @Override

--- a/src/main/java/titanicsend/model/justin/LXVirtualDiscreteParameter.java
+++ b/src/main/java/titanicsend/model/justin/LXVirtualDiscreteParameter.java
@@ -21,6 +21,7 @@ package titanicsend.model.justin;
 import heronarts.lx.LX;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 
 /**
@@ -215,6 +216,15 @@ abstract public class LXVirtualDiscreteParameter<T extends DiscreteParameter> ex
       return this.parameter.getValuei();
     }
     return super.getValuei();
+  }
+
+  @Override
+  public LXParameter reset() {
+      if (this.parameter != null) {
+          this.parameter.reset();
+          return this;
+      }
+      return this;
   }
 
   @Override

--- a/src/main/java/titanicsend/model/justin/SwatchDefinition.java
+++ b/src/main/java/titanicsend/model/justin/SwatchDefinition.java
@@ -1,0 +1,18 @@
+package titanicsend.model.justin;
+
+public class SwatchDefinition {
+
+  public final String label;
+  public final int index;
+
+  public SwatchDefinition(String label, int index) {
+    this.label = label;
+    this.index = index;
+  }
+
+  @Override
+  public String toString() {
+    return this.label;
+  }
+
+}

--- a/src/main/java/titanicsend/model/justin/SwatchParameter.java
+++ b/src/main/java/titanicsend/model/justin/SwatchParameter.java
@@ -1,0 +1,65 @@
+package titanicsend.model.justin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import heronarts.lx.parameter.ObjectParameter;
+
+public class SwatchParameter extends ObjectParameter<SwatchDefinition> {
+
+  public interface Listener {
+    public void swatchesChanged(SwatchParameter parameter);
+  }
+
+  private final List<Listener> listeners = new ArrayList<Listener>();
+
+  public SwatchParameter(String label, SwatchDefinition[] objects) {
+    super(label, objects);
+    setIncrementMode(IncrementMode.RELATIVE);
+    setWrappable(false);
+  }
+
+  @Override
+  public ObjectParameter<SwatchDefinition> setObjects(SwatchDefinition[] objects) {
+    super.setObjects(objects);
+    return this;
+  }
+
+  // Listener management code sourced from LXPalette
+
+  /**
+   * Registers a listener
+   *
+   * @param listener Parameter listener
+   * @return this
+   */
+  public SwatchParameter addListener(Listener listener) {
+    Objects.requireNonNull(listener);
+    if (this.listeners.contains(listener)) {
+      throw new IllegalStateException("Cannot add duplicate SelectedSwatchParameter.Listener: " + listener);
+    }
+    this.listeners.add(listener);
+    return this;
+  }
+
+  /**
+   * Unregisters a listener
+   *
+   * @param listener Parameter listener
+   * @return this
+   */
+  public SwatchParameter removeListener(Listener listener) {
+    if (!this.listeners.contains(listener)) {
+      throw new IllegalStateException("May not remove non-registered SelectedSwatchParameter.Listener: " + listener);
+    }
+    this.listeners.add(listener);
+    return this;
+  }
+
+  protected void notifyListeners() {
+    for (Listener listener : this.listeners) {
+      listener.swatchesChanged(this);
+    }
+  }
+}

--- a/src/main/java/titanicsend/model/justin/ViewCentral.java
+++ b/src/main/java/titanicsend/model/justin/ViewCentral.java
@@ -204,7 +204,7 @@ public class ViewCentral extends ChannelExtension<titanicsend.model.justin.ViewC
       this.channel.setModel(getModel());
 
       if (this.lx instanceof LXStudio) {
-        ((LXStudio) lx).ui.setMouseoverHelpText(channel.getLabel() + ":  " + this.view.getObject().toString());
+        ((LXStudio) lx).ui.setMouseoverHelpText(channel.getLabel() + "   View:  " + this.view.getObject().toString());
       }
     }
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -629,7 +629,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         }
 
         protected LXListenableNormalizedParameter getSwatchRemoteControl() {
-            if (ViewCentral.ENABLED) {
+            if (ColorCentral.ENABLED) {
                 return swatchParameter;
             } else {
                 return getControl(TEControlTag.BRIGHTNESS).control;
@@ -867,11 +867,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     private void linkChannelParameters(LX lx) {
         // Finally safe to assume a channel has been assigned
         this.controls.viewParameter.link();
-    }
-
-    @Override
-    protected void onActive() {
-      super.onActive();
     }
 
     public TECommonControls getControls() {

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -11,6 +11,7 @@ import heronarts.lx.parameter.BooleanParameter.Mode;
 import heronarts.lx.utils.LXUtils;
 import titanicsend.lx.LXGradientUtils;
 import titanicsend.lx.LXGradientUtils.BlendFunction;
+import titanicsend.model.justin.ColorCentral;
 import titanicsend.model.justin.LXVirtualDiscreteParameter;
 import titanicsend.model.justin.ViewCentral;
 import titanicsend.model.justin.ViewCentral.ViewCentralListener;
@@ -391,6 +392,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
       return null;
     }
 
+
     // ANGLE PARAMETER
 
     // Create new class for Angle control so we can override the reset
@@ -586,6 +588,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
             addParameter("panic", this.panic);
             addParameter("viewPerChannel", this.viewParameter);
+            addParameter("swatchPerChannel", swatchParameter);
         }
 
         /**
@@ -605,7 +608,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             setCustomRemoteControls(new LXListenableNormalizedParameter[] {
                 this.color.offset,
                 this.color.gradient,
-                getControl(TEControlTag.BRIGHTNESS).control,
+                getSwatchRemoteControl(),
                 getControl(TEControlTag.SPEED).control,
 
                 getControl(TEControlTag.XPOS).control,
@@ -625,11 +628,19 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             });
         }
 
-        protected LXListenableNormalizedParameter getViewRemoteControl() {
-            if (!ViewCentral.ENABLED) {
-                return null;
+        protected LXListenableNormalizedParameter getSwatchRemoteControl() {
+            if (ViewCentral.ENABLED) {
+                return swatchParameter;
             } else {
+                return getControl(TEControlTag.BRIGHTNESS).control;
+            }
+        }
+
+        protected LXListenableNormalizedParameter getViewRemoteControl() {
+            if (ViewCentral.ENABLED) {
                 return this.viewParameter;
+            } else {
+                return null;
             }
         }
 
@@ -757,6 +768,10 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             getControl(TEControlTag.WOW2).control.reset();
             getControl(TEControlTag.WOWTRIGGER).control.reset();
 
+            if (ColorCentral.ENABLED) {
+                swatchParameter.reset();
+            }
+
             if (ViewCentral.ENABLED) {
                 this.viewParameter.reset();
             }
@@ -842,12 +857,20 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     protected TEPerformancePattern(LX lx) {
         super(lx);
         controls = new TECommonControls();
+
+        // Patterns are created, then added to channel. Channel should be available on next engine loop.
+        lx.engine.addTask(() -> {
+            linkChannelParameters(lx);
+        });
+    }
+
+    private void linkChannelParameters(LX lx) {
+        // Finally safe to assume a channel has been assigned
+        this.controls.viewParameter.link();
     }
 
     @Override
     protected void onActive() {
-      // Finally safe to assume a channel has been assigned
-      this.controls.viewParameter.link();
       super.onActive();
     }
 


### PR DESCRIPTION
This is a color safety net.  In short, I'm concerned about the color situation.  No one has ever VJ'd to a strict color palette like this, and I'm wary about fading a second channel in and not being able to achieve contrast if it's the same swatch as the first channel.

This puts a "Swatch" knob on the pattern (pass-through to the channel swatch), giving you the option to spin through all the swatches in the palette.  The first item is the global/current swatch, followed by the list.

![image](https://github.com/titanicsend/LXStudio-TE/assets/6582491/899ee6bb-f1b4-4791-ab8e-598ad0417aeb)

The brightness parameter got bumped, it is still available in code but it looks like the midi faders will be enough for brightness.

Note swatches other than current will not be oscillated.