### PR TITLE
Fixes for NdiEngine and TdNdiPattern

### DIFF
--- a/src/main/java/titanicsend/ndi/NDIEngine.java
+++ b/src/main/java/titanicsend/ndi/NDIEngine.java
@@ -69,7 +69,7 @@ public class NDIEngine extends LXComponent implements LXLoopTask {
       return false;
     }
 
-    if (index < sources.length) {
+    if (sources != null && index < sources.length) {
       receiver.connect(sources[index]);
       return true;
     }


### PR DESCRIPTION
This PR is addressing two bugs:
  1. NdiEngine is not checking if the source is null or not, and it can cause a crash when the NDI pattern is the first pattern loaded on LX.
  2. Showing the last frame on the TdNdiPattern if there's no new frames received on NDI. This helps remove a flicker issue when NDI is being published on a bad connection over network.
