### PR TITLE
Fix typo error in APC40 user button

### DIFF
--- a/src/main/java/titanicsend/lx/APC40Mk2.java
+++ b/src/main/java/titanicsend/lx/APC40Mk2.java
@@ -1345,7 +1345,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
   }
 
   private void unregisterUserButton(BooleanParameter parameter) {
-    parameter.addListener(userButtonListener);
+    parameter.removeListener(userButtonListener);
   }
 
   private void unregister() {


### PR DESCRIPTION
Copy/Paste error, would cause a crash when midi surface was disabled.