### PR TITLE
Add Audio Reactivity controls

### DIFF
--- a/resources/docs/CommonControls.md
+++ b/resources/docs/CommonControls.md
@@ -44,7 +44,9 @@ call ```addCommonControls()``` to add the common controls to the UI.
 The common controls, their associated helper functions, and the tags used to get and
 set control values are:
 ```text
-Name		Helper 					tag                     
+Name		Helper 					tag      
+LvlReact        double getLevelReactivity() TEControlTag.LEVELREACTIVITY
+FreqReact       double getFrequencyReactivity() TEControlTag.FREQREACTIVITY               
 Color		int getCurrentColor()   <none>
 Speed		double getSpeed()	TEControlTag.SPEED
 xPos		double getXPos()	TEControlTag.XPOS
@@ -57,6 +59,7 @@ Wow1		double getWow1()	TEControlTag.WOW1
 Wow2		double getWow2()	TEControlTag.WOW2
 WowTrigger      boolean getWowTrigger() TEControlTag.WOWTRIGGER
 Angle           double getStaticRotationAngle() TEControlTag.ANGLE
+
 ```
 
 ### Default Ranges and Values
@@ -184,6 +187,13 @@ uniform float beat;
 uniform float sinPhaseBeat;
 uniform float bassLevel;
 uniform float trebleLevel;
+
+uniform float volumeRatio;
+uniform float bassRatio;
+uniform float trebleRatio;
+
+uniform float levelReact;   // reactivity to audio level changes
+uniform float frequencyReact;  // reactivity to audio frequency content
 
 // TE color
 uniform vec3 iPalette[5]; // the complete currently active palette

--- a/resources/docs/ShaderFramework.md
+++ b/resources/docs/ShaderFramework.md
@@ -54,6 +54,9 @@ uniform float volumeRatio;  // ratio of current volume to recent average volume
 uniform float bassRatio;
 uniform float trebleRatio;
 
+uniform float levelReact;   // reactivity to changes in audio level
+uniform float frequencyReact; // reactivity to audio frequency content
+
 // TE color
 uniform vec3 iColorRGB;   // color 1 - the color returned by calcColor() 
 uniform vec3 iColorHSB;   // color 1 in the HSB colorspace
@@ -88,7 +91,7 @@ uniform sampler2D iBackbuffer;
 
 ### ShaderToy/General Utility
 
-#### iTime (uniform float iTime;)
+#### iTime (uniform float iTime)
 
 'Time' since your pattern started running, in seconds.millis. With the common controls,
 the rate at which time passes will vary with the setting of the speed control.
@@ -97,7 +100,7 @@ Since shaders often use iTime to render animation as a function of time, this
 variable speed timer gives you smooth speed control without any additional code in the shader. Importantly,
 time can run both forwards and backwards, so be sure your pattern's math works in both directions.
 
-#### iResolution (uniform vec2 iResolution;)
+#### iResolution (uniform vec2 iResolution)
 
 The resolution of the "display" surface, used in shaders to normalize incoming pixel coordinates.
 Note that these are the dimensions of the off-screen 2D frame buffer that OpenGL uses for drawing and
@@ -106,7 +109,7 @@ between the frame buffer and car geometry are available in the TE
 framework's [CarGeometryPatternTools](https://github.com/titanicsend/LXStudio-TE/blob/main/src/main/java/titanicsend/pattern/jon/CarGeometryPatternTools.java)
 class.
 
-#### iMouse (uniform vec4 iMouse;)
+#### iMouse (uniform vec4 iMouse)
 
 All zeros at this time. Never changes. Included for compatibility with ShaderToy
 shaders. There's no reason to ever use this in shader code.
@@ -115,23 +118,23 @@ shaders. There's no reason to ever use this in shader code.
 
 ### Color Uniforms
 
-#### iColorRGB (uniform vec3 iColorRGB;)
+#### iColorRGB (uniform vec3 iColorRGB)
 
 The RGB color from the color control returned by the calcColor() function. Colors in
 shaders are normalized to a floating point 0.0 to 1.0 range. You do not have to multiply them back
 to 0-255, and you don't have to worry about color components under- or overflowing while doing
 calculations. They are automatically clamped to the proper range on output.
 
-#### iColorHSB (uniform vec3 iColorHSB;)
+#### iColorHSB (uniform vec3 iColorHSB)
 
 The same color as iColorRGB, but pre-converted to normalized HSB format. (All components are
 in the range 0.0 to 1.0. It's just like a Pixelblaze!)
 
-#### iColor2RGB (uniform vec3 iColorRGB;)
+#### iColor2RGB (uniform vec3 iColorRGB)
 
 The RGB color from the color control returned by the calcColor2() function, normalized as above.
 
-#### iColor2HSB (uniform vec3 iColorHSB;)
+#### iColor2HSB (uniform vec3 iColorHSB)
 
 iColor2RGB converted to HSB colorspace and normalized to the range 0.0 to 1.0.
 
@@ -139,20 +142,26 @@ iColor2RGB converted to HSB colorspace and normalized to the range 0.0 to 1.0.
 
 ### Audio Uniforms
 
-#### beat (uniform float beat;)
+#### levelReact (uniform float levelReact)
+Used by audio-reactive patterns to control how the pattern responds to changes in audio level. 
+
+#### frequencyReact (uniform float frequencyReact)
+Used by audio-reactive patterns to control how the pattern responds to changes in audio frequency content.
+
+#### beat (uniform float beat)
 
 Sawtooth wave that moves from 0 to 1 with the beat. On the beat the value
 will be 0, then ramp up to 1 before the next beat triggers.
 
-#### sinPhaseBeat (uniform float sinPhaseBeat;)
+#### sinPhaseBeat (uniform float sinPhaseBeat)
 
 Sinusoidal wave that alternates between 0 and 1 with the beat.
 
-#### bassLevel (uniform float bassLevel;)
+#### bassLevel (uniform float bassLevel)
 
 Average level of low frequency content in the current audio signal.
 
-#### trebleLevel (uniform float trebleLevel;)
+#### trebleLevel (uniform float trebleLevel)
 
 Average level of high frequency content in the current audio signal.
 
@@ -176,47 +185,47 @@ Ratio of the current treble frequency content to the recent average.
 
 ### TE Common Control Uniforms
 
-#### iSpeed (uniform float iSpeed;)
+#### iSpeed (uniform float iSpeed)
 
 Current value of the "Speed" common control. Most shaders will not need to use this because
 speed will be automatically controlled by the variable iTime mechanism described above.
 
-#### iScale (uniform float iScale;)
+#### iScale (uniform float iScale)
 
 Current value of the "Scale" common control.
 
-#### iQuantity (uniform float iQuantity;)
+#### iQuantity (uniform float iQuantity)
 
 Current value of the "Quantity" common control.
 
-#### iTranslate (uniform vec2  iTranslate;)
+#### iTranslate (uniform vec2  iTranslate)
 
 (x,y) translation vector, derived from the settings of the XPos and YPos common controls.
 
-#### iSpin (uniform float iSpin;)
+#### iSpin (uniform float iSpin)
 
 Current value of the "Spin" common control.
 
-#### iRotationAngle (uniform float iRotationAngle;)
+#### iRotationAngle (uniform float iRotationAngle)
 
 Beat-linked rotation angle derived from the current setting of the "Spin" common control.
 
-#### iBrightness (uniform float iBrightness;)
+#### iBrightness (uniform float iBrightness)
 
 The current value of the "Brightness" common control. The shader framework uses this automatically
 as "contrast". It reduces the brightness of colors without affecting alpha.
 
-#### iWow1 (uniform float iWow1;)
+#### iWow1 (uniform float iWow1)
 
 Current setting of the "Wow1" common control. Wow1 controls the level of an optional "special"
 pattern-specific feature.
 
-#### iWow2 (uniform float iWow2;)
+#### iWow2 (uniform float iWow2)
 
 Current setting of the "Wow2" common control. Wow2 controls the level of an optional "special"
 pattern-specific feature.
 
-#### iWowTrigger (uniform bool  iWowTrigger;)
+#### iWowTrigger (uniform bool iWowTrigger)
 
 Current setting of the "Wow1" common control. WowTrigger is a momentary contact button that can
 trigger an (optional) pattern-specific feature.
@@ -225,7 +234,7 @@ trigger an (optional) pattern-specific feature.
 
 ### ShaderToy Texture Uniforms
 
-#### iChannel0 (uniform sampler2D iChannel0;)
+#### iChannel0 (uniform sampler2D iChannel0)
 
 A 2D texture (2x512) containing audio data from the LX engine.
 
@@ -233,17 +242,17 @@ The first row contains FFT data -- the frequency spectrum of the current playing
 The second contains a normalized version of the music's waveform,scaled to the range -1.0 to 1.0.
 See the **AudioTest2** pattern for an example of how this data can be used.
 
-#### iChannel1 (uniform sampler2D iChannel1;)
+#### iChannel1 (uniform sampler2D iChannel1)
 
-#### iChannel2 (uniform sampler2D iChannel2;)
+#### iChannel2 (uniform sampler2D iChannel2)
 
-#### iChannel3 (uniform sampler2D iChannel3;)
+#### iChannel3 (uniform sampler2D iChannel3)
 
 iChannels 1 through 3 are 2D textures loaded from user specified files. Some ShaderToy shaders
 require these, and it is possible for you to build your own textures and load them at pattern
 creation time.
 
-### iBackbuffer (uniform sampler2D iBackbuffer;)
+### iBackbuffer (uniform sampler2D iBackbuffer)
 
 The contents of the previously rendered frame. This is useful for creating feedback effects
 like trails, echoes, etc. See the **MultipassDemo** pattern for an example.

--- a/resources/shaders/circuitry.fs
+++ b/resources/shaders/circuitry.fs
@@ -7,7 +7,7 @@
 #pragma name "Circuitry"
 #pragma TEControl.SIZE.Range(2.0,5.0,0.1)
 #pragma TEControl.QUANTITY.Range(4.0,3.0,6.0)
-#pragma TEControl.WOW2.Value(0.6)
+#pragma TEControl.WOW2.Disable
 #pragma TEControl.WOW1.Disable
 #pragma TEControl.WOWTRIGGER.Disable
 
@@ -37,9 +37,9 @@ float fractal(vec2 p) {
 
         // animated manhattan distance gives size changing rectangular
         // features
-        float m = abs(p.x+sin(iTime * 2.));
+        float m = abs(p.x+fract(bassRatio) + 0.3 * sin(beat));
         if (m < dist) {
-            dist = m + smoothstep(0.1,abs(p.y), fract(beat+bandLevel+i*0.618));
+            dist = m + smoothstep(0.1,abs(p.y), fract(bandLevel+i*0.618));
             minIteration = i;
         }
         // using minimum of manhattan and euclidean distance over all iterations
@@ -61,11 +61,11 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
 
     // use high frequency content to mess with the fractal, and
     // rotate the whole thing back and forth a little
-    bandLevel = frequencyReact * (-0.5 +trebleRatio);
+    bandLevel = frequencyReact * (-0.5 + trebleRatio);
 
     // use smoothed volume to scale the image
     uv *= (iScale - volumeRatio * levelReact);
-    float ra = iRotationAngle + 0.2 * bandLevel;
+    float ra = iRotationAngle + 0.4 * bandLevel;
     uv *= rot(ra);
     
     // draw the fractal, antialiased by drawing it multiple times

--- a/resources/shaders/circuitry.fs
+++ b/resources/shaders/circuitry.fs
@@ -24,7 +24,7 @@ float bandLevel;
 
 float fractal(vec2 p) {
     // Rock! (oscillate on x a little with the beat.)
-    p.x += bandLevel;
+    //p.x += bandLevel;
 
     float dist = 999., minDist = dist;
     minIteration=0.;
@@ -39,7 +39,7 @@ float fractal(vec2 p) {
         // features
         float m = abs(p.x+sin(iTime * 2.));
         if (m < dist) {
-            dist = m + smoothstep(0.1,abs(p.y), fract(beat+i*.5));
+            dist = m + smoothstep(0.1,abs(p.y), fract(beat+bandLevel+i*0.618));
             minIteration = i;
         }
         // using minimum of manhattan and euclidean distance over all iterations
@@ -58,15 +58,16 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     // normalize, center, correct aspect ratio
     vec2 uv = fragCoord.xy/iResolution.xy - 0.5;
     uv.x *= iResolution.x/iResolution.y;
-    uv *= iScale + 0.05 * (-0.5+sinPhaseBeat);
-    uv *= rot(iRotationAngle);
 
-    // Generate an easy-to-track audio reactive value
-    // n.b.  this is kind of underbaked, so feel free to improve it!
-    // slightly improved to dodge near-infinite coord shift at very low volume
-    float vol = trebleLevel + bassLevel;
-    bandLevel = (vol > 0.1) ? iWow2 * (-0.5 + max(trebleLevel, bassLevel) / vol) : 0.0;
+    // use high frequency content to mess with the fractal, and
+    // rotate the whole thing back and forth a little
+    bandLevel = frequencyReact * (-0.5 +trebleRatio);
 
+    // use smoothed volume to scale the image
+    uv *= (iScale - volumeRatio * levelReact);
+    float ra = iRotationAngle + 0.2 * bandLevel;
+    uv *= rot(ra);
+    
     // draw the fractal, antialiased by drawing it multiple times
     // at very small coordinate offsets.  For the car, we don't need
     // many iterations, but a few makes it look much smoother.

--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -17,6 +17,9 @@ uniform float volumeRatio;
 uniform float bassRatio;
 uniform float trebleRatio;
 
+uniform float levelReact;
+uniform float frequencyReact;
+
 // TE Colors
 uniform vec3 iColorRGB;
 uniform vec3 iColorHSB;

--- a/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -59,6 +59,12 @@ public class TECommonControls {
   public void buildDefaultControlList() {
     LXListenableNormalizedParameter p;
 
+    p = new CompoundParameter(TEControlTag.LEVELREACTIVITY.getLabel(), 0.5, 0, 1).setDescription("Level Reactivity");
+    setControl(TEControlTag.LEVELREACTIVITY, p);
+
+    p = new CompoundParameter(TEControlTag.FREQREACTIVITY.getLabel(), 0.5, 0, 1).setDescription("Frequency Reactivity");
+    setControl(TEControlTag.FREQREACTIVITY, p);
+
     p =
         new CompoundParameter(TEControlTag.SPEED.getLabel(), 0.5, -4.0, 4.0)
             .setPolarity(LXParameter.Polarity.BIPOLAR)
@@ -310,11 +316,7 @@ public class TECommonControls {
     MissingControlsManager.MissingControls missingControls =
         MissingControlsManager.get().findMissingControls(pat.getClass());
 
-    String colorPrefix = "";
-    if (missingControls != null && !missingControls.uses_palette) {
-      colorPrefix = "[x] ";
-    }
-    TEColorParameter colorParam = registerColorControl(colorPrefix);
+
 
     // controls will be added in the order their tags appear in the
     // TEControlTag enum
@@ -331,6 +333,13 @@ public class TECommonControls {
     }
 
     this.pattern.addParam("panic", this.panic);
+
+    String colorPrefix = "";
+    if (missingControls != null && !missingControls.uses_palette) {
+      colorPrefix = "[x] ";
+    }
+    TEColorParameter colorParam = registerColorControl(colorPrefix);
+
   }
 
   /** Included for consistency. We may need it later. */
@@ -349,8 +358,10 @@ public class TECommonControls {
   protected void setRemoteControls() {
     this.pattern.setCustomRemoteControls(
         new LXListenableNormalizedParameter[] {
-          this.color.offset,
-          this.color.gradient,
+          //this.color.offset,
+          //this.color.gradient,
+          getControl(TEControlTag.LEVELREACTIVITY).control,
+          getControl(TEControlTag.FREQREACTIVITY).control,
           null, // getControl(TEControlTag.BRIGHTNESS).control,
           getControl(TEControlTag.SPEED).control,
           getControl(TEControlTag.XPOS).control,
@@ -410,6 +421,9 @@ public class TECommonControls {
     getControl(TEControlTag.WOW1).control.reset();
     getControl(TEControlTag.WOW2).control.reset();
     getControl(TEControlTag.WOWTRIGGER).control.reset();
+
+    getControl(TEControlTag.LEVELREACTIVITY).control.reset();
+    getControl(TEControlTag.FREQREACTIVITY).control.reset();
   }
 
   public void dispose() {

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -314,6 +314,14 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     return controls.getValue(TEControlTag.WOWTRIGGER) > 0.0;
   }
 
+  public double getLevelReactivity() {
+    return controls.getValue(TEControlTag.LEVELREACTIVITY);
+  }
+
+  public double getFrequencyReactivity() {
+    return controls.getValue(TEControlTag.FREQREACTIVITY);
+  }
+
   /**
    * Restarts the specified timer's elapsed time when called. The timer's rate is not changed.
    *

--- a/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
@@ -28,6 +28,9 @@ public class GLPatternControl implements GLControlData {
     s.setUniform("trebleRatio", (float) pattern.getTrebleRatio());
     s.setUniform("volumeRatio", pattern.getVolumeRatiof());
 
+    s.setUniform("levelReact", (float) pattern.getLevelReactivity());
+    s.setUniform("frequencyReact", (float) pattern.getFrequencyReactivity());
+
     // color-related uniforms
     int col = pattern.calcColor();
     s.setUniform(

--- a/src/main/java/titanicsend/pattern/jon/TEControlTag.java
+++ b/src/main/java/titanicsend/pattern/jon/TEControlTag.java
@@ -11,24 +11,29 @@ public enum TEControlTag {
   WOW1,
   WOW2,
   WOWTRIGGER,
-  ANGLE;
+  ANGLE,
+  LEVELREACTIVITY,
+  FREQREACTIVITY;
+
 
   public String getPath() {
     String path =
-        switch (this) {
-          case SPEED -> "te_speed";
-          case XPOS -> "te_xpos";
-          case YPOS -> "te_ypos";
-          case SIZE -> "te_size";
-          case QUANTITY -> "te_quantity";
-          case SPIN -> "te_spin";
-          case BRIGHTNESS -> "te_brightness";
-          case WOW1 -> "te_wow1";
-          case WOW2 -> "te_wow2";
-          case WOWTRIGGER -> "te_wowtrigger";
-          case ANGLE -> "te_angle";
-          default -> "";
-        };
+      switch (this) {
+        case SPEED -> "te_speed";
+        case XPOS -> "te_xpos";
+        case YPOS -> "te_ypos";
+        case SIZE -> "te_size";
+        case QUANTITY -> "te_quantity";
+        case SPIN -> "te_spin";
+        case BRIGHTNESS -> "te_brightness";
+        case WOW1 -> "te_wow1";
+        case WOW2 -> "te_wow2";
+        case WOWTRIGGER -> "te_wowtrigger";
+        case ANGLE -> "te_angle";
+        case LEVELREACTIVITY -> "te_level";
+        case FREQREACTIVITY -> "te_freq";
+        default -> "";
+      };
 
     return path;
   }
@@ -46,6 +51,8 @@ public enum TEControlTag {
       case QUANTITY -> "Quantity";
       case BRIGHTNESS -> "Brightness";
       case WOWTRIGGER -> "WowTrigger";
+      case LEVELREACTIVITY -> "LvlReact";
+      case FREQREACTIVITY -> "FreqReact";
     };
   }
 }

--- a/src/main/java/titanicsend/ui/UITEPerformancePattern.java
+++ b/src/main/java/titanicsend/ui/UITEPerformancePattern.java
@@ -82,6 +82,8 @@ public class UITEPerformancePattern
 
     // For design mode, append Brightness.  Useful for AutoVJ especially.
     params.add(device.getControls().getControl(TEControlTag.BRIGHTNESS).control);
+    params.add(device.getControls().color.offset);
+    params.add(device.getControls().color.gradient);
 
     // slight hack to add source select and gain controls for NDI patterns without
     // replicating all this UI code...


### PR DESCRIPTION
The new controls,  Level Reactivity and Frequency Reactivity, will be the first two controls on the midi surfaces.  The old per-pattern color controls have been moved to the second page, and are no longer on the midi controller.