### PR TITLE
Move Autopilot button to top, organize other custom UI sections

### DIFF
--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -416,16 +416,16 @@ public class TEApp extends LXStudio {
 
       new TEUIControls(ui, this.virtualOverlays, ui.leftPane.model.getContentWidth()).addToContainer(ui.leftPane.model, 0);
 
-      // Global pane
-
-      new GigglePixelUI(ui, ui.leftPane.global.getContentWidth(),
-          this.gpListener, this.gpBroadcaster).addToContainer(ui.leftPane.global);
-
-      // Add UI section for autopilot
-      new TEUserInterface.AutopilotUISection(ui, this.autopilot).addToContainer(ui.leftPane.global);
+      new GigglePixelUI(ui, ui.leftPane.model.getContentWidth(),
+          this.gpListener, this.gpBroadcaster).addToContainer(ui.leftPane.model, 1);
 
       // Add UI section for all other general settings
-      new TEUserInterface.TEUISection(ui, laserTask).addToContainer(ui.leftPane.global);
+      new TEUserInterface.TEUISection(ui, laserTask).addToContainer(ui.leftPane.model, 2);
+
+      // Global pane
+
+      // Add UI section for autopilot
+      new TEUserInterface.AutopilotUISection(ui, this.autopilot).addToContainer(ui.leftPane.global, 0);
 
       applyTECameraPosition();
 

--- a/src/main/java/titanicsend/app/autopilot/TEUserInterface.java
+++ b/src/main/java/titanicsend/app/autopilot/TEUserInterface.java
@@ -14,7 +14,7 @@ public class TEUserInterface {
 
     public static class AutopilotUISection extends UICollapsibleSection {
         public AutopilotUISection(LXStudio.UI ui, TEAutopilot component) {
-            super(ui, 0, 0, ui.leftPane.global.getContentWidth(), 80);
+            super(ui, 0, 0, ui.leftPane.global.getContentWidth(), 70);
             setTitle("Autopilot");
             new UISwitch(0, 4)
                 .setParameter(component.enabled)
@@ -25,8 +25,8 @@ public class TEUserInterface {
     // Use this for other random UI buttons we want to add
     public static class TEUISection extends UICollapsibleSection {
       public TEUISection(LXStudio.UI ui, TELaserTask laser) {
-          super(ui, 0, 0, ui.leftPane.global.getContentWidth(), 80);
-          setTitle("TE General Controls");
+          super(ui, 0, 0, ui.leftPane.global.getContentWidth(), 70);
+          setTitle("TE Other Outputs");
           new UISwitch(0, 4)
               .setParameter(laser.enabled)
               .addToContainer(this);


### PR DESCRIPTION
Moved Autopilot button to the top for quick access.  Moved the other custom UI sections too... 

The Global pane contains things that would be actively used during a run session:
<img width="202" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/d06dae41-65b1-4579-89dc-944e4e052354">

The Model pane now contains things that are generally set once such as output controls:
<img width="199" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/7d88e770-ea6b-49a8-81b3-892364c40e3f">
