### PR TITLE
tweak: both LightBeams patterns use ALL_POINTS as default view

### DIFF
--- a/src/main/java/titanicsend/pattern/sinas/LightBeamsAudioReactivePattern.java
+++ b/src/main/java/titanicsend/pattern/sinas/LightBeamsAudioReactivePattern.java
@@ -24,7 +24,7 @@ public class LightBeamsAudioReactivePattern extends ConstructedShaderPattern {
   private GaussianFilter timeDiffFilter = new GaussianFilter(20);
 
   public LightBeamsAudioReactivePattern(LX lx) {
-    super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
+    super(lx, TEShaderView.ALL_POINTS);
 
     controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
     controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -10,26 +10,10 @@ import titanicsend.pattern.yoffa.framework.TEShaderView;
 @SuppressWarnings("unused")
 public class ShaderPanelsPatternConfig {
 
-  /* Removed from UI - see TEApp.java for details.
-  @LXCategory("Native Shaders Panels")
-  public static class ShaderToyPattern extends ConstructedPattern {
-      public ShaderToyPattern(LX lx) {
-          super(lx);
-      }
-
-      @Override
-      protected List<PatternEffect> createEffects() {
-          return List.of(new ShaderToyPatternEffect(new PatternTarget(this, TEShaderView.SPLIT_PANEL_SECTIONS)));
-      }
-  }
-
-  */
-
-  // multiple
   @LXCategory("Native Shaders Panels")
   public static class LightBeamsPattern extends ConstructedShaderPattern {
     public LightBeamsPattern(LX lx) {
-      super(lx, TEShaderView.ALL_PANELS_INDIVIDUAL);
+      super(lx, TEShaderView.ALL_POINTS);
     }
 
     @Override


### PR DESCRIPTION
Small followup to this comment in the previous PR affecting LightBeams: https://github.com/titanicsend/LXStudio-TE/pull/454#discussion_r1550654055