### PR TITLE
fix: pixelblaze reference to TEColorType

### DIFF
--- a/resources/pixelblaze/glue.js
+++ b/resources/pixelblaze/glue.js
@@ -3,7 +3,7 @@ This glue file implements a bunch of Pixelblaze compatibility APIs and parts of 
  */
 var Glue = Java.type("titanicsend.pattern.pixelblaze.Glue");
 var LXColor = Java.type("heronarts.lx.color.LXColor");
-var ColorType = Java.type("titanicsend.pattern.TEPattern.ColorType");
+var ColorType = Java.type("titanicsend.color.TEColorType");
 var Noise = Java.type("heronarts.lx.utils.Noise");
 var System = Java.type("java.lang.System");
 


### PR DESCRIPTION
Noticed some error messages in the logs where pixelblaze was looking for a now-nonexistent class (ColorType, renamed to TEColorType in #430 )