### PR TITLE
Fix for NDI send on project file load/unload

### DIFF
--- a/src/main/java/titanicsend/effect/NDIOutRawEffect.java
+++ b/src/main/java/titanicsend/effect/NDIOutRawEffect.java
@@ -62,6 +62,9 @@ public class NDIOutRawEffect extends TEEffect {
 
   @Override
   public void dispose() {
+    if (isInitialized) {
+      ndiSender.close();
+    }
     super.dispose();
   }
 }


### PR DESCRIPTION
One line fix:  When the sender is destroyed, explicitly close the channel and release the channel name.  Don't wait for Java to do it.   Doh!

What was happening:  Project file unload was destroying the Java objects, which didn't result in immediately closing and removing the active NDI channel. 

NDI receivers interpret that as the channel still existing, but just not sending new frames. Subsequent attempts to re-open the channel fail silently because NDI believes a channel of that name is already active until the native object associated with the now-dead Java channel object finally gets released.  The Java GC will take care of this eventually, but since it involves native memory, "eventually" might be a very long time.

Since we're using one channel name for all TE NDI output, explicitly closing the channel on dispose frees that name for immediate re-use by the next loaded pattern.   (FWIW, we've seen this, "must explicitly release native resources if you want to use them in a new project or pattern", with OpenGL too. )