### PR TITLE
Add pixel scanner

### DIFF
--- a/resources/shaders/pixel_scanner.fs
+++ b/resources/shaders/pixel_scanner.fs
@@ -1,0 +1,24 @@
+int n = int(iQuantity);
+vec3 lineCol = iColorRGB;
+vec3 baseCol = iColor2RGB;
+float scl = 0.01;
+
+float pi = 3.14;
+
+mat2 rotate(float a) {
+    return mat2(cos(a), -sin(a), sin(a), cos(a));
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )
+{
+    vec2 uv = fragCoord/iResolution.xy;
+    uv *= rotate(-iRotationAngle);
+
+    float off = -fract(.5 * iTime);
+    float lg = -fract(log(scl*uv.x + 1.) / log(scl*1. + 1.) * float(n) + off)+1.;
+    float mask = distance(lg, 0.5)*2.;
+
+    vec3 col = mix(baseCol, lineCol, smoothstep(0.8, .9, mask)) ;
+
+    fragColor = vec4(col, 1.);
+}

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -62,6 +62,21 @@ public class ShaderPanelsPatternConfig {
         }
     }
 
+    @LXCategory("Utility")
+    public static class PixelScanner extends ConstructedPattern {
+        public PixelScanner(LX lx) {
+            super(lx, TEShaderView.ALL_POINTS);
+        }
+
+        @Override
+        protected List<PatternEffect> createEffects() {
+            controls.setRange(TEControlTag.QUANTITY,5,1,10);
+
+            return List.of(new NativeShaderPatternEffect("pixel_scanner.fs",
+                new PatternTarget(this)));
+        }
+    }
+
     @LXCategory("Native Shaders Panels")
     public static class Marbling extends ConstructedPattern {
         public Marbling(LX lx) {


### PR DESCRIPTION
has a set of lines that move horizontally across the car. this has working params for things like rotate, quantity (num lines), speed, x/y, etc.

it's funky on the sides ofc, but i'm working on fixing that for all shaders.

I think between this the target stamped we can prolly get rid of handtracker, but lmk what you think.