### PR TITLE
Add APC40 setting to disable device control knobs

### DIFF
--- a/src/main/java/titanicsend/lx/APC40Mk2.java
+++ b/src/main/java/titanicsend/lx/APC40Mk2.java
@@ -862,7 +862,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     this.deviceListener = new DeviceListener(lx);
     addSetting("masterFaderEnabled", this.masterFaderEnabled);
     addSetting("crossfaderEnabled", this.crossfaderEnabled);
-    addSetting("deviceControlEnabled", this.deviceControl);
+    addSetting("deviceControl", this.deviceControl);
     addSetting("performanceLock", this.performanceLock);
   }
 
@@ -936,18 +936,8 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
 
     sendUserDefinedLights();
     sendPerformanceLights();
+    initializeDeviceControlKnobs(reconnect);
 
-    for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
-      if (isDeviceControl()) {
-        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
-      } else {
-        // Initialize device knobs for generic control
-        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_SINGLE);
-        if (!reconnect) {
-          sendControlChange(0, DEVICE_KNOB + i, 64);
-        }
-      }
-    }
     for (int i = 0; i < CHANNEL_KNOB_NUM; ++i) {
       // Initialize channel knobs for generic control, but don't
       // reset their values if we're in a reconnect situation
@@ -959,6 +949,22 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     sendChannels();
     this.cueState.reset();
     this.auxState.reset();
+  }
+
+  private void initializeDeviceControlKnobs(boolean reconnect) {
+    if (isDeviceControl()) {
+      for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
+        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
+      }
+    } else {
+      for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
+        // Initialize device knobs for generic control
+        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_SINGLE);
+        if (!reconnect) {
+          sendControlChange(0, DEVICE_KNOB + i, 64);
+        }
+      }
+    }
   }
 
   private void resetPaletteVars() {
@@ -1432,11 +1438,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       registerDeviceControl();
     } else {
       unregisterDeviceControl();
-      // Surface was enabled and now is releasing device control
-      for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
-        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_SINGLE);
-        sendControlChange(0, DEVICE_KNOB + i, 64);
-      }
+      initializeDeviceControlKnobs(false);
     }
   }
 

--- a/src/main/java/titanicsend/lx/APC40Mk2.java
+++ b/src/main/java/titanicsend/lx/APC40Mk2.java
@@ -311,7 +311,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
 
   private void setAux(boolean isAux) {
     this.isAux = isAux;
-    this.deviceListener.focusedDevice.setAux(isAux);
+    if (isDeviceControl()) {
+      this.deviceListener.focusedDevice.setAux(isAux);
+    }
     this.lx.engine.performanceMode.setValue(true);
     sendUserDefinedLights();
     sendPerformanceLights();
@@ -847,6 +849,10 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       new BooleanParameter("Crossfader", true)
           .setDescription("Whether the A/B crossfader is enabled");
 
+  public final BooleanParameter deviceControl =
+    new BooleanParameter("Device Control", false)
+      .setDescription("Use the device knobs on the right side of the APC40mkII to control the focused device");
+
   public final BooleanParameter performanceLock =
       new BooleanParameter("Performance Lock", false)
           .setDescription("Keep surface in Performance mode regardless of Design/Perform toggle");
@@ -856,14 +862,19 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     this.deviceListener = new DeviceListener(lx);
     addSetting("masterFaderEnabled", this.masterFaderEnabled);
     addSetting("crossfaderEnabled", this.crossfaderEnabled);
+    addSetting("deviceControlEnabled", this.deviceControl);
     addSetting("performanceLock", this.performanceLock);
   }
 
   @Override
   public void onParameterChanged(LXParameter p) {
     super.onParameterChanged(p);
-    if (p == this.performanceLock && this.enabled.isOn()) {
-      updatePerformanceMode();
+    if (this.enabled.isOn()) {
+      if (p == this.performanceLock) {
+        updatePerformanceMode();
+      } else if (p == this.deviceControl) {
+        onDeviceControlChanged();
+      }
     }
   }
 
@@ -874,7 +885,6 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       initialize(false);
       register();
     } else {
-      this.deviceListener.registerDevice(null);
       for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
         if (channel instanceof LXChannel) {
           ((LXChannel) channel).controlSurfaceFocusLength.setValue(0);
@@ -892,7 +902,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     if (this.enabled.isOn()) {
       setApcMode(ABLETON_ALTERNATE_MODE);
       initialize(true);
-      this.deviceListener.resend();
+      if (isDeviceControl()) {
+        this.deviceListener.resend();
+      }
     }
   }
 
@@ -926,7 +938,15 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     sendPerformanceLights();
 
     for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
-      sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
+      if (isDeviceControl()) {
+        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
+      } else {
+        // Initialize device knobs for generic control
+        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_SINGLE);
+        if (!reconnect) {
+          sendControlChange(0, DEVICE_KNOB + i, 64);
+        }
+      }
     }
     for (int i = 0; i < CHANNEL_KNOB_NUM; ++i) {
       // Initialize channel knobs for generic control, but don't
@@ -1114,7 +1134,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
   }
 
   private void sendDeviceOnOff() {
-    this.deviceListener.sendDeviceOnOff();
+    if (isDeviceControl()) {
+      this.deviceListener.sendDeviceOnOff();
+    }
   }
 
   private void sendSwatches() {
@@ -1326,7 +1348,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
   private void register() {
     this.isRegistered = true;
 
-    this.deviceListener.focusedDevice.register();
+    if (isDeviceControl()) {
+      registerDeviceControl();
+    }
 
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
       registerChannel(channel);
@@ -1370,7 +1394,10 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
   private void unregister() {
     this.isRegistered = false;
 
-    this.deviceListener.focusedDevice.unregister();
+    //this.deviceListener.registerDevice(null);
+    if (isDeviceControl()) {
+      unregisterDeviceControl();
+    }
 
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
       unregisterChannel(channel);
@@ -1394,6 +1421,31 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     }
 
     clearChannelGrid();
+  }
+
+  private boolean isDeviceControl() {
+    return this.deviceControl.isOn();
+  }
+
+  private void onDeviceControlChanged() {
+    if (isDeviceControl()) {
+      registerDeviceControl();
+    } else {
+      unregisterDeviceControl();
+      // Surface was enabled and now is releasing device control
+      for (int i = 0; i < DEVICE_KNOB_NUM; ++i) {
+        sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_SINGLE);
+        sendControlChange(0, DEVICE_KNOB + i, 64);
+      }
+    }
+  }
+
+  private void registerDeviceControl() {
+    this.deviceListener.focusedDevice.register();
+  }
+
+  private void unregisterDeviceControl() {
+    this.deviceListener.focusedDevice.unregister();
   }
 
   private void registerChannel(LXAbstractChannel channel) {
@@ -1555,13 +1607,17 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           }
           return;
         case BANK_SELECT_LEFT:
-          this.deviceListener.focusedDevice.previousChannel();
+          if (isDeviceControl()) {
+            this.deviceListener.focusedDevice.previousChannel();
+          }
           if (!isAuxActive()) {
             lx.engine.mixer.selectChannel(lx.engine.mixer.getFocusedChannel());
           }
           return;
         case BANK_SELECT_RIGHT:
-          this.deviceListener.focusedDevice.nextChannel();
+          if (isDeviceControl()) {
+            this.deviceListener.focusedDevice.nextChannel();
+          }
           if (!isAuxActive()) {
             lx.engine.mixer.selectChannel(lx.engine.mixer.getFocusedChannel());
           }
@@ -1796,17 +1852,25 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
         }
         break;
       case DEVICE_ON_OFF:
-        this.deviceListener.onDeviceOnOff();
+        if (isDeviceControl()) {
+          this.deviceListener.onDeviceOnOff();
+        }
         break;
       case DEVICE_LEFT:
-        this.deviceListener.focusedDevice.previousDevice();
+        if (isDeviceControl()) {
+          this.deviceListener.focusedDevice.previousDevice();
+        }
         break;
       case DEVICE_RIGHT:
-        this.deviceListener.focusedDevice.nextDevice();
+        if (isDeviceControl()) {
+          this.deviceListener.focusedDevice.nextDevice();
+        }
         break;
       case BANK_LEFT:
       case BANK_RIGHT:
-        this.deviceListener.incrementBank((pitch == BANK_LEFT) ? -1 : 1);
+        if (isDeviceControl()) {
+          this.deviceListener.incrementBank((pitch == BANK_LEFT) ? -1 : 1);
+        }
         break;
 
       default:
@@ -1920,7 +1984,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     }
 
     if (number >= DEVICE_KNOB && number <= DEVICE_KNOB_MAX) {
-      this.deviceListener.onKnob(number - DEVICE_KNOB, cc.getNormalized());
+      if (isDeviceControl()) {
+        this.deviceListener.onKnob(number - DEVICE_KNOB, cc.getNormalized());
+      }
       return;
     }
 


### PR DESCRIPTION
Allows knobs in the DEVICE CONTROL section of the APC40mkII to be used for generic mapping instead of controlling the focused device.

Note the knob indicator lights will not update for generic mappings.
