### PR TITLE
[do not merge] bug reproduction: addParameter() doesnt add params besides default controls to UI

### DIFF
--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -29,6 +29,7 @@ import titanicsend.util.TEColor;
 
 import java.nio.FloatBuffer;
 import java.util.HashMap;
+import java.util.List;
 
 public abstract class TEPerformancePattern extends TEAudioPattern {
 
@@ -646,7 +647,25 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          * Set remote controls in order they will appear on the midi surfaces
          */
         protected void setRemoteControls() {
-            setCustomRemoteControls(new LXListenableNormalizedParameter[] {
+            setCustomRemoteControls(buildStandardRemoteControls());
+        }
+
+        // hack: make this public so it's callable from ConstructedPattern
+        public void setRemoteControls(List<LXListenableNormalizedParameter> extraParams) {
+            LXListenableNormalizedParameter[] standardParams = buildStandardRemoteControls();
+            LXListenableNormalizedParameter[] allParams = new LXListenableNormalizedParameter[standardParams.length + extraParams.size()];
+            for (int i = 0; i < standardParams.length; i++) {
+                allParams[i] = standardParams[i];
+            }
+            for (int j = 0; j < extraParams.size(); j++) {
+                allParams[standardParams.length + j] = extraParams.get(j);
+            }
+            System.out.printf("standardParams: %s, extraParams: %s\n", standardParams.length, extraParams.size());
+            setCustomRemoteControls(allParams);
+        }
+
+        protected LXListenableNormalizedParameter[] buildStandardRemoteControls() {
+            return new LXListenableNormalizedParameter[] {
                 this.color.offset,
                 this.color.gradient,
                 getSwatchRemoteControl(),
@@ -666,7 +685,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
                 getControl(TEControlTag.WOW2).control,
                 getControl(TEControlTag.WOWTRIGGER).control,
                 null   // To be SHIFT, not implemented yet
-            });
+            };
         }
 
         protected LXListenableNormalizedParameter getSwatchRemoteControl() {

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -664,7 +664,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             setCustomRemoteControls(allParams);
         }
 
-        protected LXListenableNormalizedParameter[] buildStandardRemoteControls() {
+        public LXListenableNormalizedParameter[] buildStandardRemoteControls() {
             return new LXListenableNormalizedParameter[] {
                 this.color.offset,
                 this.color.gradient,

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -3,6 +3,7 @@ package titanicsend.pattern.yoffa.config;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 
+import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.AlternatingDotsEffect;
@@ -13,6 +14,7 @@ import titanicsend.pattern.yoffa.framework.PatternTarget;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.util.List;
+import java.util.Map;
 
 @SuppressWarnings("unused")
 public class ShaderPanelsPatternConfig {
@@ -183,6 +185,11 @@ public class ShaderPanelsPatternConfig {
     public static class NeonBlocks extends ConstructedPattern {
         public NeonBlocks(LX lx) {
             super(lx, TEShaderView.DOUBLE_LARGE);
+
+            System.out.println("NeonBlocks ----- \n");
+            for (Map.Entry<String, LXParameter> e : this.parameters.entrySet()) {
+                System.out.printf("- %s : %s\n", e.getKey(), e.getValue());
+            }
         }
 
         @Override
@@ -194,8 +201,13 @@ public class ShaderPanelsPatternConfig {
 
     @LXCategory("Native Shaders Panels")
     public static class Warp extends ConstructedPattern {
+        public final DiscreteParameter energy =
+                new DiscreteParameter("Energy", 3, 1, 11)
+                        .setDescription("Amount of Bolts");
         public Warp(LX lx) {
             super(lx, TEShaderView.DOUBLE_LARGE);
+            // adding parameter after super-constructor calls addCommonControls()
+            addParameter("energy", energy);
         }
 
         @Override

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -4,6 +4,7 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 
 import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.effect.AlternatingDotsEffect;
@@ -208,6 +209,14 @@ public class ShaderPanelsPatternConfig {
             super(lx, TEShaderView.DOUBLE_LARGE);
             // adding parameter after super-constructor calls addCommonControls()
             addParameter("energy", energy);
+
+            LXListenableNormalizedParameter[] standardParams = this.controls.buildStandardRemoteControls();
+            LXListenableNormalizedParameter[] allParams = new LXListenableNormalizedParameter[standardParams.length + 1];
+            for (int i = 0; i < standardParams.length; i++) {
+                allParams[i] = standardParams[i];
+            }
+            allParams[standardParams.length] = energy;
+            setCustomRemoteControls(allParams);
         }
 
         @Override

--- a/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
+++ b/src/main/java/titanicsend/pattern/yoffa/framework/ConstructedPattern.java
@@ -1,6 +1,7 @@
 package titanicsend.pattern.yoffa.framework;
 
 import heronarts.lx.LX;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import titanicsend.pattern.TEPerformancePattern;
 
@@ -18,10 +19,21 @@ public abstract class ConstructedPattern extends TEPerformancePattern {
 
         // initialize common controls
         addCommonControls();
-
+        System.out.printf("--------\n%s\n--------\n", this.getClass().toString());
+        List<LXListenableNormalizedParameter> extraParams = new ArrayList<>();
         // add controls for any parameters found in the created effects
         for (LXParameter parameter : getPatternParameters()) {
             addParameter(parameter.getLabel(), parameter);
+
+            System.out.printf("- patternParam: %s\n", parameter.getLabel());
+            // checking because getPatternParameters() is typed as LXParameter (should it be LXListenableNormalizedParameter?)
+            if (parameter instanceof LXListenableNormalizedParameter) {
+                extraParams.add((LXListenableNormalizedParameter) parameter);
+            }
+        }
+        if (extraParams.size() > 0) {
+            this.controls.setRemoteControls(extraParams);
+            this.remoteControlsChanged.bang();
         }
     }
 


### PR DESCRIPTION
I'm having trouble adding any extra parameters to `TEPerformancePattern` besides what's in the default controls. It seems like there are some out-of-date docs saying to call `addParameter()` after `addCommonControls()` gets called, in order to avoid messing up the order of the default controls on the midi-fighter. But it seems like UITEPerformancePattern is looking at `TEPerformancePattern.getRemoteControls()` rather than `TEPerformancePattern.parameters`.

In particular, I noticed that the handy syntax for adding inline uniforms to native shaders seems to get ignored. I added some logging to `ConstructedPattern` to verify that it's correctly finding these parameters (which it is) and to a sample pattern (`NeonBlocks`) to verify that `this.parameters` contains the right entries (which it does).

Here's the output of the logging when I run it:

```
--------
class titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$NeonBlocks
--------
- patternParam: numBlocks
- patternParam: ySpread
- patternParam: speed
- patternParam: hideBlocks
- patternParam: glow
standardParams: 16, extraParams: 5


NeonBlocks ----- 

- label : heronarts.lx.parameter.StringParameter@3fc5f86c
- enabled : heronarts.lx.parameter.BooleanParameter@720f5cba
- recall : heronarts.lx.parameter.TriggerParameter@6c2052c8
- compositeMode : heronarts.lx.parameter.ObjectParameter@6299dc0f
- compositeLevel : heronarts.lx.parameter.CompoundParameter@6d1bc5ad
- te_color : titanicsend.pattern.TEPerformancePattern$TEColorParameter@1008c34
- te_color/brightness : heronarts.lx.parameter.CompoundParameter@364b9427
- te_color/saturation : heronarts.lx.parameter.CompoundParameter@6aff1f2a
- te_color/hue : heronarts.lx.parameter.CompoundParameter@16d372c8
- te_color/solidSource : titanicsend.pattern.TEPerformancePattern$TEColorParameter$1@769c02bf
- te_color/gradient : heronarts.lx.parameter.EnumParameter@64885509
- te_color/blendMode : titanicsend.pattern.TEPerformancePattern$TEColorParameter$2@69c03e62
- te_color/offset : titanicsend.pattern.TEPerformancePattern$TEColorParameter$3@1c9c47a7
- te_color/color2offset : heronarts.lx.parameter.CompoundParameter@179ffd82
- te_speed : heronarts.lx.parameter.CompoundParameter@2786b100
- te_xpos : heronarts.lx.parameter.CompoundParameter@4f5db8bc
- te_ypos : heronarts.lx.parameter.CompoundParameter@27c62f38
- te_size : heronarts.lx.parameter.CompoundParameter@22a276d8
- te_quantity : heronarts.lx.parameter.CompoundParameter@303edd3d
- te_spin : heronarts.lx.parameter.CompoundParameter@12041bde
- te_brightness : heronarts.lx.parameter.CompoundParameter@42d5949
- te_wow1 : heronarts.lx.parameter.CompoundParameter@3588fba2
- te_wow2 : heronarts.lx.parameter.CompoundParameter@73990f1b
- te_wowtrigger : heronarts.lx.parameter.BooleanParameter@41f1305d
- te_angle : titanicsend.pattern.TEPerformancePattern$TECommonAngleParameter@2f78de3b
- panic : heronarts.lx.parameter.BooleanParameter@266d76c4
- viewPerPattern : titanicsend.model.justin.ViewCentral$ViewParameter@415e53d4
- swatchPerChannel : titanicsend.pattern.TEPattern$LXVirtualSwatchParameter@5ddf759d

/* extra params */
- numBlocks : heronarts.lx.parameter.CompoundParameter@4b9444a4
- ySpread : heronarts.lx.parameter.CompoundParameter@76ed4d44
- speed : heronarts.lx.parameter.CompoundParameter@7addc2d6
- hideBlocks : heronarts.lx.parameter.BooleanParameter@7df4deb8
- glow : heronarts.lx.parameter.CompoundParameter@10ce5270
```

I tried adding some code to allow calling `setCustomRemoteControls()` using the standard controls concatenated with any new controls, but they don't seem to show up in the UI and I can't quite figure out why:

![Screen Shot 2023-08-05 at 6 07 08 PM](https://github.com/titanicsend/LXStudio-TE/assets/236018/d51f182d-db9a-494d-8fde-2c18e6bbd3e9)


As another experiment, I picked one pattern to just add some code inline to another random pattern, `Warp` (this is throwaway code, not meant to merge, just to reproduce the issue). I called `addParameter` then tried to setCustomRemoteControls` using the original list plus one extra param. Again, this didn't seem to affect the UI.

```java
        public final DiscreteParameter energy =
                new DiscreteParameter("Energy", 3, 1, 11)
                        .setDescription("Amount of Bolts");
        public Warp(LX lx) {
            super(lx, TEShaderView.DOUBLE_LARGE);
            // adding parameter after super-constructor calls addCommonControls()
            addParameter("energy", energy);

            LXListenableNormalizedParameter[] standardParams = this.controls.buildStandardRemoteControls();
            LXListenableNormalizedParameter[] allParams = new LXListenableNormalizedParameter[standardParams.length + 1];
            for (int i = 0; i < standardParams.length; i++) {
                allParams[i] = standardParams[i];
            }
            allParams[standardParams.length] = energy;
            setCustomRemoteControls(allParams);
        }
```


![Screen Shot 2023-08-05 at 6 09 57 PM](https://github.com/titanicsend/LXStudio-TE/assets/236018/dfed27b8-db6b-4731-bbe5-4a2957e90be2)

I'm wondering if I'm missing something. It seems like adding parameters to non-`TEPerformancePattern` patterns works fine, so I'm assuming there's something about how `UITEPerformancePattern` is loading the controls. Maybe it's just not triggering properly when custom remote controls get updated? Or I'm not setting custom remote controls the right way?
