### PR TITLE
fix: trying to use DMX patterns when no DMX devices attached throws an exception / crashes LX

### DIFF
--- a/src/main/java/titanicsend/dmx/DmxBlend.java
+++ b/src/main/java/titanicsend/dmx/DmxBlend.java
@@ -41,7 +41,8 @@ public class DmxBlend {
    * @param model A model which indicates the set of points to blend
    */
   public void blend(DmxBuffer[] dst, DmxBuffer[] src, double alpha, DmxBuffer[] output, DmxWholeModel model) {
-    for (int i = 0; i < dst.length; i++) {
+    int minLength = Math.min(dst.length, Math.min(src.length, output.length));
+    for (int i = 0; i < minLength; i++) {
       DmxBuffer d = dst[i];
       DmxBuffer s = src[i];
       DmxBuffer o = output[i];

--- a/src/main/java/titanicsend/dmx/DmxEngine.java
+++ b/src/main/java/titanicsend/dmx/DmxEngine.java
@@ -542,12 +542,22 @@ public class DmxEngine implements LXLoopTask {
     if (channel instanceof LXGroup) {
       return getDmxModelBufferByGroup((LXGroup)channel).getArray();
     } else {
-      return this.dmxBufferByLXBuffer.get(this.lxBuffersByChannel.get(channel).get(0)).getArray();
+      DmxModelBuffer dmxBuffer = this.dmxBufferByLXBuffer.get(getLXBufferByChannelAndIndex(channel, 0));
+      return dmxBuffer != null ? dmxBuffer.getArray() : new DmxBuffer[]{};
     }
   }
 
   private DmxBuffer[] getRenderBuffersByChannel(LXAbstractChannel channel) {
-    return this.dmxBufferByLXBuffer.get(this.lxBuffersByChannel.get(channel).get(1)).getArray();
+    DmxModelBuffer dmxBuffer = this.dmxBufferByLXBuffer.get(getLXBufferByChannelAndIndex(channel, 1));
+    return dmxBuffer != null ? dmxBuffer.getArray() : new DmxBuffer[]{};
+  }
+
+  private LXBuffer getLXBufferByChannelAndIndex(LXAbstractChannel channel, int index) {
+    List<LXBuffer> buffers = this.lxBuffersByChannel.get(channel);
+    if (index >= buffers.size()) {
+      return null;
+    }
+    return buffers.get(index);
   }
 
   private void scaleBrightness(DmxBuffer[] fullBuffer, double brightness) {


### PR DESCRIPTION
Bug: trying to use DMX patterns when no DMX devices attached throws an exception / crashes LX

Steps to reproduce:
1. Pick a channel
2. Go to content pane, select `Form > Chevron` (or `Orbox`)
3. Select pattern inside the channel

I'm not sure what our preferred behavior should be when no DMX outputs are available should be (is there a solution higher in the stack, like disabling the engine or hiding the relevant patterns?) but for now I just tried to add some checks for nulls/array index out-of-bounds just so that we don't crash if selecting 

```
[LX 2023/10/10 11:43:39] Calls to DatagramSocket.send() appear to be unexpectedly blocking, you may be sending to an unresolvable address or network queues may be saturated. If you are on Linux/Raspberry-Pi, consult the following URL for guidance on relevant kernel parameters: https://github.com/heronarts/LXStudio/wiki/Raspberry-Pi
[LX 2023/10/10 11:56:22] FATAL ERROR IN LXEngine.run(): Index 1 out of bounds for length 1
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:266)
	at java.base/java.util.Objects.checkIndex(Objects.java:361)
	at java.base/java.util.ArrayList.get(ArrayList.java:427)
	at titanicsend.dmx.DmxEngine.getRenderBuffersByChannel(DmxEngine.java:550)
	at titanicsend.dmx.DmxEngine.runDmxMixer(DmxEngine.java:450)
	at titanicsend.dmx.DmxEngine$OutputTrigger.onSend(DmxEngine.java:98)
	at heronarts.lx.output.LXOutput.send(LXOutput.java:340)
	at heronarts.lx.output.LXOutputGroup.onSend(LXOutputGroup.java:83)
	at heronarts.lx.output.LXOutput.send(LXOutput.java:340)
	at heronarts.lx.LXEngine$Output.send(LXEngine.java:193)
	at heronarts.lx.LXEngine._run(LXEngine.java:1154)
	at heronarts.lx.LXEngine.run(LXEngine.java:948)
	at heronarts.lx.LXEngine.access$1400(LXEngine.java:63)
	at heronarts.lx.LXEngine$ExecutorService.runLoop(LXEngine.java:694)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
```

After making the change to DMX Engine, I bumped into this:

```
[LX 2023/10/10 12:14:41] FATAL ERROR IN LXEngine.run(): Index 0 out of bounds for length 0
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at titanicsend.dmx.DmxBlend.blend(DmxBlend.java:51)
	at titanicsend.dmx.DmxEngine$BlendStack.blend(DmxEngine.java:364)
	at titanicsend.dmx.DmxEngine.runDmxMixer(DmxEngine.java:450)
	at titanicsend.dmx.DmxEngine$OutputTrigger.onSend(DmxEngine.java:98)
	at heronarts.lx.output.LXOutput.send(LXOutput.java:340)
	at heronarts.lx.output.LXOutputGroup.onSend(LXOutputGroup.java:83)
	at heronarts.lx.output.LXOutput.send(LXOutput.java:340)
	at heronarts.lx.LXEngine$Output.send(LXEngine.java:193)
```