### PR TITLE
Audio Reactivity for Turbulent Noise Lines

### DIFF
--- a/resources/shaders/turbulent_noise_lines.fs
+++ b/resources/shaders/turbulent_noise_lines.fs
@@ -4,6 +4,8 @@
 const float PI = 3.1415926;
 const float TAU = 2.0 * PI;
 
+float T;
+
 // circle function from nimitz @ ShaderToy
 // returns distance from a point to a cirular pulse
 float circle(vec2 p) {
@@ -33,27 +35,39 @@ float noise(vec2 uv) {
 }
 
 // several octaves of value noise make a cloudy-looking turbulent field
+// higher bassLevel increases the amount of "dirt" in the noise field
 float turbulenceNoise(vec2 uv) {
     float k = 4.0;
 
-    //uv = rotate2D(k + 0.00001 * iTime) * uv;
     float res = 0.;
     float c = 0.5;
+    float dirt = bassLevel * levelReact * 0.5;
 
     for (int i = 0; i < 8; i++) {
-        uv -= iTranslate  * 0.2;
+        // max() here limits effects of audio signal dropout, which are particularly
+        // bad here, since floating point Infinity or NaN can cause the coordinates
+        // to be translated totally out of range, resulting in a black screen
+        // TODO - fix this for good in the 2024 audio engine update.
+        uv -= iTranslate  * 0.25 + max(0.0005,trebleRatio * frequencyReact);
         uv = rotate2D(k + 0.00001 * iTime) * k * uv;
-        res += c * noise(uv);
-        c *= 0.5;
+        res += c * noise(uv);;
+        c *= 0.5 + dirt;
+        dirt *= 0.5;
     }
 
     return res;
 }
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-
     // normalize, scale, rotate
     vec2 uv = (fragCoord.xy - 0.5 * iResolution.xy) / iResolution.x;
+
+    float warp = 80. * bassLevel * levelReact;
+    float warpAmt = levelReact * 0.03;
+
+    uv.x -= warpAmt * sin(uv.y * warp);
+    uv.y += warpAmt * cos(uv.x * warp);
+
     uv *= iScale;
     uv = uv * rotate2D(-iRotationAngle);
 
@@ -61,18 +75,20 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     uv = rotate2D(1.65 * noise(uv * 5. + 0.1 * iTime)) * uv;
 
     // Quantity controls the density of the lines derived from the noise field
-    float line = smoothstep(0., 1., abs(res + sin(TAU * res + iQuantity * uv.x)));
+    // Volume ratio alters the number of lines drawn
+    float freqShift = max(0.0005,80.0 * volumeRatio * levelReact);
+    float line = smoothstep(0., 1., abs(res + sin(TAU * res + iQuantity * (uv.x+uv.y))));
     line = smoothstep(0., 1., line);
 
     // Wow Trigger runs the TE special dual ring pulse generator, which draws only on
     // the wavy lines (and not on the background fog.)
     if (iWowTrigger) {
         uv /= exp(beat * PI);
-        line *= max(1.0, 0.75 / pow(abs(2.1 - circle(uv)),0.75));
+        line *= min(1.0, 0.75 / pow(abs(2.1 - circle(uv)),0.75));
     }
 
     // Wow1 controls the mix of lines vs. noise field background
-    float bri = mix(1.5 * res, line, iWow1);
+    float bri = mix(res, line, iWow1);
     // Wow2 controls the mix of foreground color vs. gradient
     vec3 col = bri * mix(iColorRGB, mix(iColor2RGB, iColorRGB,smoothstep(0.1,0.8, bri * bri)), iWow2);
 

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -14,14 +14,19 @@ public class TurbulenceLines extends DriftEnabledPattern {
 
     // common controls setup
     controls.setRange(TEControlTag.SPEED, 0, -4, 4);
-    controls.setValue(TEControlTag.SPEED, 0.5);
+    controls.setValue(TEControlTag.SPEED, 1.0);
 
-    controls.setRange(TEControlTag.SIZE, 1, 0.4, 1.25);
+    controls.setRange(TEControlTag.SIZE, 1, 1.25, 0.4);
     controls.setRange(TEControlTag.QUANTITY, 60, 20, 200);
-    controls.setRange(TEControlTag.WOW1, 0.5, 0, 1);
+    controls.setRange(TEControlTag.WOW1, 0.5, 0.2, 1);
 
     controls.setValue(TEControlTag.XPOS, 0.25);
     controls.setValue(TEControlTag.YPOS, -0.25);
+    avgTreble.alpha = 0.5;
+    avgBass.alpha = 0.95;
+
+    eq.getRaw();
+    eq.getDecibels();
 
     // register common controls with LX
     addCommonControls();
@@ -33,6 +38,10 @@ public class TurbulenceLines extends DriftEnabledPattern {
           public void OnFrame(GLShader s) {
             // calculate incremental transform based on elapsed time
             s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
+
+            // override iTime so we can speed up noise field progression while leaving the controls
+            // in a more reasonable range
+            s.setUniform("iTime", 2f * (float) getTime());
           }
         });
   }

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -4,10 +4,11 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
+import titanicsend.util.TEMath;
 
 @LXCategory("Noise")
 public class TurbulenceLines extends DriftEnabledPattern {
-
+  double freqShift = 0.0;
 
   public TurbulenceLines(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
@@ -22,8 +23,8 @@ public class TurbulenceLines extends DriftEnabledPattern {
 
     controls.setValue(TEControlTag.XPOS, 0.25);
     controls.setValue(TEControlTag.YPOS, -0.25);
-    avgTreble.alpha = 0.5;
-    avgBass.alpha = 0.95;
+    avgTreble.alpha = 0.04;
+    avgBass.alpha = 0.02;
 
     eq.getRaw();
     eq.getDecibels();
@@ -42,7 +43,11 @@ public class TurbulenceLines extends DriftEnabledPattern {
             // override iTime so we can speed up noise field progression while leaving the controls
             // in a more reasonable range
             s.setUniform("iTime", 2f * (float) getTime());
+            double freqShift = avgTreble.getValuef() * getFrequencyReactivity();
+            s.setUniform("freqShift", (float) freqShift);
           }
         });
   }
+
+
 }

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -8,7 +8,6 @@ import titanicsend.util.TEMath;
 
 @LXCategory("Noise")
 public class TurbulenceLines extends DriftEnabledPattern {
-  double freqShift = 0.0;
 
   public TurbulenceLines(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
@@ -23,11 +22,9 @@ public class TurbulenceLines extends DriftEnabledPattern {
 
     controls.setValue(TEControlTag.XPOS, 0.25);
     controls.setValue(TEControlTag.YPOS, -0.25);
-    avgTreble.alpha = 0.04;
-    avgBass.alpha = 0.02;
 
-    eq.getRaw();
-    eq.getDecibels();
+    // let the bass averaging filter respond a little faster
+    avgBass.alpha = 0.02;
 
     // register common controls with LX
     addCommonControls();
@@ -43,11 +40,7 @@ public class TurbulenceLines extends DriftEnabledPattern {
             // override iTime so we can speed up noise field progression while leaving the controls
             // in a more reasonable range
             s.setUniform("iTime", 2f * (float) getTime());
-            double freqShift = avgTreble.getValuef() * getFrequencyReactivity();
-            s.setUniform("freqShift", (float) freqShift);
           }
         });
   }
-
-
 }


### PR DESCRIPTION
- Level Reactivity uses bass energy to adjust the noise field generator and coordinate warping (it makes the lines slide and dance around.)
- Frequency Reactivity uses treble to control how much spare black "ink" is flying around in the wind (xpos/ypos), and also bounces extra light around in the spaces between the lines.