### PR TITLE
Add hardcoded IP for pangolin lasers

### DIFF
--- a/src/main/java/titanicsend/lasercontrol/PangolinHost.java
+++ b/src/main/java/titanicsend/lasercontrol/PangolinHost.java
@@ -5,6 +5,7 @@ package titanicsend.lasercontrol;
  * Pangolin host.
  */
 public class PangolinHost {
-    public static final String HOSTNAME = "localhost";
+    // TODO(will) change this to a config file later
+    public static final String HOSTNAME = "10.1.3.1";
     public static final int PORT = 7890;
 }


### PR DESCRIPTION
Adds the IP address of the ShowKontrol machine.

(This should be a config file, probably inside of `resources/scripts/TE-IP-addresses.txt`, but MaxMSP uses that file as well and we don't want to touch it this close to showtime)