### PR TITLE
Add Multiplier Modulator

### DIFF
--- a/Projects/EDC_showcase.lxp
+++ b/Projects/EDC_showcase.lxp
@@ -1,6 +1,6 @@
 {
-  "version": "0.4.3-SNAPSHOT",
-  "timestamp": 1684298780718,
+  "version": "0.4.4-SNAPSHOT",
+  "timestamp": 1684396708736,
   "model": {
     "id": 2,
     "class": "heronarts.lx.structure.LXStructure",
@@ -2768,7 +2768,7 @@
         },
         "parameters": {
           "label": "Mixer",
-          "crossfader": 0.6377952755905512,
+          "crossfader": 0.3543307086614173,
           "crossfaderBlendMode": 1,
           "focusedChannel": 7,
           "focusedChannelAux": 6,
@@ -2889,7 +2889,7 @@
                           "exp": 0.0
                         },
                         "children": {},
-                        "basis": 0.788733333331038
+                        "basis": 0.22949999999980264
                       }
                     ],
                     "modulations": [
@@ -2913,7 +2913,7 @@
                           "label": "LX",
                           "enabled": true,
                           "polarity": 0,
-                          "range": -0.25999997183680534
+                          "range": 0.0
                         },
                         "children": {}
                       }
@@ -2944,7 +2944,7 @@
               "fader": 1.0,
               "arm": false,
               "selected": false,
-              "enabled": false,
+              "enabled": true,
               "cue": false,
               "aux": false,
               "crossfadeGroup": 0,
@@ -2963,13 +2963,13 @@
               "transitionEnabled": true,
               "transitionTimeSecs": 0.05,
               "transitionBlendMode": 4,
-              "focusedPattern": 2,
+              "focusedPattern": 3,
               "triggerPatternCycle": false
             },
             "children": {},
             "effects": [],
             "clips": [],
-            "patternIndex": 2,
+            "patternIndex": 3,
             "patterns": [
               {
                 "id": 44470,
@@ -3396,9 +3396,9 @@
                   "viewPerPattern": 5,
                   "swatchPerChannel": 0,
                   "curve": 10.0,
-                  "yWave": 1.5,
+                  "tile": 2.0,
                   "xWave": 1.0,
-                  "tile": 2.0
+                  "yWave": 1.5
                 },
                 "children": {
                   "modulation": {
@@ -3553,10 +3553,10 @@
                   "panic": false,
                   "viewPerPattern": 0,
                   "swatchPerChannel": 0,
-                  "Double Speed": false,
-                  "Glow": 0.1,
                   "Double Layer": false,
+                  "Glow": 0.1,
                   "Energy": 0.0,
+                  "Double Speed": false,
                   "Width": 0.5
                 },
                 "children": {
@@ -4075,7 +4075,7 @@
             },
             "parameters": {
               "label": "EDGES",
-              "fader": 1.0,
+              "fader": 0.0,
               "arm": false,
               "selected": false,
               "enabled": true,
@@ -4480,7 +4480,7 @@
             },
             "parameters": {
               "label": "MULTIPLIERS",
-              "fader": 1.0,
+              "fader": 0.0,
               "arm": false,
               "selected": false,
               "enabled": false,
@@ -4782,7 +4782,7 @@
             },
             "parameters": {
               "label": "LIGHTNING",
-              "fader": 1.0,
+              "fader": 0.0,
               "arm": false,
               "selected": false,
               "enabled": false,
@@ -4874,7 +4874,7 @@
             },
             "parameters": {
               "label": "Outline",
-              "fader": 0.7428571619093418,
+              "fader": 0.0,
               "arm": false,
               "selected": false,
               "enabled": true,
@@ -4961,7 +4961,7 @@
             },
             "parameters": {
               "label": "Back",
-              "fader": 1.0,
+              "fader": 0.0,
               "arm": false,
               "selected": false,
               "enabled": true,
@@ -5092,8 +5092,52 @@
           "label": "Modulation"
         },
         "children": {},
-        "modulators": [],
-        "modulations": [],
+        "modulators": [
+          {
+            "id": 46201,
+            "class": "titanicsend.modulator.justin.MultiplierModulator",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "Multiplier",
+              "running": true,
+              "trigger": false,
+              "inputA": 0.16535433070866143,
+              "inputB": 0.25000001676380634,
+              "output": 0.04133858544913333
+            },
+            "children": {}
+          }
+        ],
+        "modulations": [
+          {
+            "source": {
+              "componentId": 46201,
+              "parameterPath": "output",
+              "path": "/modulation/modulator/1/output"
+            },
+            "target": {
+              "componentId": 44757,
+              "parameterPath": "range",
+              "path": "/mixer/master/effect/2/modulation/modulation/1/range"
+            },
+            "id": 46202,
+            "class": "heronarts.lx.modulation.LXCompoundModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "polarity": 0,
+              "range": -0.6874999953433871
+            },
+            "children": {}
+          }
+        ],
         "triggers": []
       },
       "output": {
@@ -5157,6 +5201,12 @@
         "children": {},
         "inputs": [
           {
+            "name": "FoH: APC40 mkII",
+            "channel": false,
+            "control": true,
+            "sync": false
+          },
+          {
             "name": "APC40 mkII",
             "channel": false,
             "control": true,
@@ -5165,6 +5215,14 @@
         ],
         "surfaces": [
           {
+            "name": "FoH: APC40 mkII",
+            "settings": {
+              "masterFaderEnabled": true,
+              "crossfaderEnabled": true,
+              "channelKnobIsView": true
+            }
+          },
+          {
             "name": "APC40 mkII",
             "settings": {
               "masterFaderEnabled": true,
@@ -5172,7 +5230,16 @@
             }
           }
         ],
-        "mapping": []
+        "mapping": [
+          {
+            "channel": 0,
+            "type": "CONTROL_CHANGE",
+            "path": "/lx/modulation/modulator/1/inputA",
+            "componentId": 46201,
+            "parameterPath": "inputA",
+            "cc": 55
+          }
+        ]
       },
       "osc": {
         "id": 30,
@@ -5201,7 +5268,9 @@
       "audioExpanded": true,
       "paletteExpanded": true,
       "cameraExpanded": true,
-      "modulatorExpanded": {},
+      "modulatorExpanded": {
+        "46201": true
+      },
       "preview": {
         "mode": 0,
         "animation": false,

--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -53,6 +53,8 @@ import titanicsend.lx.APC40Mk2.UserButton;
 import titanicsend.model.TEWholeModel;
 import titanicsend.model.justin.ColorCentral;
 import titanicsend.model.justin.ViewCentral;
+import titanicsend.modulator.justin.MultiplierModulator;
+import titanicsend.modulator.justin.UIMultiplierModulator;
 import titanicsend.output.GPOutput;
 import titanicsend.output.GrandShlomoStation;
 import titanicsend.pattern.TEEdgeTestPattern;
@@ -264,6 +266,12 @@ public class TEApp extends PApplet implements LXPlugin {
     lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (2)", MidiFighterTwister.class);
     lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (3)", MidiFighterTwister.class);
     lx.engine.midi.registerSurface("FoH: Midi Fighter Twister (4)", MidiFighterTwister.class);
+
+    // Custom modulator type
+    lx.registry.addModulator(MultiplierModulator.class);
+    if (lx instanceof LXStudio) {
+      ((LXStudio.Registry)lx.registry).addUIModulatorControls(UIMultiplierModulator.class);
+    }
 
     // create our library for autopilot
     this.library = initializePatternLibrary(lx);

--- a/src/main/java/titanicsend/modulator/justin/MultiplierModulator.java
+++ b/src/main/java/titanicsend/modulator/justin/MultiplierModulator.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023- Justin K. Belcher, Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package titanicsend.modulator.justin;
+
+// JKB note: going to circle back around and add divide/add/subtract as options.
+
+import heronarts.lx.LXCategory;
+import heronarts.lx.osc.LXOscComponent;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.modulator.LXModulator;
+
+@LXModulator.Global("Multiplier")
+@LXCategory(LXCategory.MACRO)
+public class MultiplierModulator extends LXModulator implements LXOscComponent {
+
+  public final CompoundParameter inputA =
+      new CompoundParameter("Input A")
+      .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+      .setDescription("Map something to Input A or set manually");
+
+  public final CompoundParameter inputB =
+      new CompoundParameter("Input B")
+      .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+      .setDescription("Map something to Input B or set manually");
+
+  public final CompoundParameter output =
+      new CompoundParameter("Output")
+      .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+      .setDescription("Output = Multiplied A and B normalized values.  Map output to a destination.");
+
+  public MultiplierModulator() {
+    this("Multiplier");
+  }
+
+  public MultiplierModulator(String label) {
+    super(label);
+    addParameter("inputA", this.inputA);
+    addParameter("inputB", this.inputB);
+    addParameter("output", this.output);
+  }
+
+  @Override
+  protected double computeValue(double deltaMs) {
+    // TODO: Right now, mapping the modulator requires selection the output knob as a source. Fix that.
+    this.output.setNormalized(this.inputA.getNormalized() * this.inputB.getNormalized());
+    return this.output.getNormalized();
+  }
+
+}

--- a/src/main/java/titanicsend/modulator/justin/UIMultiplierModulator.java
+++ b/src/main/java/titanicsend/modulator/justin/UIMultiplierModulator.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023- Justin K. Belcher, Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package titanicsend.modulator.justin;
+
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.modulation.UIModulator;
+import heronarts.lx.studio.ui.modulation.UIModulatorControls;
+import heronarts.p4lx.ui.UI2dContainer;
+import heronarts.p4lx.ui.component.UIKnob;
+
+public class UIMultiplierModulator implements UIModulatorControls<MultiplierModulator> {
+
+  public void buildModulatorControls(LXStudio.UI ui, UIModulator uiModulator, MultiplierModulator modulator) {
+    uiModulator.setContentHeight(UIKnob.HEIGHT + 4);
+    uiModulator.setLayout(UI2dContainer.Layout.HORIZONTAL);
+    uiModulator.setChildSpacing(2);
+    new UIKnob(modulator.inputA).setY(4).addToContainer(uiModulator);
+    new UIKnob(modulator.inputB).setY(4).addToContainer(uiModulator);
+    new UIKnob(modulator.output).setEditable(false).setY(4).addToContainer(uiModulator);
+  }
+
+}


### PR DESCRIPTION
Multiply two normalized values and map the output to something.

Allows for example: mapping a midi knob to a destination while scaling down the impact.

<img width="227" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/8f16066e-a505-4913-85ec-3d27a2b9e0ff">

TODO: allow mapping without selecting the Output as the source.