### PR TITLE
hiding per-channel color controls

### DIFF
--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -104,7 +104,7 @@ public class TEApp extends LXStudio {
   private static String resourceSubdir;
 
   // Global feature on/off switches for troubleshooting
-  public static final boolean ENABLE_COLOR_CENTRAL = true;
+  public static final boolean ENABLE_COLOR_CENTRAL = false;
   public static final boolean ENABLE_VIEW_CENTRAL = true;
 
   @LXPlugin.Name("Titanic's End")

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -10,6 +10,7 @@ import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.*;
 import heronarts.lx.parameter.BooleanParameter.Mode;
 import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.TEApp;
 import heronarts.lx.utils.LXUtils;
 import titanicsend.lx.LXGradientUtils;
 import titanicsend.lx.LXGradientUtils.BlendFunction;
@@ -652,11 +653,11 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
                 colorPrefix = "[x] ";
             }
             TEColorParameter colorParam = registerColorControl(colorPrefix);
-//            if (missingControls != null && !missingControls.uses_palette) {
-//                markUnused(colorParam.offset);
-//                markUnused(colorParam.gradient);
-//                markUnused(swatchParameter);
-//            }
+            if (!TEApp.ENABLE_COLOR_CENTRAL) {
+                markUnused(colorParam.offset);
+                markUnused(colorParam.gradient);
+                markUnused(swatchParameter);
+            }
 
             // controls will be added in the order their tags appear in the
             // TEControlTag enum
@@ -703,8 +704,8 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          */
         protected void setRemoteControls() {
             setCustomRemoteControls(new LXListenableNormalizedParameter[] {
-                this.color.offset,
-                this.color.gradient,
+                TEApp.ENABLE_COLOR_CENTRAL ? this.color.offset : null,
+                TEApp.ENABLE_COLOR_CENTRAL ? this.color.gradient : null,
                 getSwatchRemoteControl(),
                 getControl(TEControlTag.SPEED).control,
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -10,7 +10,6 @@ import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.*;
 import heronarts.lx.parameter.BooleanParameter.Mode;
 import heronarts.lx.studio.LXStudio;
-import heronarts.lx.studio.TEApp;
 import heronarts.lx.utils.LXUtils;
 import titanicsend.app.TEGlobalPatternControls;
 import titanicsend.lx.LXGradientUtils;
@@ -659,6 +658,7 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             // TEControlTag enum
             for (TEControlTag tag : TEControlTag.values()) {
                 LXListenableNormalizedParameter param = controlList.get(tag).control;
+
                 if (missingControls != null) {
                     if (missingControls.missing_control_tags.contains(tag)){
                         markUnused(param);
@@ -700,8 +700,8 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
          */
         protected void setRemoteControls() {
             setCustomRemoteControls(new LXListenableNormalizedParameter[] {
-                TEApp.ENABLE_COLOR_CENTRAL ? this.color.offset : null,
-                TEApp.ENABLE_COLOR_CENTRAL ? this.color.gradient : null,
+                this.color.offset,
+                this.color.gradient,
                 getSwatchRemoteControl(),
                 getControl(TEControlTag.SPEED).control,
 

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -653,11 +653,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
                 colorPrefix = "[x] ";
             }
             TEColorParameter colorParam = registerColorControl(colorPrefix);
-            if (!TEApp.ENABLE_COLOR_CENTRAL) {
-                markUnused(colorParam.offset);
-                markUnused(colorParam.gradient);
-                markUnused(swatchParameter);
-            }
 
             // controls will be added in the order their tags appear in the
             // TEControlTag enum

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -658,7 +658,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
             // TEControlTag enum
             for (TEControlTag tag : TEControlTag.values()) {
                 LXListenableNormalizedParameter param = controlList.get(tag).control;
-
                 if (missingControls != null) {
                     if (missingControls.missing_control_tags.contains(tag)){
                         markUnused(param);


### PR DESCRIPTION
Since we're going to allow GrandMA to control our color palette via ArtNet, the idea is we'll have some DMX modulators that control the global color palette (as @jkbelcher set up in #402 ).

To prevent LED operators from accidentally overriding those, we want to hide the offset/gradient/swatch controls from the per-channel pattern controls + midi surfaces.

### Short term

The least invasive approach in the short term felt like the following:
- set `TEApp.ENABLE_COLOR_CENTRAL = false`
  - this hides the `swatch` parameter, and replaces it with the brightness knob in [getSwatchRemoteControl](https://github.com/titanicsend/LXStudio-TE/blob/main/src/main/java/titanicsend/pattern/TEPerformancePattern.java#L729)
- since the offset and gradient controls were still visible, I added some logic to insert nulls into the list of controls if `ENABLE_COLOR_CENTRAL=false`.

Performance View:

![Screen Shot 2023-10-12 at 6 19 31 PM](https://github.com/titanicsend/LXStudio-TE/assets/236018/17678012-9028-4b02-961f-216b8614d9b1)

Design View:
- [ ] Note: there are 2 brightness controls in this view now - should I hide one of them?

![Screen Shot 2023-10-12 at 6 20 06 PM](https://github.com/titanicsend/LXStudio-TE/assets/236018/c70a18c4-3467-4445-9b68-28bf8e2d2196)



### Longer term

It sounded like @jkbelcher and @jvyduna wanted to remove the concept of per-channel color controls entirely, but I don't have enough context on that to be 100% sure that's worth doing right now.  (feedback / guidance would be appreciated on whether this is worth doing, and on whether my understanding below is accurate)

Just to test my understanding of how this might work:
- If we do remove `TEColorParameter` from `TEPerformancePattern`, it seems like we'll need to retrofit the patterns that are getting their colors via `this.controls.color.calcColor[2]` / `TEPerformancePattern.calcColor[2]`.
- It seems like `TEPattern.getSwatchColor` directly references the global palette and could be swapped in for the `calcColor` methods. 
- I'm not totally clear on how exactly how to untangle `TEPerformancePattern.getGradientColor(float lerp)` from `TEPerformancePattern.controls.color`. It seems to reference "gradient stops" that get updated from the color controls. `TEPattern.updateGradientStops` seems to set the gradient stops to what they should be if `TEPerformancePattern.controls.color` wasn't there, but I'm not 100% sure.