### PR TITLE
Allow DmxColorModulator to force Fixed color mode

### DIFF
--- a/src/main/java/titanicsend/modulator/dmx/DmxColorModulator.java
+++ b/src/main/java/titanicsend/modulator/dmx/DmxColorModulator.java
@@ -7,9 +7,11 @@ package titanicsend.modulator.dmx;
 import heronarts.lx.LXCategory;
 import heronarts.lx.color.ColorParameter;
 import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LXDynamicColor;
 import heronarts.lx.dmx.DmxModulator;
 import heronarts.lx.dmx.LXDmxEngine;
 import heronarts.lx.modulator.LXModulator;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.EnumParameter;
 
 /**
@@ -51,6 +53,10 @@ public class DmxColorModulator extends DmxModulator {
     new EnumParameter<ColorPosition>("Color Position", ColorPosition.NONE)
     .setDescription("Destination color position (1-based) in the global palette current swatch");
 
+  public final BooleanParameter fixed =
+    new BooleanParameter("Fixed", true)
+    .setDescription("When applying DMX color to the palette, also set the target color mode to Fixed");
+
   public final ColorParameter color = new ColorParameter("Color", LXColor.BLACK);
 
   public DmxColorModulator() {
@@ -88,6 +94,9 @@ public class DmxColorModulator extends DmxModulator {
         this.lx.engine.palette.swatch.addColor().primary.setColor(LXColor.BLACK);
       }
       this.lx.engine.palette.swatch.getColor(colorPosition.index).primary.setColor(color);
+      if (this.fixed.isOn()) {
+        this.lx.engine.palette.swatch.getColor(colorPosition.index).mode.setValue(LXDynamicColor.Mode.FIXED);
+      }
     }
 
     return LXColor.luminosity(color) / 100.;

--- a/src/main/java/titanicsend/ui/modulator/UIDmxColorModulator.java
+++ b/src/main/java/titanicsend/ui/modulator/UIDmxColorModulator.java
@@ -2,6 +2,7 @@ package titanicsend.ui.modulator;
 
 import heronarts.glx.ui.UI2dComponent;
 import heronarts.glx.ui.UI2dContainer;
+import heronarts.glx.ui.component.UIButton;
 import heronarts.glx.ui.component.UIDropMenu;
 import heronarts.glx.ui.component.UIIntegerBox;
 import heronarts.glx.ui.component.UILabel;
@@ -32,7 +33,11 @@ public class UIDmxColorModulator implements UIModulatorControls<DmxColorModulato
     UI2dContainer.newVerticalContainer(70, 2)
     .addChildren(
         new UILabel(70, 16, "Palette Color").setTextAlignment(Align.LEFT, Align.MIDDLE),
-        new UIDropMenu(56, 16, modulator.colorPosition).setX(6)
+        new UIDropMenu(56, 16, modulator.colorPosition).setX(6),
+        new UIButton(56, 16, modulator.fixed)
+          .setActiveLabel("Fixed")
+          .setInactiveLabel("Same")
+          .setX(6)
         )
     .setX(128)
     .addToContainer(uiModulator);


### PR DESCRIPTION
Adds a new option in DmxColorModulator, defaulting to On, that sets the target color to Fixed mode.  This keeps the palette color from cycling unexpectedly if it was set to Oscillate or Cycle modes.

![image](https://github.com/titanicsend/LXStudio-TE/assets/6582491/231d226e-982c-435a-bddc-bc537bd6a44f)
