### PR TITLE
Mark unused controls in java patterns

### DIFF
--- a/src/main/java/titanicsend/dmx/pattern/ExampleDmxTEPerformancePattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/ExampleDmxTEPerformancePattern.java
@@ -34,10 +34,20 @@ public class ExampleDmxTEPerformancePattern extends TEPerformancePattern {
   public ExampleDmxTEPerformancePattern(LX lx) {
     super(lx);
 
+    // set up the controls used for this pattern.
     this.controls.setRange(TEControlTag.SIZE, 0, 0, 1);
     this.controls.setRange(TEControlTag.XPOS, 0, 0, 360);
     this.controls.getControl(TEControlTag.XPOS).control.setWrappable(true);
     this.controls.setRange(TEControlTag.YPOS, 0, -130, 114);
+
+    // Mark all unused controls for this pattern.
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.BRIGHTNESS));
+    controls.markUnused(controls.getLXControl(TEControlTag.EXPLODE));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
     addCommonControls();
   }

--- a/src/main/java/titanicsend/pattern/jon/ArcEdges.java
+++ b/src/main/java/titanicsend/pattern/jon/ArcEdges.java
@@ -24,6 +24,7 @@ public class ArcEdges extends TEPerformancePattern {
     public ArcEdges(LX lx) {
         super(lx, TEShaderView.ALL_POINTS);
 
+        // set up the controls used for this pattern.
         controls.setRange(TEControlTag.SIZE, 1, 5, 0.1);              // scale
         controls.setRange(TEControlTag.QUANTITY, 0.6, 0.72, 0.35);  // noise field position
         controls.setRange(TEControlTag.WOW1, 0.025, 0.001, 0.08);     // noise magnitude

--- a/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
+++ b/src/main/java/titanicsend/pattern/jon/EdgeKITT.java
@@ -19,6 +19,15 @@ public class EdgeKITT extends TEPerformancePattern {
 
         controls.setRange(TEControlTag.SIZE, 0.5, 0.01, 1.5);
 
+        controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+        controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+        controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+        controls.markUnused(controls.getLXControl(TEControlTag.EXPLODE));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+        controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
+        controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
         addCommonControls();
     }
 

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -23,9 +23,13 @@ public class SpiralDiamonds extends TEPerformancePattern {
     public SpiralDiamonds(LX lx) {
         super(lx, TEShaderView.DOUBLE_LARGE);
 
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
         // Quantity controls density of diamonds
         controls.setRange(TEControlTag.QUANTITY,4,1,7)
                 .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
+
 
         addCommonControls();
         addParameter("energy", energy);

--- a/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
+++ b/src/main/java/titanicsend/pattern/jon/TESparklePattern.java
@@ -255,6 +255,8 @@ public class TESparklePattern extends TEPerformancePattern {
         // maxlevel (in YPos control position)
         controls.setControl(TEControlTag.YPOS,engine.maxLevel);
 
+        controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
+        controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
         addCommonControls();
     }
 

--- a/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TEGradientPattern.java
@@ -95,7 +95,9 @@ public class TEGradientPattern extends TEPerformancePattern {
     this.controls.setRange(TEControlTag.WOW2, 0, 0, 360);
     
     ((LXListenableNormalizedParameter)controls.getLXControl(TEControlTag.WOW2)).setWrappable(true);
-    
+
+    controls.markUnused(controls.getLXControl(TEControlTag.SPEED));
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
     addCommonControls();
   }
   

--- a/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
@@ -4,13 +4,26 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.model.LXPoint;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.jon.TEControlTag;
 
 @LXCategory(LXCategory.COLOR)
 public class TESolidPattern extends TEPerformancePattern {
 
   public TESolidPattern(LX lx) {
     super(lx);
-    
+
+    controls.markUnused(controls.getLXControl(TEControlTag.SPEED));
+    controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.SIZE));
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.BRIGHTNESS));
+    controls.markUnused(controls.getLXControl(TEControlTag.EXPLODE));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
     addCommonControls();
   }
 

--- a/src/main/java/titanicsend/pattern/mike/Checkers.java
+++ b/src/main/java/titanicsend/pattern/mike/Checkers.java
@@ -5,6 +5,7 @@ import heronarts.lx.LXCategory;
 import heronarts.lx.model.LXPoint;
 import titanicsend.model.TEPanelModel;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 import java.util.*;
@@ -17,6 +18,18 @@ public class Checkers extends TEPerformancePattern {
   public Checkers(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
 
+    // Mark all unused controls for this pattern.
+    controls.markUnused(controls.getLXControl(TEControlTag.SPEED));
+    controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.SIZE));
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.EXPLODE));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
     addCommonControls();
 
     this.panelGroup = new HashMap<>();

--- a/src/main/java/titanicsend/pattern/tom/BouncingDots.java
+++ b/src/main/java/titanicsend/pattern/tom/BouncingDots.java
@@ -34,6 +34,16 @@ public class BouncingDots extends TEPerformancePattern {
         // add common controls
         controls.setRange(TEControlTag.SIZE, DEFAULT_DOT_SIZE, MIN_DOT_SIZE, MAX_DOT_SIZE)
                 .setUnits(TEControlTag.SIZE, LXParameter.Units.INTEGER);
+
+        controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+        controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+        controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+        controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+        controls.markUnused(controls.getLXControl(TEControlTag.EXPLODE));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+        controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+        controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
         addCommonControls();
     }
 


### PR DESCRIPTION
This is a short PR to mark unused parameters in the Java patterns.

I went through the code, and double checked the patterns in the UI to make sure the controls are not actually being used by the patterns.

To find which patterns to update, I found all places the "TEPerformancePattern.addCommonControls" and went through all the patterns that are not using shaders.

Also ignored these patterns:
 - Pixelblaze patterns and their sub-classes: the parent class is calling the addCommonControls and all children are inheriting all the controls automatically.
 - Constructed patterns and their sub-classes: Similar to the pixelblaze, the parent class call addCommonControls and all sub-classes are inheriting. But when looking at the code, these classes are using a deprecated fragmented shader class, and they actually have different parameters that are not showing up in the UI.