### PR TITLE
Fix Alpha/Brightness for last few shaders.

### DIFF
--- a/resources/shaders/radial_simplex.fs
+++ b/resources/shaders/radial_simplex.fs
@@ -172,7 +172,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     noise = noise * noise;
 
     // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = mix(iColorRGB, mix(iColorRGB, iColor2RGB, wave(noise)), iWow2);
+    vec3 col = noise * mix(iColorRGB, mix(iColorRGB, iColor2RGB, wave(noise)), iWow2);
 
-    fragColor = vec4(col, noise);
+    fragColor = vec4(col, 1.0);
 }

--- a/resources/shaders/simplex_posterized.fs
+++ b/resources/shaders/simplex_posterized.fs
@@ -154,7 +154,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float gradient = mix(noise,mod((noise * levels),2.0),iWow1);
 
     // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = mix(iColorRGB, mix(iColorRGB, iColor2RGB,gradient), iWow2);
+    vec3 col = noise * mix(iColorRGB, mix(iColorRGB, iColor2RGB,gradient), iWow2);
 
-    fragColor = vec4(col, noise);
+    fragColor = vec4(col, 1.0);
 }

--- a/resources/shaders/smoke_shader.fs
+++ b/resources/shaders/smoke_shader.fs
@@ -49,6 +49,5 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     uv.y = pow(clamp(uv.y + 0.15, 0.0, 1.0), iWow2);
     col.y -= mix(0.0, uv.y, satGradient);
 
-    // use our output brightness as alpha
     fragColor = vec4(uv.y * hsv2rgb(col), 1.0);
 }

--- a/resources/shaders/smoke_shader.fs
+++ b/resources/shaders/smoke_shader.fs
@@ -50,5 +50,5 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     col.y -= mix(0.0, uv.y, satGradient);
 
     // use our output brightness as alpha
-    fragColor = vec4(hsv2rgb(col), uv.y);
+    fragColor = vec4(uv.y * hsv2rgb(col), 1.0);
 }


### PR DESCRIPTION
Alpha/brightness PR turned smokeshader to solid color.  One-line fix makes everything OK again!

Edit:  After testing also found that RadialSimplex and SimplexPosterized shaders were also affected.  Added fixes to this PR.

Only the GLSL shaders, have changed.   Once merged and pulled, you should be able to just delete and reload innstances of the affected shaders in their channels to get this working, even mid-show.  (Or just reload the .lxp)  No need to restart or rebuild LX.  