### PR TITLE
remove RhythmicFlashingStatic (from base Oct_21 showfile and available patterns list)

### DIFF
--- a/Projects/Oct_21.lxp
+++ b/Projects/Oct_21.lxp
@@ -1,6 +1,6 @@
 {
   "version": "0.4.2.TE.7-SNAPSHOT",
-  "timestamp": 1697916459321,
+  "timestamp": 1711571514462,
   "model": {
     "id": 2,
     "class": "heronarts.lx.structure.LXStructure",
@@ -30,7 +30,7 @@
         "children": {},
         "views": [
           {
-            "id": 39,
+            "id": 923,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 0,
@@ -47,7 +47,7 @@
             "children": {}
           },
           {
-            "id": 40,
+            "id": 924,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 1,
@@ -64,7 +64,7 @@
             "children": {}
           },
           {
-            "id": 41,
+            "id": 925,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 2,
@@ -81,7 +81,7 @@
             "children": {}
           },
           {
-            "id": 42,
+            "id": 926,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 3,
@@ -98,7 +98,7 @@
             "children": {}
           },
           {
-            "id": 43,
+            "id": 927,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 4,
@@ -115,7 +115,7 @@
             "children": {}
           },
           {
-            "id": 44,
+            "id": 928,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 5,
@@ -132,7 +132,7 @@
             "children": {}
           },
           {
-            "id": 45,
+            "id": 929,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 6,
@@ -149,7 +149,7 @@
             "children": {}
           },
           {
-            "id": 46,
+            "id": 930,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 7,
@@ -166,7 +166,7 @@
             "children": {}
           },
           {
-            "id": 47,
+            "id": 931,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 8,
@@ -183,7 +183,7 @@
             "children": {}
           },
           {
-            "id": 48,
+            "id": 932,
             "class": "heronarts.lx.structure.view.LXViewDefinition",
             "internal": {
               "modulationColor": 9,
@@ -3107,7 +3107,7 @@
           "label": "Mixer",
           "crossfader": 0.4645669291338583,
           "crossfaderBlendMode": 1,
-          "focusedChannel": 1,
+          "focusedChannel": 0,
           "focusedChannelAux": 1,
           "cueA": false,
           "cueB": false,
@@ -3327,7 +3327,7 @@
               "label": "Group-MAIN",
               "fader": 0.0,
               "arm": false,
-              "selected": false,
+              "selected": true,
               "enabled": true,
               "cue": false,
               "aux": false,
@@ -3361,8 +3361,8 @@
               "label": "2 (Moton Hi + Lo)",
               "fader": 0.0,
               "arm": false,
-              "selected": true,
-              "enabled": false,
+              "selected": false,
+              "enabled": true,
               "cue": true,
               "aux": false,
               "crossfadeGroup": 0,
@@ -3383,13 +3383,13 @@
               "transitionEnabled": false,
               "transitionTimeSecs": 5.0,
               "transitionBlendMode": 0,
-              "focusedPattern": 14,
+              "focusedPattern": 16,
               "triggerPatternCycle": false
             },
             "children": {},
             "effects": [],
             "clips": [],
-            "patternIndex": 14,
+            "patternIndex": 16,
             "patterns": [
               {
                 "id": 44599,
@@ -3428,13 +3428,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3467,11 +3465,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3512,13 +3511,11 @@
                   "te_quantity": 0.5516398458350886,
                   "te_spin": 0.0,
                   "te_brightness": 0.984251968503937,
-                  "te_explode": 0.0,
                   "te_wow1": 0.02392234373829706,
                   "te_wow2": 0.008,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3551,11 +3548,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3596,13 +3594,11 @@
                   "te_quantity": 0.2,
                   "te_spin": 0.050029108176637305,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.8806484294123947,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3635,11 +3631,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3680,13 +3677,11 @@
                   "te_quantity": 6.939062508259667,
                   "te_spin": 0.037191224803793776,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.03131562514638062,
                   "te_wow2": 0.4375625123735516,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3719,11 +3714,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3764,13 +3760,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.2041910189643763,
                   "te_brightness": 0.9954296875512227,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.5568750025704503,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3803,11 +3797,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3848,13 +3843,11 @@
                   "te_quantity": 0.5846093705695239,
                   "te_spin": 0.04270036099655128,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3887,11 +3880,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -3932,13 +3926,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.08131408865688172,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.22277344157919288,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -3971,11 +3963,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4016,18 +4009,16 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.24286416742858874,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.03804269667673088,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "speed": 0.7,
                   "hideBlocks": false,
-                  "glow": 0.5,
+                  "speed": 0.7,
+                  "ySpread": 1.6,
                   "numBlocks": 30.0,
-                  "ySpread": 1.6
+                  "glow": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -4060,11 +4051,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4105,13 +4097,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.147684087404641,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.34183593711350113,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "width": 0.5,
                   "glow": 0.2
                 },
@@ -4146,11 +4136,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4191,13 +4182,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.18732665787880243,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.21481250040233135,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4230,11 +4219,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4275,13 +4265,11 @@
                   "te_quantity": 0.5,
                   "te_spin": -0.005087701462599514,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0030859375838190317,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4314,11 +4302,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4359,13 +4348,11 @@
                   "te_quantity": 5.41656237810821,
                   "te_spin": 0.07980624998421404,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.13390625221654773,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4398,11 +4385,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4443,13 +4431,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.04472564114094557,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.7362500061281025,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4482,11 +4468,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4527,13 +4514,11 @@
                   "te_quantity": 2.277640621177852,
                   "te_spin": 5.603575452026721E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4566,11 +4551,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4611,13 +4597,11 @@
                   "te_quantity": 0.06404060646775175,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 7.9753433587052855,
                   "te_wow2": 0.2949609411007259,
                   "te_wowtrigger": false,
                   "te_angle": -0.47442957844482914,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4650,11 +4634,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4695,13 +4680,11 @@
                   "te_quantity": 0.15,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2.823343762219956,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4734,179 +4717,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
-                  "/te_wow1",
-                  "/te_wow2",
-                  "/te_wowtrigger",
-                  "/te_explode"
-                ],
-                "effects": []
-              },
-              {
-                "id": 45732,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$RhythmicFlashStatic",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true,
-                  "expanded": true,
-                  "expandedCue": true,
-                  "expandedAux": true,
-                  "modulationExpanded": false
-                },
-                "parameters": {
-                  "label": "+ RhythmicFlashStatic",
-                  "view": 0,
-                  "viewPriority": 0,
-                  "enabled": true,
-                  "recall": false,
-                  "compositeMode": 0,
-                  "compositeLevel": 1.0,
-                  "hasCustomCycleTime": false,
-                  "customCycleTimeSecs": 60.0,
-                  "te_color/brightness": 100.0,
-                  "te_color/saturation": 100.0,
-                  "te_color/hue": 0.0,
-                  "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
-                  "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "te_speed": 4.0,
-                  "te_xpos": 0.0,
-                  "te_ypos": 0.0,
-                  "te_size": 0.4045218554348685,
-                  "te_quantity": 0.1827734352555126,
-                  "te_spin": 0.0,
-                  "te_brightness": 1.0,
-                  "te_explode": 0.0,
-                  "te_wow1": 0.5212890676921234,
-                  "te_wow2": 0.0,
-                  "te_wowtrigger": false,
-                  "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
-                },
-                "children": {
-                  "modulation": {
-                    "id": 45733,
-                    "class": "heronarts.lx.modulation.LXModulationEngine",
-                    "internal": {
-                      "modulationColor": 0,
-                      "modulationControlsExpanded": true,
-                      "modulationsExpanded": true
-                    },
-                    "parameters": {
-                      "label": "Modulation"
-                    },
-                    "children": {},
-                    "modulators": [],
-                    "modulations": [],
-                    "triggers": []
-                  }
-                },
-                "deviceVersion": -1,
-                "remoteControls": [
-                  "/te_color/offset",
-                  "/te_color/gradient",
                   null,
-                  "/te_speed",
-                  "/te_xpos",
-                  "/te_ypos",
-                  "/te_quantity",
-                  "/te_size",
-                  "/te_angle",
-                  "/te_spin",
-                  "/panic",
-                  "/viewPerPattern",
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
-                ],
-                "effects": []
-              },
-              {
-                "id": 87212,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$RhythmicFlashStatic",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true,
-                  "expanded": true,
-                  "expandedCue": true,
-                  "expandedAux": true,
-                  "modulationExpanded": false
-                },
-                "parameters": {
-                  "label": "- RhythmicFlashStatic",
-                  "view": 0,
-                  "viewPriority": 0,
-                  "enabled": true,
-                  "recall": false,
-                  "compositeMode": 0,
-                  "compositeLevel": 1.0,
-                  "hasCustomCycleTime": false,
-                  "customCycleTimeSecs": 60.0,
-                  "te_color/brightness": 100.0,
-                  "te_color/saturation": 100.0,
-                  "te_color/hue": 0.0,
-                  "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
-                  "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "te_speed": 4.0,
-                  "te_xpos": 0.0,
-                  "te_ypos": 0.0,
-                  "te_size": 1.0,
-                  "te_quantity": 0.08726560887589585,
-                  "te_spin": 0.0,
-                  "te_brightness": 1.0,
-                  "te_explode": 0.0,
-                  "te_wow1": 0.6836718742270023,
-                  "te_wow2": 0.0,
-                  "te_wowtrigger": false,
-                  "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
-                },
-                "children": {
-                  "modulation": {
-                    "id": 87213,
-                    "class": "heronarts.lx.modulation.LXModulationEngine",
-                    "internal": {
-                      "modulationColor": 0,
-                      "modulationControlsExpanded": true,
-                      "modulationsExpanded": true
-                    },
-                    "parameters": {
-                      "label": "Modulation"
-                    },
-                    "children": {},
-                    "modulators": [],
-                    "modulations": [],
-                    "triggers": []
-                  }
-                },
-                "deviceVersion": -1,
-                "remoteControls": [
-                  "/te_color/offset",
-                  "/te_color/gradient",
                   null,
-                  "/te_speed",
-                  "/te_xpos",
-                  "/te_ypos",
-                  "/te_quantity",
-                  "/te_size",
-                  "/te_angle",
-                  "/te_spin",
-                  "/panic",
-                  "/viewPerPattern",
-                  "/te_wow1",
-                  "/te_wow2",
-                  "/te_wowtrigger",
-                  "/te_explode"
+                  "/view"
                 ],
                 "effects": []
               },
@@ -4947,13 +4763,11 @@
                   "te_quantity": 2.132656247355044,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7086614173228338,
                   "te_wow2": 0.07341043937242764,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -4986,11 +4800,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5031,13 +4846,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0020226369617407,
                   "te_wow2": 0.0011017418411508606,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5070,11 +4883,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5115,13 +4929,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 3.3531249929219484,
                   "te_wow2": 0.9017187533900142,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5154,11 +4966,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5199,13 +5012,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5818750029429793,
                   "te_wow2": 0.4201562483794987,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5238,11 +5049,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5283,13 +5095,11 @@
                   "te_quantity": 1.6415039142593741,
                   "te_spin": 0.02460976594934472,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0011328124674037099,
                   "te_wow2": 0.022343749762512743,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5322,11 +5132,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5367,13 +5178,11 @@
                   "te_quantity": 0.6857421912063728,
                   "te_spin": 0.011455688556307075,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7417578133172356,
                   "te_wow2": 0.19558593455440132,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5406,11 +5215,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5451,13 +5261,11 @@
                   "te_quantity": 4.0250781601062045,
                   "te_spin": 0.06542404777056943,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.4898828104051063,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -5491,11 +5299,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5536,13 +5345,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.016798590155487236,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -5576,11 +5383,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5621,13 +5429,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.07596914142428668,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6927343787901918,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -5662,11 +5468,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5707,15 +5514,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.02527603201144535,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6591953097515216,
                   "te_wow2": 0.5987500015908154,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "noise2": 2.0,
-                  "noise": 2.0
+                  "noise": 2.0,
+                  "noise2": 2.0
                 },
                 "children": {
                   "modulation": {
@@ -5748,11 +5553,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5793,13 +5599,11 @@
                   "te_quantity": 12.201367290959752,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.17629828819048154,
                   "te_wow2": 0.12638287340573184,
                   "te_wowtrigger": false,
                   "te_angle": 0.02282563233349233,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5832,11 +5636,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5877,13 +5682,11 @@
                   "te_quantity": 12.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.05832031272148014,
                   "te_wow2": 0.036132811524439604,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -5916,11 +5719,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -5961,13 +5765,11 @@
                   "te_quantity": 3.057421952718869,
                   "te_spin": 0.0,
                   "te_brightness": 0.984251968503937,
-                  "te_explode": 0.0,
                   "te_wow1": 0.08080078112412592,
                   "te_wow2": 0.09841796767912456,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6000,11 +5802,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6045,13 +5848,11 @@
                   "te_quantity": 3.468359389473335,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.18421874890918843,
                   "te_wow2": 0.026400867777172564,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6084,11 +5885,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6129,13 +5931,11 @@
                   "te_quantity": 3.052656266372651,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.916523442487232,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6168,11 +5968,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6213,13 +6014,11 @@
                   "te_quantity": 2.545781277003698,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.8271093598305015,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6252,11 +6051,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6297,13 +6097,11 @@
                   "te_quantity": 55.01484438267653,
                   "te_spin": 0.03925351557702528,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 0.0024999999441206455,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6336,11 +6134,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6381,13 +6180,11 @@
                   "te_quantity": 53.17265726305777,
                   "te_spin": 0.004430566324421736,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6420,11 +6217,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6465,13 +6263,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.06886718503665179,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6504,11 +6300,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6549,13 +6346,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.030156247630657163,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6588,11 +6383,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -6637,13 +6433,13 @@
               "transitionEnabled": false,
               "transitionTimeSecs": 5.0,
               "transitionBlendMode": 0,
-              "focusedPattern": 25,
+              "focusedPattern": 15,
               "triggerPatternCycle": false
             },
             "children": {},
             "effects": [],
             "clips": [],
-            "patternIndex": 25,
+            "patternIndex": 24,
             "patterns": [
               {
                 "id": 99935,
@@ -6682,13 +6478,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6721,11 +6515,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6766,13 +6561,11 @@
                   "te_quantity": 0.5516398458350886,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.02392234373829706,
                   "te_wow2": 0.011544062746605053,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6805,11 +6598,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6850,13 +6644,11 @@
                   "te_quantity": 0.2,
                   "te_spin": 0.050029108176637305,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.8806484294123947,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6889,11 +6681,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -6934,13 +6727,11 @@
                   "te_quantity": 6.939062508259667,
                   "te_spin": 0.037191224803793776,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.035146874938509425,
                   "te_wow2": 0.5699062613304703,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -6973,11 +6764,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7018,13 +6810,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.2041910189643763,
                   "te_brightness": 0.5748031496062992,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.5568750025704503,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7057,11 +6847,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7102,13 +6893,11 @@
                   "te_quantity": 0.5846093705695239,
                   "te_spin": 0.06630625069306673,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.39980470202863216,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7141,11 +6930,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7186,13 +6976,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.08131408865688172,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0034863287255575415,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7225,11 +7013,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7270,18 +7059,16 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.24286416742858874,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.03804269667673088,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "numBlocks": 30.0,
                   "hideBlocks": false,
                   "speed": 0.7,
-                  "glow": 0.5,
-                  "ySpread": 1.6
+                  "ySpread": 1.6,
+                  "numBlocks": 30.0,
+                  "glow": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -7314,11 +7101,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7359,15 +7147,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.147684087404641,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.34183593711350113,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "glow": 0.2,
-                  "width": 0.5
+                  "width": 0.5,
+                  "glow": 0.2
                 },
                 "children": {
                   "modulation": {
@@ -7400,11 +7186,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7445,13 +7232,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.18732665787880243,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0165624957531691,
                   "te_wow2": 0.0012499999720603228,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7484,11 +7269,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7529,13 +7315,11 @@
                   "te_quantity": 0.5,
                   "te_spin": -0.005087701462599514,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7568,11 +7352,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7613,13 +7398,11 @@
                   "te_quantity": 5.41656237810821,
                   "te_spin": 0.07980624998421404,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.13390625221654773,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7652,11 +7435,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7697,13 +7481,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.04472564114094557,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.7362500061281025,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7736,11 +7518,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7781,13 +7564,11 @@
                   "te_quantity": 2.0266679903994373,
                   "te_spin": 5.603575452026721E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7820,11 +7601,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -7865,13 +7647,11 @@
                   "te_quantity": 0.06404060646775175,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.619849976915793,
                   "te_wow2": 0.2949609411007259,
                   "te_wowtrigger": false,
                   "te_angle": -0.47442957844482914,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -7904,95 +7684,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
-                  "/te_wow1",
-                  "/te_wow2",
-                  "/te_wowtrigger",
-                  "/te_explode"
-                ],
-                "effects": []
-              },
-              {
-                "id": 100312,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$RhythmicFlashStatic",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true,
-                  "expanded": true,
-                  "expandedCue": true,
-                  "expandedAux": true,
-                  "modulationExpanded": false
-                },
-                "parameters": {
-                  "label": "+ RhythmicFlashStatic",
-                  "view": 0,
-                  "viewPriority": 0,
-                  "enabled": true,
-                  "recall": false,
-                  "compositeMode": 0,
-                  "compositeLevel": 1.0,
-                  "hasCustomCycleTime": false,
-                  "customCycleTimeSecs": 60.0,
-                  "te_color/brightness": 100.0,
-                  "te_color/saturation": 100.0,
-                  "te_color/hue": 0.0,
-                  "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
-                  "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "te_speed": 4.0,
-                  "te_xpos": 0.0,
-                  "te_ypos": 0.0,
-                  "te_size": 0.4045218554348685,
-                  "te_quantity": 0.1827734352555126,
-                  "te_spin": 0.0,
-                  "te_brightness": 1.0,
-                  "te_explode": 0.0,
-                  "te_wow1": 0.5212890676921234,
-                  "te_wow2": 0.0,
-                  "te_wowtrigger": false,
-                  "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
-                },
-                "children": {
-                  "modulation": {
-                    "id": 100313,
-                    "class": "heronarts.lx.modulation.LXModulationEngine",
-                    "internal": {
-                      "modulationColor": 0,
-                      "modulationControlsExpanded": true,
-                      "modulationsExpanded": true
-                    },
-                    "parameters": {
-                      "label": "Modulation"
-                    },
-                    "children": {},
-                    "modulators": [],
-                    "modulations": [],
-                    "triggers": []
-                  }
-                },
-                "deviceVersion": -1,
-                "remoteControls": [
-                  "/te_color/offset",
-                  "/te_color/gradient",
                   null,
-                  "/te_speed",
-                  "/te_xpos",
-                  "/te_ypos",
-                  "/te_quantity",
-                  "/te_size",
-                  "/te_angle",
-                  "/te_spin",
-                  "/panic",
-                  "/viewPerPattern",
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8033,13 +7730,11 @@
                   "te_quantity": 2.132656247355044,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7086614173228338,
                   "te_wow2": 0.07341043937242764,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8072,11 +7767,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8117,13 +7813,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 3.3531249929219484,
                   "te_wow2": 0.9017187533900142,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8156,11 +7850,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8201,13 +7896,11 @@
                   "te_quantity": 1.6415039142593741,
                   "te_spin": 0.02460976594934472,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0011328124674037099,
                   "te_wow2": 0.022343749762512743,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8240,11 +7933,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8285,13 +7979,11 @@
                   "te_quantity": 4.0250781601062045,
                   "te_spin": 0.06542404777056943,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.4898828104051063,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -8325,11 +8017,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8370,15 +8063,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.07596914142428668,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6927343787901918,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "noise2": 2.0,
-                  "noise": 2.0
+                  "noise": 2.0,
+                  "noise2": 2.0
                 },
                 "children": {
                   "modulation": {
@@ -8411,11 +8102,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8456,13 +8148,11 @@
                   "te_quantity": 12.201367290959752,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.17629828819048154,
                   "te_wow2": 0.12638287340573184,
                   "te_wowtrigger": false,
                   "te_angle": 0.02282563233349233,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8495,11 +8185,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8540,13 +8231,11 @@
                   "te_quantity": 3.057421952718869,
                   "te_spin": 0.0,
                   "te_brightness": 0.984251968503937,
-                  "te_explode": 0.0,
                   "te_wow1": 0.08080078112412592,
                   "te_wow2": 0.09841796767912456,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8579,11 +8268,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8624,13 +8314,11 @@
                   "te_quantity": 3.052656266372651,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.916523442487232,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8663,11 +8351,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8708,13 +8397,11 @@
                   "te_quantity": 55.01484438267653,
                   "te_spin": 0.03925351557702528,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 0.0024999999441206455,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8747,11 +8434,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -8792,13 +8480,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.06886718503665179,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8831,11 +8517,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -8925,13 +8612,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -8964,11 +8649,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9009,13 +8695,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9048,11 +8732,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9093,13 +8778,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9132,11 +8815,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9177,13 +8861,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9216,11 +8898,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9261,13 +8944,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.12299268096941951,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.5568750025704503,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9300,11 +8981,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9345,13 +9027,11 @@
                   "te_quantity": 7.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2.5,
                   "te_wow2": 1.5,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9384,11 +9064,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9429,13 +9110,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03087158836549264,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.3703906235678005,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9468,11 +9147,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9513,13 +9193,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.08131408865688172,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0474707037465123,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9552,11 +9230,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9597,18 +9276,16 @@
                   "te_quantity": 0.4706250060116872,
                   "te_spin": -0.008833064220220899,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 2,
                   "Energy": 0.0,
                   "Glow": 1.5,
+                  "Speed": 0.0,
                   "Wibble Size": 0.15,
                   "Thickness": 0.3,
-                  "Speed": 0.0,
                   "Glow2": 9.0
                 },
                 "children": {
@@ -9642,11 +9319,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9687,15 +9365,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.05147226591235965,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.34183593711350113,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "glow": 0.2,
-                  "width": 0.5
+                  "width": 0.5,
+                  "glow": 0.2
                 },
                 "children": {
                   "modulation": {
@@ -9728,11 +9404,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9773,13 +9450,11 @@
                   "te_quantity": 20.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.1342578122857958,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9812,11 +9487,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9857,13 +9533,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6584375031292438,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9896,11 +9570,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -9941,13 +9616,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.07980624998421404,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.14383593810925957,
                   "te_wow2": 0.03859374998137355,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -9980,11 +9653,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10025,13 +9699,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0,
                   "te_wow2": 0.5,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10064,11 +9736,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10109,13 +9782,11 @@
                   "te_quantity": 0.5565234392415732,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.9976562500232831,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10148,11 +9819,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10193,13 +9865,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.04472564114094557,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10232,11 +9902,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10277,13 +9948,11 @@
                   "te_quantity": 1.7921367343471502,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0,
                   "te_wow2": 0.9872265623416752,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10316,11 +9985,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10361,13 +10031,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.5,
                   "te_wow2": 0.2,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10400,11 +10068,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10445,13 +10114,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 0.4645669291338583,
-                  "te_explode": 0.0,
                   "te_wow1": 3.8740157480314963,
                   "te_wow2": 2.1968503937007853,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10484,11 +10151,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10529,13 +10197,11 @@
                   "te_quantity": 0.6857421912063728,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7417578133172356,
                   "te_wow2": 0.19558593455440132,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10568,11 +10234,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10613,13 +10280,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.06542404777056943,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -10653,11 +10318,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10698,13 +10364,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.07596914142428668,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7305624997032283,
                   "te_wow2": 0.6053125001490116,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -10739,11 +10403,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10784,13 +10449,11 @@
                   "te_quantity": 12.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6513671880937182,
                   "te_wow2": 0.11,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10823,11 +10486,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10868,13 +10532,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.14833984359152963,
                   "te_wow2": 0.0883789052652719,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10907,11 +10569,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -10952,13 +10615,11 @@
                   "te_quantity": 2.545781277003698,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.8271093598305015,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -10991,11 +10652,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11036,13 +10698,11 @@
                   "te_quantity": 55.01484438267653,
                   "te_spin": 0.03925351557702528,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11075,11 +10735,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11120,13 +10781,11 @@
                   "te_quantity": 0.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11159,11 +10818,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11204,13 +10864,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.06886718503665179,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11243,11 +10901,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11288,13 +10947,11 @@
                   "te_quantity": 7.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.04,
                   "te_wow2": 0.5,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11327,11 +10984,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -11376,7 +11034,7 @@
               "transitionEnabled": false,
               "transitionTimeSecs": 5.0,
               "transitionBlendMode": 0,
-              "focusedPattern": 9,
+              "focusedPattern": 15,
               "triggerPatternCycle": false
             },
             "children": {},
@@ -11421,13 +11079,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11460,11 +11116,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11505,13 +11162,11 @@
                   "te_quantity": 0.5516398458350886,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.02392234373829706,
                   "te_wow2": 0.011544062746605053,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11544,11 +11199,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11589,13 +11245,11 @@
                   "te_quantity": 0.2,
                   "te_spin": 0.050029108176637305,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.8806484294123947,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11628,11 +11282,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11673,13 +11328,11 @@
                   "te_quantity": 6.939062508259667,
                   "te_spin": 0.037191224803793776,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.035146874938509425,
                   "te_wow2": 0.5699062613304703,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11712,11 +11365,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11757,13 +11411,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.2041910189643763,
                   "te_brightness": 0.5748031496062992,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.5568750025704503,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11796,11 +11448,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11841,13 +11494,11 @@
                   "te_quantity": 0.5846093705695239,
                   "te_spin": 0.06630625069306673,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.39980470202863216,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11880,11 +11531,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -11925,13 +11577,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.08131408865688172,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0034863287255575415,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -11964,11 +11614,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12009,18 +11660,16 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.24286416742858874,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.03804269667673088,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "hideBlocks": false,
-                  "numBlocks": 30.0,
-                  "glow": 0.5,
+                  "speed": 0.7,
                   "ySpread": 1.6,
-                  "speed": 0.7
+                  "numBlocks": 30.0,
+                  "glow": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -12053,11 +11702,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12098,13 +11748,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.147684087404641,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.34183593711350113,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "width": 0.5,
                   "glow": 0.2
                 },
@@ -12139,11 +11787,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12184,13 +11833,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.18732665787880243,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0165624957531691,
                   "te_wow2": 0.0012499999720603228,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12223,11 +11870,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12268,13 +11916,11 @@
                   "te_quantity": 0.5,
                   "te_spin": -0.005087701462599514,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12307,11 +11953,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12352,13 +11999,11 @@
                   "te_quantity": 5.41656237810821,
                   "te_spin": 0.07980624998421404,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.13390625221654773,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12391,11 +12036,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12436,13 +12082,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.04472564114094557,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.7362500061281025,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12475,11 +12119,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12520,13 +12165,11 @@
                   "te_quantity": 2.0266679903994373,
                   "te_spin": 5.603575452026721E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12559,11 +12202,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12604,13 +12248,11 @@
                   "te_quantity": 0.06404060646775175,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.619849976915793,
                   "te_wow2": 0.2949609411007259,
                   "te_wowtrigger": false,
                   "te_angle": -0.47442957844482914,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12643,95 +12285,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
-                  "/te_wow1",
-                  "/te_wow2",
-                  "/te_wowtrigger",
-                  "/te_explode"
-                ],
-                "effects": []
-              },
-              {
-                "id": 100880,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$RhythmicFlashStatic",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true,
-                  "expanded": true,
-                  "expandedCue": true,
-                  "expandedAux": true,
-                  "modulationExpanded": false
-                },
-                "parameters": {
-                  "label": "+ RhythmicFlashStatic",
-                  "view": 0,
-                  "viewPriority": 0,
-                  "enabled": true,
-                  "recall": false,
-                  "compositeMode": 0,
-                  "compositeLevel": 1.0,
-                  "hasCustomCycleTime": false,
-                  "customCycleTimeSecs": 60.0,
-                  "te_color/brightness": 100.0,
-                  "te_color/saturation": 100.0,
-                  "te_color/hue": 0.0,
-                  "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
-                  "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "te_speed": 4.0,
-                  "te_xpos": 0.0,
-                  "te_ypos": 0.0,
-                  "te_size": 0.4045218554348685,
-                  "te_quantity": 0.1827734352555126,
-                  "te_spin": 0.0,
-                  "te_brightness": 1.0,
-                  "te_explode": 0.0,
-                  "te_wow1": 0.5212890676921234,
-                  "te_wow2": 0.0,
-                  "te_wowtrigger": false,
-                  "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
-                },
-                "children": {
-                  "modulation": {
-                    "id": 100881,
-                    "class": "heronarts.lx.modulation.LXModulationEngine",
-                    "internal": {
-                      "modulationColor": 0,
-                      "modulationControlsExpanded": true,
-                      "modulationsExpanded": true
-                    },
-                    "parameters": {
-                      "label": "Modulation"
-                    },
-                    "children": {},
-                    "modulators": [],
-                    "modulations": [],
-                    "triggers": []
-                  }
-                },
-                "deviceVersion": -1,
-                "remoteControls": [
-                  "/te_color/offset",
-                  "/te_color/gradient",
                   null,
-                  "/te_speed",
-                  "/te_xpos",
-                  "/te_ypos",
-                  "/te_quantity",
-                  "/te_size",
-                  "/te_angle",
-                  "/te_spin",
-                  "/panic",
-                  "/viewPerPattern",
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12772,13 +12331,11 @@
                   "te_quantity": 2.132656247355044,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7086614173228338,
                   "te_wow2": 0.07341043937242764,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12811,11 +12368,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12856,13 +12414,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 3.3531249929219484,
                   "te_wow2": 0.9017187533900142,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12895,11 +12451,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -12940,13 +12497,11 @@
                   "te_quantity": 1.6415039142593741,
                   "te_spin": 0.02460976594934472,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0011328124674037099,
                   "te_wow2": 0.022343749762512743,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -12979,11 +12534,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13024,13 +12580,11 @@
                   "te_quantity": 4.0250781601062045,
                   "te_spin": 0.06542404777056943,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.4898828104051063,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -13064,11 +12618,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13109,13 +12664,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.07596914142428668,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6927343787901918,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -13150,11 +12703,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13195,13 +12749,11 @@
                   "te_quantity": 12.201367290959752,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.17629828819048154,
                   "te_wow2": 0.12638287340573184,
                   "te_wowtrigger": false,
                   "te_angle": 0.02282563233349233,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13234,11 +12786,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13279,13 +12832,11 @@
                   "te_quantity": 3.057421952718869,
                   "te_spin": 0.0,
                   "te_brightness": 0.984251968503937,
-                  "te_explode": 0.0,
                   "te_wow1": 0.08080078112412592,
                   "te_wow2": 0.09841796767912456,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13318,11 +12869,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13363,13 +12915,11 @@
                   "te_quantity": 3.052656266372651,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.916523442487232,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13402,11 +12952,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13447,13 +12998,11 @@
                   "te_quantity": 55.01484438267653,
                   "te_spin": 0.03925351557702528,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 0.0024999999441206455,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13486,11 +13035,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13531,13 +13081,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.11611127952484077,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13570,11 +13118,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -13619,7 +13168,7 @@
               "transitionEnabled": false,
               "transitionTimeSecs": 5.0,
               "transitionBlendMode": 0,
-              "focusedPattern": 13,
+              "focusedPattern": 15,
               "triggerPatternCycle": false
             },
             "children": {},
@@ -13664,13 +13213,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13703,11 +13250,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13748,13 +13296,11 @@
                   "te_quantity": 0.6625242168813565,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.006811484342397308,
                   "te_wow2": 0.020444765753578394,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13787,11 +13333,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13832,13 +13379,11 @@
                   "te_quantity": 0.2,
                   "te_spin": 0.02766504463120567,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13871,11 +13416,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -13916,13 +13462,11 @@
                   "te_quantity": 6.939062508259667,
                   "te_spin": 0.037191224803793776,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.015381250124773942,
                   "te_wow2": 0.2,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -13955,11 +13499,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14000,13 +13545,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03445663998146631,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14039,11 +13582,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14084,13 +13628,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.02587573864673831,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.3703906235678005,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14123,11 +13665,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14168,13 +13711,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.020619165905980896,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.03316406130034011,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14207,11 +13748,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14252,18 +13794,16 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "hideBlocks": false,
                   "speed": 0.7,
-                  "glow": 0.5,
                   "ySpread": 1.6,
-                  "numBlocks": 30.0
+                  "numBlocks": 30.0,
+                  "glow": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -14296,11 +13836,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14341,15 +13882,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.021138433760371056,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "glow": 0.2,
-                  "width": 0.5
+                  "width": 0.5,
+                  "glow": 0.2
                 },
                 "children": {
                   "modulation": {
@@ -14382,11 +13921,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14427,13 +13967,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.01492978495824504,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.7228750022128223,
                   "te_wow2": 0.9920703158713877,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14466,11 +14004,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14511,13 +14050,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5864843736635521,
                   "te_wow2": 0.19714844206464477,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14550,11 +14087,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14595,13 +14133,11 @@
                   "te_quantity": 3.522890617372468,
                   "te_spin": 0.016677300933833905,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.06635156387201276,
                   "te_wow2": 0.03859374998137355,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14634,11 +14170,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14679,13 +14216,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.019468969627801203,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14718,11 +14253,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14763,13 +14299,11 @@
                   "te_quantity": 1.7921367343471502,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0,
                   "te_wow2": 0.9872265623416752,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14802,11 +14336,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -14847,13 +14382,11 @@
                   "te_quantity": 0.15,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2.823343762219956,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -14886,95 +14419,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
-                  "/te_wow1",
-                  "/te_wow2",
-                  "/te_wowtrigger",
-                  "/te_explode"
-                ],
-                "effects": []
-              },
-              {
-                "id": 98202,
-                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$RhythmicFlashStatic",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true,
-                  "expanded": true,
-                  "expandedCue": true,
-                  "expandedAux": true,
-                  "modulationExpanded": false
-                },
-                "parameters": {
-                  "label": "- RhythmicFlashStatic",
-                  "view": 0,
-                  "viewPriority": 0,
-                  "enabled": true,
-                  "recall": false,
-                  "compositeMode": 0,
-                  "compositeLevel": 1.0,
-                  "hasCustomCycleTime": false,
-                  "customCycleTimeSecs": 60.0,
-                  "te_color/brightness": 100.0,
-                  "te_color/saturation": 100.0,
-                  "te_color/hue": 0.0,
-                  "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
-                  "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "te_speed": 4.0,
-                  "te_xpos": 0.0,
-                  "te_ypos": 0.0,
-                  "te_size": 1.0,
-                  "te_quantity": 0.08726560887589585,
-                  "te_spin": 0.0,
-                  "te_brightness": 1.0,
-                  "te_explode": 0.0,
-                  "te_wow1": 0.6836718742270023,
-                  "te_wow2": 0.0,
-                  "te_wowtrigger": false,
-                  "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
-                },
-                "children": {
-                  "modulation": {
-                    "id": 98203,
-                    "class": "heronarts.lx.modulation.LXModulationEngine",
-                    "internal": {
-                      "modulationColor": 0,
-                      "modulationControlsExpanded": true,
-                      "modulationsExpanded": true
-                    },
-                    "parameters": {
-                      "label": "Modulation"
-                    },
-                    "children": {},
-                    "modulators": [],
-                    "modulations": [],
-                    "triggers": []
-                  }
-                },
-                "deviceVersion": -1,
-                "remoteControls": [
-                  "/te_color/offset",
-                  "/te_color/gradient",
                   null,
-                  "/te_speed",
-                  "/te_xpos",
-                  "/te_ypos",
-                  "/te_quantity",
-                  "/te_size",
-                  "/te_angle",
-                  "/te_spin",
-                  "/panic",
-                  "/viewPerPattern",
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15015,13 +14465,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0020226369617407,
                   "te_wow2": 0.0011017418411508606,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15054,11 +14502,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15099,13 +14548,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5818750029429793,
                   "te_wow2": 0.4201562483794987,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15138,11 +14585,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15183,13 +14631,11 @@
                   "te_quantity": 0.6857421912063728,
                   "te_spin": 0.011455688556307075,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7417578133172356,
                   "te_wow2": 0.19558593455440132,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15222,11 +14668,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15267,13 +14714,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.016798590155487236,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -15307,11 +14752,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15352,13 +14798,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.02527603201144535,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6591953097515216,
                   "te_wow2": 0.5987500015908154,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -15393,11 +14837,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15438,13 +14883,11 @@
                   "te_quantity": 12.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.05832031272148014,
                   "te_wow2": 0.036132811524439604,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15477,11 +14920,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15522,13 +14966,11 @@
                   "te_quantity": 3.468359389473335,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.18421874890918843,
                   "te_wow2": 0.026400867777172564,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15561,11 +15003,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15606,13 +15049,11 @@
                   "te_quantity": 2.545781277003698,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.8271093598305015,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15645,11 +15086,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15690,13 +15132,11 @@
                   "te_quantity": 53.17265726305777,
                   "te_spin": 0.004430566324421736,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15729,11 +15169,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15774,13 +15215,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.030156247630657163,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15813,11 +15252,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -15907,13 +15347,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -15946,11 +15384,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -15991,13 +15430,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16030,11 +15467,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16075,13 +15513,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16114,11 +15550,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16159,13 +15596,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16198,11 +15633,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16243,13 +15679,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.12299268096941951,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.5568750025704503,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16282,11 +15716,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16327,13 +15762,11 @@
                   "te_quantity": 7.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2.5,
                   "te_wow2": 1.5,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16366,11 +15799,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16411,13 +15845,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03087158836549264,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.3703906235678005,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16450,11 +15882,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16495,13 +15928,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.08131408865688172,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0474707037465123,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16534,11 +15965,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16579,19 +16011,17 @@
                   "te_quantity": 0.4706250060116872,
                   "te_spin": -0.008833064220220899,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 2,
-                  "Glow": 1.5,
-                  "Wibble Size": 0.15,
-                  "Energy": 0.0,
                   "Speed": 0.0,
+                  "Energy": 0.0,
+                  "Thickness": 0.3,
+                  "Glow": 1.5,
                   "Glow2": 9.0,
-                  "Thickness": 0.3
+                  "Wibble Size": 0.15
                 },
                 "children": {
                   "modulation": {
@@ -16624,11 +16054,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16669,15 +16100,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.05147226591235965,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.34183593711350113,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
-                  "glow": 0.2,
-                  "width": 0.5
+                  "width": 0.5,
+                  "glow": 0.2
                 },
                 "children": {
                   "modulation": {
@@ -16710,11 +16139,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16755,13 +16185,11 @@
                   "te_quantity": 20.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.1342578122857958,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16794,11 +16222,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16839,13 +16268,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6584375031292438,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16878,11 +16305,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -16923,13 +16351,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.07980624998421404,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.14383593810925957,
                   "te_wow2": 0.03859374998137355,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -16962,11 +16388,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17007,13 +16434,11 @@
                   "te_quantity": 0.5078740157480315,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0,
                   "te_wow2": 0.5,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17046,11 +16471,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17091,13 +16517,11 @@
                   "te_quantity": 0.5565234392415732,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.9976562500232831,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17130,11 +16554,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17175,13 +16600,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.04472564114094557,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17214,11 +16637,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17259,13 +16683,11 @@
                   "te_quantity": 1.7921367343471502,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0,
                   "te_wow2": 0.9872265623416752,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17298,11 +16720,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17343,13 +16766,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.01582092283984826,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.5,
                   "te_wow2": 0.2,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17382,11 +16803,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17427,13 +16849,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03362066073850878,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17466,11 +16886,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17511,13 +16932,11 @@
                   "te_quantity": 0.6857421912063728,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7417578133172356,
                   "te_wow2": 0.19558593455440132,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17550,11 +16969,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17595,13 +17015,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.06542404777056943,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "energy": 0.1
                 },
                 "children": {
@@ -17635,11 +17053,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17680,13 +17099,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.07596914142428668,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.7305624997032283,
                   "te_wow2": 0.6053125001490116,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -17721,11 +17138,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17766,13 +17184,11 @@
                   "te_quantity": 12.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.6513671880937182,
                   "te_wow2": 0.11,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17805,11 +17221,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17850,13 +17267,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.14833984359152963,
                   "te_wow2": 0.0883789052652719,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17889,11 +17304,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -17934,13 +17350,11 @@
                   "te_quantity": 2.545781277003698,
                   "te_spin": 0.01429106447359374,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 4.8271093598305015,
                   "te_wow2": 0.7677734363824129,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -17973,11 +17387,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -18018,13 +17433,11 @@
                   "te_quantity": 55.01484438267653,
                   "te_spin": 0.03925351557702528,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -18057,11 +17470,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -18102,13 +17516,11 @@
                   "te_quantity": 0.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -18141,11 +17553,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -18186,13 +17599,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 4.0943001286142255E-4,
                   "te_brightness": 1.0,
-                  "te_explode": 0.06886718503665179,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -18225,11 +17636,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -18319,13 +17731,11 @@
                   "te_quantity": 0.6265214827268938,
                   "te_spin": 0.0,
                   "te_brightness": 0.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.03684999973513186,
                   "te_wow2": 0.006525000032968818,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -18492,11 +17902,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -18537,13 +17948,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 0.0,
-                  "te_explode": 0.030000004917383194,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -18710,11 +18119,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -18970,13 +18380,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.9682812377577648,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19009,11 +18417,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -19103,13 +18512,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19142,11 +18549,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -19406,13 +18814,11 @@
                   "te_quantity": 0.075,
                   "te_spin": 0.2703999879121781,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.1179999750107528,
                   "te_wow2": 0.2009999971836805,
                   "te_wowtrigger": false,
                   "te_angle": 2.5132741252125035,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19445,11 +18851,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -19490,13 +18897,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 0.3900000136345625,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19529,11 +18934,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -19574,13 +18980,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 0.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19613,11 +19017,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -19658,13 +19063,11 @@
                   "te_quantity": 1.5,
                   "te_spin": -0.0035999971568589917,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 1.2566370333478902,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19819,11 +19222,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -19864,13 +19268,11 @@
                   "te_quantity": 40.95999816894533,
                   "te_spin": -1.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -19903,11 +19305,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -19948,13 +19351,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.48000001162290573,
                   "te_wow2": 4.499999921768904,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "enableEdges": true,
                   "enablePanels": true
                 },
@@ -19989,11 +19390,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20034,13 +19436,11 @@
                   "te_quantity": 1.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20073,11 +19473,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20118,13 +19519,11 @@
                   "te_quantity": 8.0,
                   "te_spin": 0.0,
                   "te_brightness": 0.9600000008940697,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.8975000246427953,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20157,11 +19556,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20202,13 +19602,11 @@
                   "te_quantity": 3.0,
                   "te_spin": 0.0,
                   "te_brightness": 0.7400000058114529,
-                  "te_explode": 0.0,
                   "te_wow1": 4.260000003129244,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20241,11 +19639,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20286,13 +19685,11 @@
                   "te_quantity": 57.79999915510416,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.20999999530613422,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20325,11 +19722,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20370,13 +19768,11 @@
                   "te_quantity": 0.3,
                   "te_spin": 0.07840000901222255,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 2.6,
                   "te_wow2": 0.3,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20409,11 +19805,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20454,13 +19851,11 @@
                   "te_quantity": 8.0,
                   "te_spin": 0.04145572827203958,
                   "te_brightness": 0.8300000037997961,
-                  "te_explode": 0.0,
                   "te_wow1": 0.1424999968148768,
                   "te_wow2": 0.4200000409036875,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20493,11 +19888,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20538,13 +19934,11 @@
                   "te_quantity": 0.675,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.025,
                   "te_wow2": 0.008,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20577,11 +19971,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -20671,13 +20066,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.006399999713897708,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.06283185166739447,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20710,11 +20103,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20755,13 +20149,11 @@
                   "te_quantity": 4.0,
                   "te_spin": 0.009999999552965155,
                   "te_brightness": 0.009999999776482582,
-                  "te_explode": 0.0,
                   "te_wow1": 6.319999881088734,
                   "te_wow2": 0.001,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20794,11 +20186,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20839,13 +20232,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 2.010619253356624,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20878,11 +20269,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -20923,13 +20315,11 @@
                   "te_quantity": 0.9899999890476465,
                   "te_spin": 0.048400007671118184,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": -0.6999999843537807,
                   "te_wow2": 154.79999385774136,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -20962,11 +20352,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21007,13 +20398,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.1024000097274782,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 35.99999248981476,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21046,11 +20435,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21091,13 +20481,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.03999999821186062,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": -1.0,
                   "te_wow2": 259.1999942064285,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21130,11 +20518,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21175,13 +20564,11 @@
                   "te_quantity": 1.5,
                   "te_spin": 0.009999999552965155,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21214,11 +20601,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21259,13 +20647,11 @@
                   "te_quantity": 8.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 2.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21298,11 +20684,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21343,13 +20730,11 @@
                   "te_quantity": 3.0,
                   "te_spin": -0.003199999856948854,
                   "te_brightness": 0.8600000031292439,
-                  "te_explode": 0.0,
                   "te_wow1": 4.994999986700714,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21382,11 +20767,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21427,13 +20813,11 @@
                   "te_quantity": 20.0,
                   "te_spin": 0.014399999356269788,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.549999987706542,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21466,11 +20850,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21511,15 +20896,13 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.35,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 6,
-                  "noise2": 2.0,
-                  "noise": 2.0
+                  "noise": 2.0,
+                  "noise2": 2.0
                 },
                 "children": {
                   "modulation": {
@@ -21552,11 +20935,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21597,13 +20981,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.02560000243186966,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 2.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21636,11 +21018,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21681,13 +21064,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 5
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21720,11 +21101,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -21765,13 +21147,11 @@
                   "te_quantity": 0.3,
                   "te_spin": 0.05454718751049237,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.091999975591898,
                   "te_wow2": 0.144749998440966,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -21804,11 +21184,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -22138,13 +21519,11 @@
                   "te_quantity": 0.3900000024586916,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "enableEdges": false,
                   "enablePanels": true
                 },
@@ -22179,11 +21558,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22224,18 +21604,16 @@
                   "te_quantity": 0.3900000136345625,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 6,
-                  "numBlocks": 30.0,
-                  "glow": 0.5,
-                  "ySpread": 1.6,
                   "hideBlocks": false,
-                  "speed": 0.7
+                  "speed": 0.7,
+                  "ySpread": 1.6,
+                  "numBlocks": 30.0,
+                  "glow": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -22268,11 +21646,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22313,13 +21692,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22352,11 +21729,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22397,13 +21775,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 1.0,
                   "te_wow2": 1.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22436,11 +21812,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22481,13 +21858,11 @@
                   "te_quantity": 9.46000001206994,
                   "te_spin": 0.09000000938773178,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.20999999530613422,
                   "te_wow2": 1.119999997317791,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22520,11 +21895,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22565,13 +21941,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.2,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 5
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22604,11 +21978,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22649,18 +22024,16 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 6,
-                  "Glow": 0.1,
-                  "Double Layer": false,
                   "Double Speed": false,
+                  "Energy": 0.0,
                   "Width": 0.5,
-                  "Energy": 0.0
+                  "Double Layer": false,
+                  "Glow": 0.1
                 },
                 "children": {
                   "modulation": {
@@ -22693,11 +22066,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22738,13 +22112,11 @@
                   "te_quantity": 5.0,
                   "te_spin": 0.25,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.5039999887347221,
                   "te_wow2": 3.9600000008940697,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22777,11 +22149,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22822,13 +22195,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22861,11 +22232,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22906,13 +22278,11 @@
                   "te_quantity": 0.3,
                   "te_spin": 0.11559999483227745,
                   "te_brightness": 0.5000000111758709,
-                  "te_explode": 0.0,
                   "te_wow1": 1.7679999604821206,
                   "te_wow2": 0.2977499950211495,
                   "te_wowtrigger": false,
                   "te_angle": 0.06283185166739447,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -22945,11 +22315,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -22990,13 +22361,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23029,11 +22398,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23133,13 +22503,11 @@
                   "te_quantity": 0.0,
                   "te_spin": 0.0,
                   "te_brightness": 0.7900000046938658,
-                  "te_explode": 0.0,
                   "te_wow1": 0.2200000174343586,
                   "te_wow2": 6.740000028163195,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
                   "panic": false,
-                  "viewPerPattern": 0,
                   "enableEdges": true,
                   "enablePanels": true
                 },
@@ -23174,11 +22542,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23219,13 +22588,11 @@
                   "te_quantity": 6.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23258,11 +22625,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23303,13 +22671,11 @@
                   "te_quantity": 0.5,
                   "te_spin": -0.03239999855160702,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23342,11 +22708,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23387,13 +22754,11 @@
                   "te_quantity": 8.0,
                   "te_spin": 0.05,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.15,
                   "te_wow2": 2.25,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23426,11 +22791,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23471,13 +22837,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.2,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 5
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23510,11 +22874,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23555,13 +22920,11 @@
                   "te_quantity": 1.0,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 5.0,
                   "te_wow2": 0.005,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 2
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23594,11 +22957,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23639,13 +23003,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23678,11 +23040,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -23723,13 +23086,11 @@
                   "te_quantity": 0.0,
                   "te_spin": 0.2499999888241291,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 6
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -23762,11 +23123,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -24059,13 +23421,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -24098,11 +23458,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -24360,13 +23721,11 @@
                   "te_quantity": 0.5,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.0,
                   "te_wow2": 0.0,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 4
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -24399,11 +23758,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               },
@@ -24444,13 +23804,11 @@
                   "te_quantity": 0.675,
                   "te_spin": 0.0,
                   "te_brightness": 1.0,
-                  "te_explode": 0.0,
                   "te_wow1": 0.025,
                   "te_wow2": 0.008,
                   "te_wowtrigger": false,
                   "te_angle": 0.0,
-                  "panic": false,
-                  "viewPerPattern": 0
+                  "panic": false
                 },
                 "children": {
                   "modulation": {
@@ -24483,11 +23841,12 @@
                   "/te_angle",
                   "/te_spin",
                   "/panic",
-                  "/viewPerPattern",
+                  null,
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  "/te_explode"
+                  null,
+                  "/view"
                 ],
                 "effects": []
               }
@@ -24722,7 +24081,7 @@
               "exp": 0.25859374599531293
             },
             "children": {},
-            "basis": 0.13475000000016735
+            "basis": 0.06925000000001091
           },
           {
             "id": 78340,
@@ -24757,7 +24116,7 @@
               "exp": 1.0
             },
             "children": {},
-            "basis": 0.06737500000008367
+            "basis": 0.5346250000000055
           },
           {
             "id": 68570,
@@ -24792,7 +24151,7 @@
               "exp": 1.0
             },
             "children": {},
-            "basis": 0.2668437500000209
+            "basis": 0.6336562500000014
           },
           {
             "id": 116084,
@@ -24814,7 +24173,7 @@
               "midiFilter/velocityRange": 127,
               "inputA": 0.0,
               "inputB": 1.0,
-              "output": 0.5017063733567046
+              "output": 0.7919294758938509
             },
             "children": {}
           },
@@ -24838,7 +24197,7 @@
               "midiFilter/velocityRange": 127,
               "inputA": 0.0,
               "inputB": 0.9921259842519685,
-              "output": 0.539613775452587
+              "output": 0.06174044358807503
             },
             "children": {}
           },
@@ -24862,7 +24221,7 @@
               "midiFilter/velocityRange": 127,
               "inputA": 0.0,
               "inputB": 1.0,
-              "output": 3.4651877232981752E-12
+              "output": 6.734572287818126E-13
             },
             "children": {}
           }
@@ -25072,38 +24431,13 @@
           },
           {
             "source": {
-              "id": 78341,
-              "path": "/modulation/modulator/8"
-            },
-            "target": {
-              "componentId": 45732,
-              "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/17/te_quantity"
-            },
-            "id": 89367,
-            "class": "heronarts.lx.modulation.LXCompoundModulation",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "LX",
-              "enabled": true,
-              "polarity": 0,
-              "range": 0.8111816374585032
-            },
-            "children": {}
-          },
-          {
-            "source": {
               "id": 68570,
               "path": "/modulation/modulator/10"
             },
             "target": {
               "componentId": 54171,
               "parameterPath": "te_ypos",
-              "path": "/mixer/channel/2/pattern/19/te_ypos"
+              "path": "/mixer/channel/2/pattern/17/te_ypos"
             },
             "id": 89368,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25128,7 +24462,7 @@
             "target": {
               "componentId": 54184,
               "parameterPath": "te_ypos",
-              "path": "/mixer/channel/2/pattern/21/te_ypos"
+              "path": "/mixer/channel/2/pattern/19/te_ypos"
             },
             "id": 89369,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25153,7 +24487,7 @@
             "target": {
               "componentId": 46205,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/23/te_quantity"
+              "path": "/mixer/channel/2/pattern/21/te_quantity"
             },
             "id": 89370,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25178,7 +24512,7 @@
             "target": {
               "componentId": 46205,
               "parameterPath": "te_ypos",
-              "path": "/mixer/channel/2/pattern/23/te_ypos"
+              "path": "/mixer/channel/2/pattern/21/te_ypos"
             },
             "id": 89371,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25203,7 +24537,7 @@
             "target": {
               "componentId": 46205,
               "parameterPath": "te_wow2",
-              "path": "/mixer/channel/2/pattern/23/te_wow2"
+              "path": "/mixer/channel/2/pattern/21/te_wow2"
             },
             "id": 89372,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25228,7 +24562,7 @@
             "target": {
               "componentId": 46205,
               "parameterPath": "te_wow1",
-              "path": "/mixer/channel/2/pattern/23/te_wow1"
+              "path": "/mixer/channel/2/pattern/21/te_wow1"
             },
             "id": 89373,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25253,7 +24587,7 @@
             "target": {
               "componentId": 87290,
               "parameterPath": "te_wow2",
-              "path": "/mixer/channel/2/pattern/24/te_wow2"
+              "path": "/mixer/channel/2/pattern/22/te_wow2"
             },
             "id": 89374,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25278,7 +24612,7 @@
             "target": {
               "componentId": 87290,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/24/te_size"
+              "path": "/mixer/channel/2/pattern/22/te_size"
             },
             "id": 89375,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25303,7 +24637,7 @@
             "target": {
               "componentId": 46179,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/25/te_quantity"
+              "path": "/mixer/channel/2/pattern/23/te_quantity"
             },
             "id": 89376,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25328,7 +24662,7 @@
             "target": {
               "componentId": 46179,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/25/te_size"
+              "path": "/mixer/channel/2/pattern/23/te_size"
             },
             "id": 89377,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25353,7 +24687,7 @@
             "target": {
               "componentId": 46179,
               "parameterPath": "te_spin",
-              "path": "/mixer/channel/2/pattern/25/te_spin"
+              "path": "/mixer/channel/2/pattern/23/te_spin"
             },
             "id": 89378,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25378,7 +24712,7 @@
             "target": {
               "componentId": 87303,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/26/te_quantity"
+              "path": "/mixer/channel/2/pattern/24/te_quantity"
             },
             "id": 89379,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25403,7 +24737,7 @@
             "target": {
               "componentId": 46021,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/27/te_size"
+              "path": "/mixer/channel/2/pattern/25/te_size"
             },
             "id": 89380,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25428,7 +24762,7 @@
             "target": {
               "componentId": 46021,
               "parameterPath": "te_wow2",
-              "path": "/mixer/channel/2/pattern/27/te_wow2"
+              "path": "/mixer/channel/2/pattern/25/te_wow2"
             },
             "id": 89381,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25453,7 +24787,7 @@
             "target": {
               "componentId": 87316,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/28/te_size"
+              "path": "/mixer/channel/2/pattern/26/te_size"
             },
             "id": 89382,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25478,7 +24812,7 @@
             "target": {
               "componentId": 54210,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/29/te_quantity"
+              "path": "/mixer/channel/2/pattern/27/te_quantity"
             },
             "id": 89384,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25503,7 +24837,7 @@
             "target": {
               "componentId": 54223,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/31/te_quantity"
+              "path": "/mixer/channel/2/pattern/29/te_quantity"
             },
             "id": 89385,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25528,7 +24862,7 @@
             "target": {
               "componentId": 54223,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/31/te_size"
+              "path": "/mixer/channel/2/pattern/29/te_size"
             },
             "id": 89386,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25553,7 +24887,7 @@
             "target": {
               "componentId": 46218,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/33/te_size"
+              "path": "/mixer/channel/2/pattern/31/te_size"
             },
             "id": 89387,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25578,7 +24912,7 @@
             "target": {
               "componentId": 46218,
               "parameterPath": "te_wow1",
-              "path": "/mixer/channel/2/pattern/33/te_wow1"
+              "path": "/mixer/channel/2/pattern/31/te_wow1"
             },
             "id": 89388,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25603,7 +24937,7 @@
             "target": {
               "componentId": 46218,
               "parameterPath": "te_wow1",
-              "path": "/mixer/channel/2/pattern/33/te_wow1"
+              "path": "/mixer/channel/2/pattern/31/te_wow1"
             },
             "id": 89389,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25628,7 +24962,7 @@
             "target": {
               "componentId": 46218,
               "parameterPath": "te_wow2",
-              "path": "/mixer/channel/2/pattern/33/te_wow2"
+              "path": "/mixer/channel/2/pattern/31/te_wow2"
             },
             "id": 89390,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25653,7 +24987,7 @@
             "target": {
               "componentId": 87355,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/34/te_size"
+              "path": "/mixer/channel/2/pattern/32/te_size"
             },
             "id": 89391,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25678,7 +25012,7 @@
             "target": {
               "componentId": 46231,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/35/te_size"
+              "path": "/mixer/channel/2/pattern/33/te_size"
             },
             "id": 89392,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25703,7 +25037,7 @@
             "target": {
               "componentId": 46231,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/35/te_quantity"
+              "path": "/mixer/channel/2/pattern/33/te_quantity"
             },
             "id": 89393,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25728,7 +25062,7 @@
             "target": {
               "componentId": 46231,
               "parameterPath": "te_wow2",
-              "path": "/mixer/channel/2/pattern/35/te_wow2"
+              "path": "/mixer/channel/2/pattern/33/te_wow2"
             },
             "id": 89394,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25753,7 +25087,7 @@
             "target": {
               "componentId": 46231,
               "parameterPath": "te_spin",
-              "path": "/mixer/channel/2/pattern/35/te_spin"
+              "path": "/mixer/channel/2/pattern/33/te_spin"
             },
             "id": 89395,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25778,7 +25112,7 @@
             "target": {
               "componentId": 46231,
               "parameterPath": "te_wow1",
-              "path": "/mixer/channel/2/pattern/35/te_wow1"
+              "path": "/mixer/channel/2/pattern/33/te_wow1"
             },
             "id": 89396,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25803,7 +25137,7 @@
             "target": {
               "componentId": 87368,
               "parameterPath": "te_wow1",
-              "path": "/mixer/channel/2/pattern/36/te_wow1"
+              "path": "/mixer/channel/2/pattern/34/te_wow1"
             },
             "id": 89397,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25828,7 +25162,7 @@
             "target": {
               "componentId": 87368,
               "parameterPath": "te_size",
-              "path": "/mixer/channel/2/pattern/36/te_size"
+              "path": "/mixer/channel/2/pattern/34/te_size"
             },
             "id": 89398,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25853,7 +25187,7 @@
             "target": {
               "componentId": 87368,
               "parameterPath": "te_quantity",
-              "path": "/mixer/channel/2/pattern/36/te_quantity"
+              "path": "/mixer/channel/2/pattern/34/te_quantity"
             },
             "id": 89399,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -25872,38 +25206,13 @@
           },
           {
             "source": {
-              "id": 68570,
-              "path": "/modulation/modulator/10"
-            },
-            "target": {
-              "componentId": 46060,
-              "parameterPath": "te_explode",
-              "path": "/mixer/channel/2/pattern/37/te_explode"
-            },
-            "id": 89400,
-            "class": "heronarts.lx.modulation.LXCompoundModulation",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "LX",
-              "enabled": true,
-              "polarity": 0,
-              "range": 0.5320312534458935
-            },
-            "children": {}
-          },
-          {
-            "source": {
               "id": 78341,
               "path": "/modulation/modulator/8"
             },
             "target": {
               "componentId": 46060,
               "parameterPath": "te_ypos",
-              "path": "/mixer/channel/2/pattern/37/te_ypos"
+              "path": "/mixer/channel/2/pattern/35/te_ypos"
             },
             "id": 89401,
             "class": "heronarts.lx.modulation.LXCompoundModulation",
@@ -26435,32 +25744,6 @@
               "enabled": true,
               "polarity": 0,
               "range": 0.1217773468233645
-            },
-            "children": {}
-          },
-          {
-            "source": {
-              "componentId": 116089,
-              "parameterPath": "output",
-              "path": "/modulation/modulator/13/output"
-            },
-            "target": {
-              "componentId": 45917,
-              "parameterPath": "te_explode",
-              "path": "/mixer/channel/2/pattern/8/te_explode"
-            },
-            "id": 119978,
-            "class": "heronarts.lx.modulation.LXCompoundModulation",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "LX",
-              "enabled": true,
-              "polarity": 0,
-              "range": 0.39921875577419996
             },
             "children": {}
           },
@@ -27820,8 +27103,34 @@
         },
         "children": {}
       },
+      "NDIEngine": {
+        "id": 37,
+        "class": "titanicsend.ndi.NDIEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "NDIEngine"
+        },
+        "children": {}
+      },
+      "GLEngine": {
+        "id": 38,
+        "class": "titanicsend.pattern.glengine.GLEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "GLEngine"
+        },
+        "children": {}
+      },
       "focus": {
-        "id": 49,
+        "id": 40,
         "class": "titanicsend.osc.CrutchOSC",
         "internal": {
           "modulationColor": 0,
@@ -27850,9 +27159,9 @@
         "depth": 1.0,
         "camera": {
           "active": false,
-          "radius": 1.4882593698387697E7,
+          "radius": 1.7E7,
           "theta": 270.0,
-          "phi": -6.215020164847374,
+          "phi": -6.0,
           "x": 2255849.2623291016,
           "y": 5053059.60546875,
           "z": 207717.87439727783

--- a/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/OrganicPatternConfig.java
@@ -265,17 +265,17 @@ public class OrganicPatternConfig {
     }
   }
 
-  @LXCategory("DREVO Shaders")
-  public static class RhythmicFlashStatic extends ConstructedPattern {
-    public RhythmicFlashStatic(LX lx) {
-      super(lx, TEShaderView.ALL_PANELS);
-    }
-
-    @Override
-    protected List<PatternEffect> createEffects() {
-      return List.of(new RhythmicFlashingStatic(new PatternTarget(this)));
-    }
-  }
+//  @LXCategory("DREVO Shaders")
+//  public static class RhythmicFlashStatic extends ConstructedPattern {
+//    public RhythmicFlashStatic(LX lx) {
+//      super(lx, TEShaderView.ALL_PANELS);
+//    }
+//
+//    @Override
+//    protected List<PatternEffect> createEffects() {
+//      return List.of(new RhythmicFlashingStatic(new PatternTarget(this)));
+//    }
+//  }
 
   @LXCategory("DREVO Shaders")
   public static class MatrixScroller extends ConstructedPattern {


### PR DESCRIPTION
The pattern killed FPS during LA show so I'm commenting the pattern code out, so it doesn't show up in the pattern list in Chromatik. (Note that I didn't need to remove it from TEApp, since TEApp bulk-includes patterns from `OrganicPatternConfig.java`

Keeping the underlying logic around for future reference - this could look good as a native shader, particularly with audio-reactivity hooked up to the amount of static.