### PR TITLE
Move to CC BY-NC-SA 4.0 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -15,7 +15,7 @@ The contents of:
     /src/main/java/titanicsend
     /test
 
-are hereby licensed under the terms of the MIT license, with the following exceptions: The contents of the following directories have complex or indeterminate licensing, and should not be considered open-source software:
+are hereby licensed under the terms of the [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/) license, with the following exceptions: The contents of the following directories have complex or indeterminate licensing, and should not be considered open-source software:
 
     /resources/pixelblaze
     /src/main/java/titanicsend/pattern/pixelblaze


### PR DESCRIPTION
In March 2023 the TE software team decided to change licenses to the CC BY-NC-SA 4.0 license.  It was understood that work up until that point would remain under the MIT license but everything moving forward would be under the new license.  This PR updates the LICENSE.md file which had not been updated to reflect the intended change.