### PR TITLE
Update midi surfaces and Dev Switch

### DIFF
--- a/src/main/java/titanicsend/app/GigglePixelUI.java
+++ b/src/main/java/titanicsend/app/GigglePixelUI.java
@@ -34,12 +34,17 @@ public class GigglePixelUI extends UICollapsibleSection {
                        GigglePixelListener listener,
                        GigglePixelBroadcaster broadcaster) {
     super(ui, 0, 0, width, 16);
+
+    width = getContentWidth();
     setTitle("GigglePixel");
     setLayout(UI2dContainer.Layout.VERTICAL);
+
     UIDropMenu dropmenu = new UIDropMenu(0, 0, width, 16, gpMode);
     dropmenu.addToContainer(this);
-    UILabel label = new UILabel(0, 0, width, 16, "Peers:");
+    UILabel label = new UILabel(0, 0, width, 12, "Peers:");
+    label.setBottomMargin(4);
     label.addToContainer(this);
+
     listener.peersTextbox = new UITextBox(0, 0, width, 16);
     listener.peersTextbox.addToContainer(this);
 

--- a/src/main/java/titanicsend/app/dev/DevSwitch.java
+++ b/src/main/java/titanicsend/app/dev/DevSwitch.java
@@ -407,8 +407,8 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
 
     this.lx.engine.output.enabled.setValue(true);    
     this.engineLEDs.setValue(true);
-    this.engineBeacons.setValue(true);
-    this.engineDJlights.setValue(true);
+    this.engineBeacons.setValue(false);
+    this.engineDJlights.setValue(false);
     this.lx.engine.osc.receiveActive.setValue(true);
     this.lx.engine.osc.transmitActive.setValue(true);
     CrutchOSC.get().transmitActive.setValue(true);

--- a/src/main/java/titanicsend/app/dev/DevSwitch.java
+++ b/src/main/java/titanicsend/app/dev/DevSwitch.java
@@ -468,6 +468,12 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
     for (LXMidiSurface surface : this.lx.engine.midi.surfaces) {
       if (isTESurface(surface)) {
         surface.enabled.setValue(enabled);
+
+        if (surface instanceof titanicsend.lx.APC40Mk2) {
+          ((titanicsend.lx.APC40Mk2)surface).performanceLock.setValue(true);
+        } else if (surface instanceof heronarts.lx.midi.surface.APC40Mk2) {
+          ((heronarts.lx.midi.surface.APC40Mk2)surface).performanceLock.setValue(true);
+        }
       }
     }
 

--- a/src/main/java/titanicsend/app/dev/DevSwitch.java
+++ b/src/main/java/titanicsend/app/dev/DevSwitch.java
@@ -191,6 +191,7 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
     addDetailParameter(this.lx.engine.osc.transmitActive, "OSC Output");
     addDetailParameter(TELaserTask.get().enabled, INDENT + "OSC to lasers");
     addDetailParameter(CrutchOSC.get().transmitActive, INDENT + "OSC to iPads");
+    addDetailParameter(this.lx.engine.dmx.artNetReceiveActive, "ArtNet Input");
     addDetailParameter(this.lx.engine.audio.enabled, "Audio Input");
     addDetailParameter(this.midiSurfaces);
     addDetailParameter(this.lx.engine.tempo.enabled, "Tempo Enabled");
@@ -343,6 +344,7 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
         !this.lx.engine.osc.transmitActive.isOn() &&
         !CrutchOSC.get().transmitActive.isOn() &&
         !TELaserTask.get().enabled.isOn() &&
+        this.lx.engine.dmx.artNetReceiveActive.isOn() &&
         this.lx.engine.audio.enabled.isOn() &&
         this.midiSurfaces.isOn() &&
         this.lx.engine.tempo.enabled.isOn() &&
@@ -358,6 +360,7 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
         this.lx.engine.osc.transmitActive.isOn() &&
         CrutchOSC.get().transmitActive.isOn() &&
         TELaserTask.get().enabled.isOn() == TELaserTask.DEFAULT_ENABLE_IN_PRODUCTION &&
+        this.lx.engine.dmx.artNetReceiveActive.isOn() &&
         this.lx.engine.audio.enabled.isOn() &&
         this.midiSurfaces.isOn() &&
         this.lx.engine.tempo.enabled.isOn() &&
@@ -386,6 +389,7 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
     this.lx.engine.osc.transmitActive.setValue(false);
     CrutchOSC.get().transmitActive.setValue(false);
     TELaserTask.get().enabled.setValue(false);
+    this.lx.engine.dmx.artNetReceiveActive.setValue(true);
     this.lx.engine.audio.enabled.setValue(true);
     if (!this.midiSurfaces.getValueb()) {
       this.midiSurfaces.setValue(true);
@@ -413,6 +417,7 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
     this.lx.engine.osc.transmitActive.setValue(true);
     CrutchOSC.get().transmitActive.setValue(true);
     TELaserTask.get().enabled.setValue(TELaserTask.DEFAULT_ENABLE_IN_PRODUCTION);
+    this.lx.engine.dmx.artNetReceiveActive.setValue(true);
     this.lx.engine.audio.enabled.setValue(true);
     if (!this.midiSurfaces.getValueb()) {
       this.midiSurfaces.setValue(true);

--- a/src/main/java/titanicsend/app/dev/UIDevSwitch.java
+++ b/src/main/java/titanicsend/app/dev/UIDevSwitch.java
@@ -28,7 +28,7 @@ public class UIDevSwitch extends UICollapsibleSection implements UIControls {
 
   public UIDevSwitch(UI ui, DevSwitch devSwitch, float w) {
     super(ui, 0, 0, w, 0);
-    this.setTitle("DEV SWITCH");
+    this.setTitle("CONTROL PANEL");
     this.setLayout(Layout.VERTICAL, VERTICAL_SPACING);
 
     this.controlWidth = getContentWidth() -  (PADDING * 2) - LABEL_WIDTH ;

--- a/src/main/java/titanicsend/lx/MidiFighterTwister.java
+++ b/src/main/java/titanicsend/lx/MidiFighterTwister.java
@@ -408,7 +408,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
               payload[idx] = configData.get(iConfig++);
             }
 
-            // System.out.println("Encoder sysex(" + this.encoderIndex + "): " + bytesToString(payload));
+            // LXMidiEngine.log("MFT Encoder sysex(" + this.encoderIndex + "): " + bytesToString(payload));
             output.sendSysex(payload);
           }
         }
@@ -433,7 +433,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
         payload[6] = sysexTag;                      // Encoder identifier
         payload[7] = (byte)0xf7;                    // End sysex
 
-        // System.out.println("Encoder sysex(" + this.encoderIndex + "): " + bytesToString(payload));
+        // LXMidiEngine.log("MFT Encoder sysex(" + this.encoderIndex + "): " + bytesToString(payload));
         output.sendSysex(payload);
 
         // TODO: Process response
@@ -449,7 +449,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
 
     private void pull() {
       // TODO: Query current surface settings
-      System.err.println("Warning: sysex pull not implemented");
+      LXMidiEngine.error("Warning: MFT sysex pull not implemented");
 
       // TODO: Check firmware version for compatibility,
       // only send sysex if year > 2016
@@ -470,7 +470,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
 
     private boolean sendEncoders(boolean forceAll) {
       if (!this.initialized) {
-        System.err.println("Cannot push empty config to device");
+        LXMidiEngine.error("Cannot push empty config to MFT device");
         return false;
       }
 
@@ -489,7 +489,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
 
     private void sendGlobal() {
       if (!this.initialized) {
-        System.err.println("Cannot push empty config to device");
+        LXMidiEngine.error("Cannot push empty config to MFT device");
         return;
       }
 
@@ -506,7 +506,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       }
       sysex[iSys] = (byte)0xf7;
 
-      // System.out.println("System sysex:      " + bytesToString(sysex));
+      // LXMidiEngine.log("MFT System sysex:      " + bytesToString(sysex));
       output.sendSysex(sysex);
     }
 
@@ -901,8 +901,8 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
     this.deviceListener = new DeviceListener(lx);
     addSetting("knobClickMode", this.knobClickMode);
     addSetting("focusMode", this.focusMode);
-    addState("currentBank", this.currentBank);
-    addState("isAux", this.isAux);
+    addSetting("isAux", this.isAux);
+    addSetting("currentBank", this.currentBank);
   }
 
   @Override


### PR DESCRIPTION
The commit messages describe all the changes.

Dev Switch now looks like:
![image](https://github.com/titanicsend/LXStudio-TE/assets/6582491/42a878cb-4b02-41a9-b09d-e7c5111e82c3)

Minor fixes to the GigglePixel UI:
<img width="188" alt="image" src="https://github.com/titanicsend/LXStudio-TE/assets/6582491/03697eec-dac5-4458-ab6e-6aaba0c4e339">

MidiFighterTwister UI should now show the Aux & Bank settings.