### PR TITLE
DmxEngine bug fix: avoid blending channels that have never been run

### DIFF
--- a/resources/vehicle/beacons.txt
+++ b/resources/vehicle/beacons.txt
@@ -1,5 +1,5 @@
 # ID	X	Y	Z	Yaw	Pitch	Roll	IP	SequenceEnabled	fps	Universe	Channel(0-based, fixture may be 1-based)	TiltLimit
-B1	0	7000000	7000000	0	0	0	10.6.1.101	false	30	0	0	45
+#B1	0	7000000	7000000	0	0	0	10.6.1.101	false	30	0	0	45
 #B2	0	7000000	7000000	0	0	0	10.6.1.102	false	30	0	30	45
 #B3	0	7000000	7000000	0	0	0	10.6.1.103	false	30	0	60	45
 #BJKB	0	7000000	7000000	0	0	0	10.1.1.58	false	30	0	0	45


### PR DESCRIPTION
Bug fix: If a file containing disabled channels was opened, and in Performance mode one of the disabled channels was aux-cued prior to being cued or enabled, the DmxEngine was crashing when attempting to look up unknown buffers.  This fix avoids the lookup for these channels; there is no need to blend if the channel has not run.

Both @andrewlook and @jvyduna have seen this error recently.

Also:

- Commented out beacon 1 in the config file by default, so we're not sending packets to a non-existent IP.
- Removed profiler nanoseconds tracking, that should be reserved for the normal mixer.