### PR TITLE
Implement view-per-pattern

### DIFF
--- a/src/main/java/titanicsend/model/justin/ViewParameter.java
+++ b/src/main/java/titanicsend/model/justin/ViewParameter.java
@@ -1,9 +1,0 @@
-package titanicsend.model.justin;
-
-import java.util.Arrays;
-
-import heronarts.lx.model.LXModel;
-import heronarts.lx.parameter.ObjectParameter;
-import titanicsend.util.TE;
-
-

--- a/src/main/java/titanicsend/model/justin/ViewParameter.java
+++ b/src/main/java/titanicsend/model/justin/ViewParameter.java
@@ -2,40 +2,8 @@ package titanicsend.model.justin;
 
 import java.util.Arrays;
 
+import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.ObjectParameter;
 import titanicsend.util.TE;
 
-public class ViewParameter extends ObjectParameter<ViewDefinition> {
 
-  public ViewParameter(String label, ViewDefinition[] objects) {
-    super(label, objects);
-    setIncrementMode(IncrementMode.RELATIVE);
-    setWrappable(false);
-  }
-
-  /**
-   * Set to view with the matching label.
-   *
-   * If parameter is null, sets to default / no view
-   * If label is not found, does nothing
-   */
-  public ViewParameter setView(String label) {
-    return setView(label, false);
-  }
-
-  public ViewParameter setView(String label, boolean defaultOnNotFound) {
-    ViewDefinition view = null;
-    if (!TE.isEmpty(label)) {
-      view = Arrays.stream(getObjects())
-              .filter(v -> label.equals(v.label))
-              .findFirst()
-              .orElse(null);
-    }
-    if (view != null) {
-      setValue(view);
-    } else {
-      setValue(0);
-    }
-    return this;
-  }
-}

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -172,8 +172,12 @@ public abstract class TEPattern extends LXPattern {
 
   @Override
   protected void onModelChanged(LXModel model) {
-    // If the View changes, clear all pixels because some might not be used by the pattern
-    clearPixels();
+    // If the View changes, clear all pixels because some might not be used by the pattern.
+    // With view-per-pattern, this can now get called when pattern is inactive.
+    if (this.colors != null) {
+      // Active pattern
+      clearPixels();
+    }
     super.onModelChanged(model);
   }
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -616,7 +616,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             }
 
             addParameter("panic", this.panic);
-            addParameter("viewPerChannel", this.viewParameter);
             addParameter("viewPerPattern", viewPerPattern);
             addParameter("swatchPerChannel", swatchParameter);
         }
@@ -900,7 +899,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
         this.viewPerPattern.setDefault(getDefaultView(), true);
 
         lx.engine.addTask(() -> {
-            if (this.colors == null) {
+            if (this.controls.color == null) {
                 // Instantiation failed. Turn off now to avoid fatal call to null variables.
                 return;
             }

--- a/src/main/java/titanicsend/pattern/ben/XorceryDiamonds.java
+++ b/src/main/java/titanicsend/pattern/ben/XorceryDiamonds.java
@@ -13,12 +13,12 @@ import java.util.List;
 @LXCategory("Native Shaders Panels")
 public class XorceryDiamonds extends ConstructedPattern {
 	public XorceryDiamonds(LX lx) {
-		super(lx);
+		super(lx, TEShaderView.ALL_PANELS);
 	}
 
 	@Override
 	protected List<PatternEffect> createEffects() {
 		return List.of(new NativeShaderPatternEffect("xorcery_diamonds.fs",
-				new PatternTarget(this, TEShaderView.ALL_PANELS)));
+				new PatternTarget(this)));
 	}
 }

--- a/src/main/java/titanicsend/pattern/jon/ArcEdges.java
+++ b/src/main/java/titanicsend/pattern/jon/ArcEdges.java
@@ -21,7 +21,7 @@ public class ArcEdges extends TEPerformancePattern {
 
     // Constructor
     public ArcEdges(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         controls.setRange(TEControlTag.SIZE, 1, 5, 0.1);              // scale
         controls.setRange(TEControlTag.QUANTITY, 0.675, 0.72, 0.35);  // noise field position
@@ -32,7 +32,7 @@ public class ArcEdges extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("arcedges.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
 
         // create an n x 4 array, so we can pass line segment descriptors
         // to GLSL shaders.
@@ -88,8 +88,4 @@ public class ArcEdges extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
+++ b/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
@@ -1,8 +1,8 @@
 package titanicsend.pattern.jon;
 
 import heronarts.lx.LX;
-import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 /**
  * Class for patterns that need controllable continuous, unbounded
@@ -25,8 +25,8 @@ public abstract class DriftEnabledPattern extends TEPerformancePattern {
     private double xOffset = 0;
     private double yOffset = 0;
 
-    protected DriftEnabledPattern(LX lx) {
-        super(lx);
+    protected DriftEnabledPattern(LX lx, TEShaderView defaultView) {
+        super(lx, defaultView);
     }
 
     void updateTranslation(double deltaMs) {

--- a/src/main/java/titanicsend/pattern/jon/EdgeFall.java
+++ b/src/main/java/titanicsend/pattern/jon/EdgeFall.java
@@ -28,7 +28,7 @@ public class EdgeFall extends TEPerformancePattern {
 
     // Constructor
     public EdgeFall(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // Size controls line width/glow
         controls.setRange(TEControlTag.SIZE, 80, 200, 15);
@@ -41,7 +41,7 @@ public class EdgeFall extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("edgefall.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
 
         // create an n x 4 array, so we can pass line segment descriptors
         // to GLSL shaders.
@@ -169,8 +169,4 @@ public class EdgeFall extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
+++ b/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
@@ -4,6 +4,7 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 import titanicsend.util.TEColor;
 import titanicsend.util.TEMath;
 
@@ -14,7 +15,7 @@ import static titanicsend.util.TEMath.clamp;
 public class EdgeKITT extends TEPerformancePattern {
 
     public EdgeKITT(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         controls.setRange(TEControlTag.SIZE, 0.5, 0.01, 1.5);
 

--- a/src/main/java/titanicsend/pattern/jon/Electric.java
+++ b/src/main/java/titanicsend/pattern/jon/Electric.java
@@ -16,7 +16,7 @@ public class Electric extends TEPerformancePattern {
     NativeShader shader;
 
     public Electric(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.DOUBLE_LARGE);
 
         controls.setRange(TEControlTag.SPEED, 0.6, -1, 1);
         controls.setRange(TEControlTag.WOW1, 0, 0, 2.6);
@@ -27,7 +27,7 @@ public class Electric extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("electric.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE));
+                new PatternTarget(this));
     }
 
     @Override
@@ -49,8 +49,4 @@ public class Electric extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/ElectricEdges.java
+++ b/src/main/java/titanicsend/pattern/jon/ElectricEdges.java
@@ -14,7 +14,7 @@ public class ElectricEdges extends TEPerformancePattern {
     NativeShader shader;
 
     public ElectricEdges(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_EDGES);
 
         // Set control range -- this uses the same shader as the electric panel
         // pattern, but it is parameterized *very* differently.
@@ -29,7 +29,7 @@ public class ElectricEdges extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("electric.fs",
-                new PatternTarget(this, TEShaderView.ALL_EDGES));
+                new PatternTarget(this));
     }
 
     @Override
@@ -51,8 +51,4 @@ public class ElectricEdges extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/FollowThatStar.java
+++ b/src/main/java/titanicsend/pattern/jon/FollowThatStar.java
@@ -16,7 +16,7 @@ public class FollowThatStar extends TEPerformancePattern {
     NativeShader shader;
 
     public FollowThatStar(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
 
         // create new effect with alpha on and no automatic uniforms
@@ -34,7 +34,7 @@ public class FollowThatStar extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("followthatstar.fs",
-                new PatternTarget(this, TEShaderView.ALL_POINTS), options);
+                new PatternTarget(this), options);
     }
 
     @Override
@@ -56,8 +56,4 @@ public class FollowThatStar extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/FourStar.java
+++ b/src/main/java/titanicsend/pattern/jon/FourStar.java
@@ -36,7 +36,7 @@ public class FourStar extends TEPerformancePattern {
                     .setDescription("Oh boy...");
 
     public FourStar(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_PANELS);
 
         // create new effect with alpha on and no automatic
         // parameter uniforms
@@ -58,7 +58,7 @@ public class FourStar extends TEPerformancePattern {
         tempoDivision.bang();
 
         effect = new NativeShaderPatternEffect("fourstar.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS), options);
+                new PatternTarget(this), options);
     }
 
     @Override
@@ -110,11 +110,6 @@ public class FourStar extends TEPerformancePattern {
         tempoDivision.setWrappable(false);
 
         addParameter("tempoDivision", tempoDivision);
-    }
-
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
     }
 
 }

--- a/src/main/java/titanicsend/pattern/jon/Iceflow.java
+++ b/src/main/java/titanicsend/pattern/jon/Iceflow.java
@@ -40,7 +40,7 @@ public class Iceflow extends TEPerformancePattern {
                     .setDescription("Speed relative to beat");
 
     public Iceflow(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_PANELS);
 
         // create new effect with alpha on and no automatic
         // parameter uniforms
@@ -58,7 +58,7 @@ public class Iceflow extends TEPerformancePattern {
         addParameter("beatScale",beatScale);
 
         effect = new NativeShaderPatternEffect("iceflow.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS), options);
+                new PatternTarget(this), options);
 
     }
 
@@ -110,8 +110,4 @@ public class Iceflow extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/Phasers.java
+++ b/src/main/java/titanicsend/pattern/jon/Phasers.java
@@ -17,7 +17,7 @@ public class Phasers extends TEPerformancePattern {
     NativeShader shader;
 
     public Phasers(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_PANELS);
 
         // create new effect with alpha on and no automatic
         // parameter uniforms
@@ -51,7 +51,7 @@ public class Phasers extends TEPerformancePattern {
 
         // Create the underlying shader pattern
         effect = new NativeShaderPatternEffect("phasers.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS), options);
+                new PatternTarget(this), options);
     }
 
     @Override
@@ -77,8 +77,4 @@ public class Phasers extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/RadialSimplex.java
+++ b/src/main/java/titanicsend/pattern/jon/RadialSimplex.java
@@ -39,7 +39,7 @@ public class RadialSimplex extends TEPerformancePattern {
 
 
     public RadialSimplex(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // common controls setup
         controls.setRange(TEControlTag.SPEED, 0, -4, 4);
@@ -55,7 +55,7 @@ public class RadialSimplex extends TEPerformancePattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("radial_simplex.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
     }
 
     @Override
@@ -78,8 +78,4 @@ public class RadialSimplex extends TEPerformancePattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
+++ b/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
@@ -14,7 +14,7 @@ public class SimplexPosterized extends DriftEnabledPattern {
     NativeShader shader;
 
     public SimplexPosterized(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // common controls setup
         controls.setRange(TEControlTag.SPEED, 0, -4, 4);
@@ -27,7 +27,7 @@ public class SimplexPosterized extends DriftEnabledPattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("simplex_posterized.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
     }
 
     @Override
@@ -50,8 +50,4 @@ public class SimplexPosterized extends DriftEnabledPattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -21,7 +21,7 @@ public class SpiralDiamonds extends TEPerformancePattern {
                     .setDescription("Ummm.... what does this button do?");
 
     public SpiralDiamonds(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.DOUBLE_LARGE);
 
         // Quantity controls density of diamonds
         controls.setRange(TEControlTag.QUANTITY,4,1,7)
@@ -84,8 +84,4 @@ public class SpiralDiamonds extends TEPerformancePattern {
          }
     }
 
-    @Override
-    public String getDefaultView() {
-        return TEShaderView.DOUBLE_LARGE.viewLabel;
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/TriangleNoise.java
+++ b/src/main/java/titanicsend/pattern/jon/TriangleNoise.java
@@ -15,7 +15,7 @@ public class TriangleNoise extends DriftEnabledPattern {
     NativeShader shader;
 
     public TriangleNoise(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // common controls setup
         controls.setRange(TEControlTag.SPEED, 0, -4, 4); // overall scale
@@ -31,7 +31,7 @@ public class TriangleNoise extends DriftEnabledPattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("triangle_noise.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
     }
 
     @Override
@@ -54,8 +54,4 @@ public class TriangleNoise extends DriftEnabledPattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -14,7 +14,7 @@ public class TurbulenceLines extends DriftEnabledPattern {
     NativeShader shader;
 
     public TurbulenceLines(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // common controls setup
         controls.setRange(TEControlTag.SPEED, 0, -4, 4);
@@ -31,7 +31,7 @@ public class TurbulenceLines extends DriftEnabledPattern {
         addCommonControls();
 
         effect = new NativeShaderPatternEffect("turbulent_noise_lines.fs",
-            new PatternTarget(this, TEShaderView.ALL_POINTS));
+            new PatternTarget(this));
 
     }
 
@@ -55,8 +55,4 @@ public class TurbulenceLines extends DriftEnabledPattern {
         shader = effect.getNativeShader();
     }
 
-    @Override
-    public String getDefaultView() {
-        return effect.getDefaultView();
-    }
 }

--- a/src/main/java/titanicsend/pattern/mike/Checkers.java
+++ b/src/main/java/titanicsend/pattern/mike/Checkers.java
@@ -5,6 +5,7 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.model.LXPoint;
 import titanicsend.model.TEPanelModel;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.util.*;
 
@@ -14,7 +15,7 @@ public class Checkers extends TEPerformancePattern {
   private final HashMap<TEPanelModel, Integer> panelGroup;
 
   public Checkers(LX lx) {
-    super(lx);
+    super(lx, TEShaderView.ALL_POINTS);
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazeParallel.java
@@ -3,6 +3,7 @@ package titanicsend.pattern.pixelblaze;
 import heronarts.lx.LX;
 import heronarts.lx.model.LXPoint;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,7 @@ public class PixelblazeParallel extends TEPerformancePattern {
   });
 
   public PixelblazeParallel(LX lx) {
-    super(lx);
+    super(lx, TEShaderView.ALL_POINTS);
 
     try {
 

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePattern.java
@@ -7,6 +7,7 @@ import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import javax.script.ScriptException;
 import java.util.ArrayList;
@@ -43,7 +44,7 @@ public abstract class PixelblazePattern extends TEPerformancePattern {
   };
 
   public PixelblazePattern(LX lx) {
-    super(lx);
+    super(lx, TEShaderView.ALL_POINTS);
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
+++ b/src/main/java/titanicsend/pattern/pixelblaze/PixelblazePort.java
@@ -5,6 +5,7 @@ import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.util.ArrayList;
 
@@ -27,7 +28,7 @@ public abstract class PixelblazePort extends TEPerformancePattern {
     public int color;
 
     public PixelblazePort(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         configureControls();
         addCommonControls();

--- a/src/main/java/titanicsend/pattern/tom/BouncingDots.java
+++ b/src/main/java/titanicsend/pattern/tom/BouncingDots.java
@@ -9,6 +9,7 @@ import heronarts.lx.parameter.LXParameter;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.jon.TEControlTag;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import static titanicsend.util.TEColor.TRANSPARENT;
 
@@ -25,7 +26,7 @@ public class BouncingDots extends TEPerformancePattern {
     });
 
     public BouncingDots(LX lx) {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         // start our sine modulator
         startModulator(this.phase);

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -39,62 +39,62 @@ public class OrganicPatternConfig {
     @LXCategory("Yoffa Panel Shader")
     public static class RainbowSwirlPanels extends ConstructedPattern {
         public RainbowSwirlPanels(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new RainbowSwirlShader(new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+            return List.of(new RainbowSwirlShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Edge Shader")
     public static class RainbowSwirlEdges extends ConstructedPattern {
         public RainbowSwirlEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new RainbowSwirlShader(new PatternTarget(this, TEShaderView.ALL_EDGES)));
+            return List.of(new RainbowSwirlShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Shader")
     public static class NeonBarsPanels extends ConstructedPattern {
         public NeonBarsPanels(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new NeonBarsShader(new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+            return List.of(new NeonBarsShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Edge Shader")
     public static class NeonBarsEdges extends ConstructedPattern {
         public NeonBarsEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new NeonBarsShader(new PatternTarget(this, TEShaderView.ALL_EDGES)));
+            return List.of(new NeonBarsShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Shader")
     public static class NeonCellsLegacy extends ConstructedPattern {
         public NeonCellsLegacy(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new NeonCellsShader(new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+            return List.of(new NeonCellsShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Shader")
     public static class WaterPanels extends ConstructedPattern {
         public WaterPanels(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
@@ -108,14 +108,14 @@ public class OrganicPatternConfig {
             getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)
             getControls().setRange(TEControlTag.WOW2, 0.005,0.001,0.01); // intensity 2
 
-            return List.of(new WaterShader(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new WaterShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Edge Shader")
     public static class WaterEdges extends ConstructedPattern {
         public WaterEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
         @Override
         protected List<PatternEffect> createEffects() {
@@ -129,85 +129,85 @@ public class OrganicPatternConfig {
             getControls().setRange(TEControlTag.WOW1, 5,1,20);    // iterations (intensity 1)
             getControls().setRange(TEControlTag.WOW2, 0.005,0.001,0.01); // intensity 2
 
-            return List.of(new WaterShader(new PatternTarget(this, TEShaderView.ALL_EDGES)));
+            return List.of(new WaterShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Shader")
     public static class WavyPanels extends ConstructedPattern {
         public WavyPanels(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new WavyShader(new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+            return List.of(new WavyShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Shader")
     public static class NeonSnake extends ConstructedPattern {
         public NeonSnake(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new NeonSnakeShader(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new NeonSnakeShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Edge Shader")
     public static class WavyEdges extends ConstructedPattern {
         public WavyEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new WavyShader(new PatternTarget(this, TEShaderView.ALL_EDGES)));
+            return List.of(new WavyShader(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Organic")
     public static class PulseCenter extends ConstructedPattern {
         public PulseCenter(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new PulseEffect(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new PulseEffect(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Panel Organic")
     public static class AlternatingDots extends ConstructedPattern {
         public AlternatingDots(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new AlternatingDotsEffect(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new AlternatingDotsEffect(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Yoffa Edge Organic")
     public static class PowerGrid extends ConstructedPattern {
         public PowerGrid(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new ShimmeringEffect(new PatternTarget(this, TEShaderView.ALL_EDGES)));
+            return List.of(new ShimmeringEffect(new PatternTarget(this)));
         }
     }
 
     @LXCategory("Video Patterns")
     public static class BasicVideoPattern extends ConstructedPattern {
         public BasicVideoPattern(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new BasicVideoPatternEffect(new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+            return List.of(new BasicVideoPatternEffect(new PatternTarget(this)));
         }
     }
 
@@ -215,12 +215,12 @@ public class OrganicPatternConfig {
     @LXCategory("Video Patterns")
     public static class FullscreenVideoA extends ConstructedPattern {
         public FullscreenVideoA(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new BasicVideoPatternEffect(new PatternTarget(this, TEShaderView.ALL_PANELS),
+            return List.of(new BasicVideoPatternEffect(new PatternTarget(this),
                     "resources/pattern/test_vid_a.mp4"));
         }
     }
@@ -228,12 +228,12 @@ public class OrganicPatternConfig {
     @LXCategory("Video Patterns")
     public static class FullscreenVideoB extends ConstructedPattern {
         public FullscreenVideoB(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new BasicVideoPatternEffect(new PatternTarget(this, TEShaderView.ALL_PANELS),
+            return List.of(new BasicVideoPatternEffect(new PatternTarget(this),
                     "resources/pattern/test_vid_b.mp4"));
         }
     }
@@ -241,23 +241,23 @@ public class OrganicPatternConfig {
     @LXCategory("DREVO Shaders")
     public static class RhythmicFlashStatic extends ConstructedPattern {
         public RhythmicFlashStatic(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
-            return List.of(new RhythmicFlashingStatic(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new RhythmicFlashingStatic(new PatternTarget(this)));
         }
     }
 
     @LXCategory("DREVO Shaders")
     public static class MatrixScroller extends ConstructedPattern {
         public MatrixScroller(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
         @Override
         protected List<PatternEffect> createEffects() {
 
-            return List.of(new MatrixScrolling(new PatternTarget(this, TEShaderView.ALL_PANELS)));
+            return List.of(new MatrixScrolling(new PatternTarget(this)));
         }
     }
 

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderEdgesPatternConfig.java
@@ -18,7 +18,7 @@ public class ShaderEdgesPatternConfig {
     @LXCategory("Native Shaders Edges")
     public static class LightBeamsEdges extends ConstructedPattern {
         public LightBeamsEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
 
         @Override
@@ -27,14 +27,14 @@ public class ShaderEdgesPatternConfig {
             controls.setValue(TEControlTag.SPEED, 0.5);
 
             return List.of(new NativeShaderPatternEffect("light_beams.fs",
-                new PatternTarget(this, TEShaderView.ALL_EDGES)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Edges")
     public static class NeonRipplesEdges extends ConstructedPattern {
         public NeonRipplesEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
 
         @Override
@@ -58,20 +58,20 @@ public class ShaderEdgesPatternConfig {
             controls.setValue(TEControlTag.SPIN, 0.05);
 
             return List.of(new NativeShaderPatternEffect("neon_ripples.fs",
-                new PatternTarget(this, TEShaderView.ALL_EDGES)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Edges")
     public static class SpaceExplosionEdges extends ConstructedPattern {
         public SpaceExplosionEdges(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_EDGES);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("space_explosion.fs",
-                new PatternTarget(this, TEShaderView.ALL_EDGES)));
+                new PatternTarget(this)));
         }
     }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -36,7 +36,7 @@ public class ShaderPanelsPatternConfig {
     @LXCategory("Native Shaders Panels")
     public static class LightBeamsPattern extends ConstructedPattern {
         public LightBeamsPattern(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
         }
 
         @Override
@@ -45,40 +45,40 @@ public class ShaderPanelsPatternConfig {
             controls.setValue(TEControlTag.SPEED, 0.5);
 
             return List.of(new NativeShaderPatternEffect("light_beams.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS_INDIVIDUAL)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class NeonHeartNative extends ConstructedPattern {
         public NeonHeartNative(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("neon_heart.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS_INDIVIDUAL)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class Marbling extends ConstructedPattern {
         public Marbling(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("marbling.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class NeonRipples extends ConstructedPattern {
         public NeonRipples(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
 
         @Override
@@ -92,105 +92,105 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW2,0,0,3);  // radial rotation distortion
 
             return List.of(new NativeShaderPatternEffect("neon_ripples.fs",
-                new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class NeonTriangles extends ConstructedPattern {
         public NeonTriangles(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("neon_triangles.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS_INDIVIDUAL)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class SpaceExplosion extends ConstructedPattern {
         public SpaceExplosion(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("space_explosion.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS_INDIVIDUAL)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class SynthWaves extends ConstructedPattern {
         public SynthWaves(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("synth_waves.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class PulsingHeart extends ConstructedPattern {
         public PulsingHeart(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("pulsing_heart.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS_INDIVIDUAL)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class NeonBlocks extends ConstructedPattern {
         public NeonBlocks(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("neon_blocks.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class Warp extends ConstructedPattern {
         public Warp(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("warp.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class Fire extends ConstructedPattern {
         public Fire(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("fire.fs",
-                new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class StormScanner extends ConstructedPattern {
         public StormScanner(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
@@ -202,79 +202,79 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW1, .35, 0.1, 1);  // Contrast
 
             return List.of(new NativeShaderPatternEffect("storm_scanner.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE), "gray_noise.png"));
+                new PatternTarget(this), "gray_noise.png"));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class JetStream extends ConstructedPattern {
         public JetStream(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("jet_stream.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE), "color_noise.png"));
+                new PatternTarget(this), "color_noise.png"));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class OutrunGrid extends ConstructedPattern {
         public OutrunGrid(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("outrun_grid.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class Galaxy extends ConstructedPattern {
         public Galaxy(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("galaxy.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class AudioTest2 extends ConstructedPattern {
         public AudioTest2(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("audio_test2.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("Native Shaders Panels")
     public static class NeonCells extends ConstructedPattern {
         public NeonCells(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
         }
 
         @Override
         protected List<PatternEffect> createEffects() {
             return List.of(new NativeShaderPatternEffect("neon_cells.fs",
-                new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("DREVO Shaders")
     public static class SlitheringSnake extends ConstructedPattern {
         public SlitheringSnake(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
@@ -288,14 +288,14 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW2,0.4,0,1.00);  // background level
 
             return List.of(new NativeShaderPatternEffect("snake_approaching.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("DREVO Shaders")
     public static class PulsingPetriDish extends ConstructedPattern {
         public PulsingPetriDish(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_PANELS);
         }
 
         @Override
@@ -307,14 +307,14 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.SIZE, 1, 0.5,5); // overall scale
 
             return List.of(new NativeShaderPatternEffect("pulsing_petri_dish.fs",
-                new PatternTarget(this, TEShaderView.ALL_PANELS)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("DREVO Shaders")
     public static class Mondelbrot extends ConstructedPattern {
         public Mondelbrot(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.DOUBLE_LARGE);
         }
 
         @Override
@@ -327,14 +327,14 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW1, 0.5, 0.05, 2.5);  // contrast
 
             return List.of(new NativeShaderPatternEffect("mandelbrot.fs",
-                new PatternTarget(this, TEShaderView.DOUBLE_LARGE)));
+                new PatternTarget(this)));
         }
     }
 
     @LXCategory("DREVO Shaders")
     public static class MetallicWaves extends ConstructedPattern {
         public MetallicWaves(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_POINTS);
         }
 
         @Override
@@ -348,7 +348,7 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW1, 0, 0, 0.25);  // pixelated decomposition
 
             return List.of(
-                new NativeShaderPatternEffect("metallic_wave.fs", new PatternTarget(this, TEShaderView.ALL_POINTS))
+                new NativeShaderPatternEffect("metallic_wave.fs", new PatternTarget(this))
             );
         }
     }
@@ -358,7 +358,7 @@ public class ShaderPanelsPatternConfig {
     @LXCategory("Noise")
     public static class SmokeShader extends ConstructedPattern {
         public SmokeShader(LX lx) {
-            super(lx);
+            super(lx, TEShaderView.ALL_POINTS);
         }
 
         @Override
@@ -373,7 +373,7 @@ public class ShaderPanelsPatternConfig {
             controls.setRange(TEControlTag.WOW2, 1.0, 0.25, 2.0);
 
             return List.of(new NativeShaderPatternEffect("smoke_shader.fs",
-                new PatternTarget(this, TEShaderView.ALL_POINTS)));
+                new PatternTarget(this)));
         }
     }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
@@ -11,8 +11,9 @@ public abstract class ConstructedPattern extends TEPerformancePattern {
 
     private final List<PatternEffect> effects;
 
-    protected ConstructedPattern(LX lx) {
-        super(lx);
+    protected ConstructedPattern(LX lx, TEShaderView defaultView) {
+        super(lx, defaultView);
+
         effects = createEffects();
 
         // initialize common controls
@@ -61,14 +62,6 @@ public abstract class ConstructedPattern extends TEPerformancePattern {
         for (PatternEffect effect : effects) {
             effect.run(deltaMillis);
         }
-    }
-
-    @Override
-    public String getDefaultView() {
-        if (this.effects.size() > 0) {
-            return this.effects.get(0).getDefaultView();
-        }
-        return super.getDefaultView();
     }
 
     protected abstract List<PatternEffect> createEffects();

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternEffect.java
@@ -10,13 +10,11 @@ import java.util.*;
 public abstract class PatternEffect {
 
     protected final TEPerformancePattern pattern;
-    public final TEShaderView defaultView;
     private boolean shouldBlend;
 
 
     public PatternEffect(PatternTarget target) {
         this.pattern = target.pattern;
-        this.defaultView = target.defaultView;
     }
 
     public final void onActive() {
@@ -64,7 +62,4 @@ public abstract class PatternEffect {
         return pattern.getTempo();
     }
 
-    public String getDefaultView() {
-        return this.defaultView.viewLabel;
-    }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/PatternTarget.java
@@ -6,16 +6,14 @@ import titanicsend.pattern.TEPattern;
 public class PatternTarget {
 
     TEPerformancePattern pattern;
-    public final TEShaderView defaultView;
     public TEPattern.ColorType colorType = TEPattern.ColorType.PRIMARY;
 
-    public PatternTarget(TEPerformancePattern pattern, TEShaderView defaultView) {
+    public PatternTarget(TEPerformancePattern pattern) {
         this.pattern = pattern;
-        this.defaultView = defaultView;
     }
 
-    public PatternTarget(TEPerformancePattern pattern, TEShaderView defaultView, TEPattern.ColorType ct) {
-        this(pattern, defaultView);
+    public PatternTarget(TEPerformancePattern pattern, TEPattern.ColorType ct) {
+        this(pattern);
         this.colorType = ct;
     }
 

--- a/src/main/java/titanicsend/pattern/yoffa/framework/TEShaderView.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/TEShaderView.java
@@ -20,4 +20,11 @@ public enum TEShaderView {
   private TEShaderView(String viewLabel) {
     this.viewLabel = viewLabel;
   }
+
+  /**
+   * Get string value to be used as key to ViewParameter
+   */
+  public String getParameterKey() {
+    return this.viewLabel;
+  }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/media/BasicImagePattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/media/BasicImagePattern.java
@@ -4,6 +4,7 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.model.LXPoint;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class BasicImagePattern extends TEPerformancePattern {
     private final ImagePainter eddiePainter;
 
     public BasicImagePattern(LX lx) throws IOException {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/yoffa/media/BasicVideoPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/media/BasicVideoPattern.java
@@ -3,6 +3,7 @@ package titanicsend.pattern.yoffa.media;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.io.IOException;
 
@@ -17,7 +18,7 @@ public class BasicVideoPattern extends TEPerformancePattern {
     private final VideoPainter videoPainter;
 
     public BasicVideoPattern(LX lx) throws IOException {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/yoffa/media/ReactiveHeartPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/media/ReactiveHeartPattern.java
@@ -4,6 +4,7 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.utils.LXUtils;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.io.IOException;
 
@@ -19,7 +20,7 @@ public class ReactiveHeartPattern extends TEPerformancePattern {
     private final VideoPainter videoPainter;
 
     public ReactiveHeartPattern(LX lx) throws IOException {
-        super(lx);
+        super(lx, TEShaderView.ALL_POINTS);
 
         addCommonControls();
 


### PR DESCRIPTION
It turns out we want the View to be adjustable per-pattern to accommodate playlist-style channels such as those used by AutoVJ.

The problem with views per-channel is the channels become locked to various model layouts.  This is fine in the case of "channel 7 is always the outline", but doesn't work in the case of "Channel 2 is high energy patterns, not necessarily all using the same view."  Also, you can't change the view of a channel while it is faded into the mix as there's no transition.  So the channels end up permanently fixed to a view OR channel has to be faded all the way down before view can be changed.  Overall it does seem nice to unshackle channel usage from visual groupings of fixtures.

Turns out this was easier to implement than views per-channel.  I refrained from deleting all the per-channel scaffolding though because... you never know.

A couple other conveniences gained:

- Patterns initialize to their preferred view.
- View selection on each pattern survives file save/load.
- Cleaner implementation since the list of views is available at pattern instantiation time, rather than with channels where there is a delay until the pattern is added to a channel.

NOTE: For now, inserts/deletes from the middle of views.txt should be avoided pre-show as they will bump the view selections out of alignment in existing .lxps such as AutoVJ.  Maybe this can be improved later to save the string instead.

@mcslee Note this interesting evolvement of the feature.