### PR TITLE
Tools: google java format

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ Steps for setup:
 
 6. Assuming things work okay, a UI for LX Studio will pop up: Great! Now, you can play with the buttons.
 
+### Code Style
+
+These are the steps to use [google-java-format](https://github.com/google/google-java-format) automatically
+and ensure that each commit gets formatted before being submitted.
+
+1. Setup git pre-commit hook to run the `google-java-format` CLI tool on changed files
+
+```sh
+cp pre-commit ./git/hooks/pre-commit
+```
+
+NOTE: you can run the CLI tool to see what it'll output using the `format.sh` script:
+
+```sh
+./format.sh -h
+
+# to reformat one file
+./format.sh src/main/java/titanicsend/MyFile.java
+
+# to bulk-reformat the whole codebase
+./format.sh $(find ./src -type f -iname "*.java")
+```
+
+2. Install the IDE plugin for [IntelliJ](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides) or [Eclipse](https://github.com/google/google-java-format#eclipse)
 
 ### Potential issues
 

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+RELEASE=1.15.0
+JAR_NAME="google-java-format-${RELEASE}-all-deps.jar"
+RELEASES_URL=https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format
+JAR_URL="${RELEASES_URL}/${RELEASE}/${JAR_NAME}"
+
+CACHE_DIR="$HOME/.cache/google-java-format-git-pre-commit-hook"
+JAR_FILE="$CACHE_DIR/$JAR_NAME"
+JAR_DOWNLOAD_FILE="${JAR_FILE}.tmp"
+
+if [[ ! -f "$JAR_FILE" ]]
+then
+    mkdir -p "$CACHE_DIR"
+    curl -L "$JAR_URL" -o "$JAR_DOWNLOAD_FILE"
+    mv "$JAR_DOWNLOAD_FILE" "$JAR_FILE"
+fi
+
+java -jar "${JAR_FILE}" --replace $@
+

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+RELEASE=1.15.0
+JAR_NAME="google-java-format-${RELEASE}-all-deps.jar"
+RELEASES_URL=https://repo1.maven.org/maven2/com/google/googlejavaformat/google-java-format
+JAR_URL="${RELEASES_URL}/${RELEASE}/${JAR_NAME}"
+
+CACHE_DIR="$HOME/.cache/google-java-format-git-pre-commit-hook"
+JAR_FILE="$CACHE_DIR/$JAR_NAME"
+JAR_DOWNLOAD_FILE="${JAR_FILE}.tmp"
+
+if [[ ! -f "$JAR_FILE" ]]
+then
+    mkdir -p "$CACHE_DIR"
+    curl -L "$JAR_URL" -o "$JAR_DOWNLOAD_FILE"
+    mv "$JAR_DOWNLOAD_FILE" "$JAR_FILE"
+fi
+
+#java -jar "${JAR_FILE}" --replace $@
+
+changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*java$" || true)
+if [[ -n "$changed_java_files" ]]
+then
+    echo "Reformatting Java files: $changed_java_files"
+    if ! java -jar "$JAR_FILE" --replace $changed_java_files
+    then
+        echo "An error occurred, aborting commit!" >&2
+        exit 1
+    fi
+else
+    echo "No Java files changes found."
+fi

--- a/pre-commit
+++ b/pre-commit
@@ -23,7 +23,7 @@ changed_java_files=$(git diff --cached --name-only --diff-filter=ACMR | grep ".*
 if [[ -n "$changed_java_files" ]]
 then
     echo "Reformatting Java files: $changed_java_files"
-    if ! java -jar "$JAR_FILE" --replace $changed_java_files
+    if ! java -jar "$JAR_FILE" --dry-run --set-exit-if-changed $changed_java_files
     then
         echo "An error occurred, aborting commit!" >&2
         exit 1


### PR DESCRIPTION
Alternative to #433 that doesn't involve checkstyle.

---

These are the steps to use [google-java-format](https://github.com/google/google-java-format) automatically
and ensure that each commit gets formatted before being submitted.

1. Setup git pre-commit hook to run the `google-java-format` CLI tool on changed files

```sh
cp pre-commit ./git/hooks/pre-commit
```

NOTE: you can run the CLI tool to see what it'll output using the `format.sh` script:

```sh
./format.sh -h

# to reformat one file
./format.sh src/main/java/titanicsend/MyFile.java

# to bulk-reformat the whole codebase
./format.sh $(find ./src -type f -iname "*.java")
```

2. Install the IDE plugin for [IntelliJ](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides) or [Eclipse](https://github.com/google/google-java-format#eclipse)

