### PR TITLE
new util pattern for visually targeting specific pixels

### DIFF
--- a/src/main/java/titanicsend/app/TEApp.java
+++ b/src/main/java/titanicsend/app/TEApp.java
@@ -72,6 +72,7 @@ import titanicsend.pattern.justin.TESolidPattern;
 import titanicsend.pattern.mike.*;
 import titanicsend.pattern.pixelblaze.*;
 import titanicsend.pattern.tom.*;
+import titanicsend.pattern.util.TargetPixelStamper;
 import titanicsend.pattern.will.PowerDebugger;
 import titanicsend.pattern.yoffa.config.OrganicPatternConfig;
 import titanicsend.pattern.yoffa.config.ShaderEdgesPatternConfig;
@@ -246,6 +247,7 @@ public class TEApp extends PApplet implements LXPlugin {
 
     // Nonfunctional - need work or additional hardware that will not be at EDC
     lx.registry.addPattern(HandTracker.class);
+    lx.registry.addPattern(TargetPixelStamper.class);
 
     // "ShaderToyPattern" in ShaderPanelsPatternConfig.java
 

--- a/src/main/java/titanicsend/pattern/util/TargetPixelStamper.java
+++ b/src/main/java/titanicsend/pattern/util/TargetPixelStamper.java
@@ -1,0 +1,110 @@
+package titanicsend.pattern.util;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.LXParameter;
+import titanicsend.pattern.TEPattern;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static titanicsend.util.TEColor.TRANSPARENT;
+
+//TODO make this properly wrap around the 3d model
+@LXCategory("Utility Patterns")
+public class TargetPixelStamper extends TEPattern {
+
+    public final CompoundParameter xParam =
+            new CompoundParameter("X", 61, -100, 100)
+                    .setDescription("Target position left and right");
+
+    public final CompoundParameter yParam =
+            new CompoundParameter("Y", 25.5, 0, 100)
+                    .setDescription("Target height from ground");
+
+    public final CompoundParameter size =
+            new CompoundParameter("Size", 1, 0.1, 4)
+                    .setDescription("Target size");
+
+    public final BooleanParameter stamp = new BooleanParameter("Stamp").setMode(BooleanParameter.Mode.MOMENTARY);
+    public final BooleanParameter clear = new BooleanParameter("Clear").setMode(BooleanParameter.Mode.MOMENTARY);
+
+    private final int[] COLOR_LIST = {LXColor.GREEN, LXColor.BLUE, LXColor.RED, LXColor.WHITE};
+
+    private Map<LXPoint, Integer> currentBullseye;
+    private final Map<LXPoint, Integer> savedStamps = new HashMap<>();
+
+    public TargetPixelStamper(LX lx) {
+        super(lx);
+        addParameter("X", this.xParam);
+        addParameter("Y", this.yParam);
+        addParameter("Size", this.size);
+        addParameter("Stamp", this.stamp);
+        addParameter("Clear", this.clear);
+    }
+
+    @Override
+    public void run(double deltaMs) {
+        showSavedStamps();
+        showCurrentTarget();
+    }
+
+    private void showSavedStamps() {
+        for (LXPoint point : savedStamps.keySet()) {
+            colors[point.index] = savedStamps.get(point);
+        }
+    }
+
+    private void showCurrentTarget() {
+        float y = this.yParam.getValuef();
+        float z = -this.xParam.getValuef();
+
+        float zMax = this.modelTE.boundaryPoints.maxZBoundaryPoint.z;
+        float yMax = this.modelTE.boundaryPoints.maxYBoundaryPoint.y;
+
+        Map<LXPoint, Integer> bullseye = new HashMap<>();
+        LXPoint targetPoint = null;
+        double closestDistance = Float.MAX_VALUE;
+        for (LXPoint point : this.modelTE.points) {
+            if (this.modelTE.isGapPoint(point)) continue;
+            float zPercent = 100.0f * point.z / zMax;
+            float yPercent = 100.0f * point.y / yMax;
+            float dy = yPercent - y;
+            float dz = zPercent - z;
+            dz *= 0.85; // Make ellipse into circle
+            double distance = Math.sqrt(dy * dy + dz * dz);
+            if (distance < closestDistance) {
+                closestDistance = distance;
+                targetPoint = point;
+            }
+            if (!savedStamps.containsKey(point)){
+                colors[point.index] = TRANSPARENT;
+            }
+            for (int i = COLOR_LIST.length - 1; i >= 0; i--) {
+                if (distance < size.getValue() * i) {
+                    colors[point.index] = COLOR_LIST[i];
+                    bullseye.put(point, COLOR_LIST[i]);
+                }
+            }
+        }
+        if (targetPoint != null) {
+            colors[targetPoint.index] = COLOR_LIST[0];
+        }
+        bullseye.put(targetPoint, COLOR_LIST[0]);
+        this.currentBullseye = bullseye;
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter p) {
+        super.onParameterChanged(p);
+        if (p == stamp) {
+            savedStamps.putAll(currentBullseye);
+        } else if (p == clear) {
+            savedStamps.clear();
+        }
+    }
+}


### PR DESCRIPTION
[Notion task](https://www.notion.so/titanicsend/f5264e3538bf417e86956d87124d1a89?v=e45c0f187eb84ecabbae9c00a27f0fd2&p=aca54d6af197448e95bf3ebbedd40a3b&pm=s)

Movable bullseye with a single pixel in the middle. Can stamp multiple places in the car at once. Still doesn't wrap around the car appropriately (similar to hand tracker) but the rest of the functionality is ready to go. If you see the middle pixel disappearing, it will be fixed with proper wrapping (it appears on the other side of the car). This will be fixed with [HandTracker Improvements](https://www.notion.so/titanicsend/f5264e3538bf417e86956d87124d1a89?v=e45c0f187eb84ecabbae9c00a27f0fd2&p=5d2923a030d448948fc568c28930f239&pm=s)

Middle pixel doesn't cycle colors, lmk if you think we need this.