### PR TITLE
Hide unused controls from UI without impacting midi controllers

### DIFF
--- a/src/main/java/titanicsend/ui/UITEPerformancePattern.java
+++ b/src/main/java/titanicsend/ui/UITEPerformancePattern.java
@@ -74,6 +74,9 @@ public class UITEPerformancePattern implements UIDeviceControls<TEPerformancePat
     // For design mode, append Brightness.  Useful for AutoVJ especially.
     params.add(device.getControls().getControl(TEControlTag.BRIGHTNESS).control);
 
+    // For the UI, replace unused controls with null
+    hideUnusedControls(params);
+
     int ki = 0;
     int col = 0;
     for (LXNormalizedParameter param : params) {
@@ -107,6 +110,21 @@ public class UITEPerformancePattern implements UIDeviceControls<TEPerformancePat
       ++ki;
     }
     uiDevice.setContentWidth((col + 1) * (4 * (UIKnob.WIDTH + 2) + 15) - 15 - 2);
+  }
+
+  private void hideUnusedControls(List<LXNormalizedParameter> params) {
+    for (int i=0; i < params.size(); i++) {
+      LXNormalizedParameter p = params.get(i);
+      if (p != null && isUnusedControl(p)) {
+        params.set(i, null);
+      }
+    }
+  }
+
+  private boolean isUnusedControl(LXNormalizedParameter p) {
+    // ** TODO: compare to list or map of unused controls, such as:
+    // return this.device.listOfUnusedControls.contains(p);
+    return false;
   }
 
   @Override


### PR DESCRIPTION
Here's a clean way to help the VJ see which controls are active for the current pattern.  By hiding the unused controls you wouldn't need to change their labels.