### PR TITLE
Move Auto shaders to ShaderPanelsConfig

### DIFF
--- a/resources/shaders/circuitry.fs
+++ b/resources/shaders/circuitry.fs
@@ -4,12 +4,6 @@
 // The "artistic intention" is to sorta depict what's going on in all the circuitry inside Titanic's End
 //
 // Wow2 controls audio reactivity
-#pragma name "Circuitry"
-#pragma TEControl.SIZE.Range(2.0,5.0,0.1)
-#pragma TEControl.QUANTITY.Range(4.0,3.0,6.0)
-#pragma TEControl.WOW2.Disable
-#pragma TEControl.WOW1.Disable
-#pragma TEControl.WOWTRIGGER.Disable
 
 #include <include/constants.fs>
 #include <include/colorspace.fs>

--- a/resources/shaders/waterfall.fs
+++ b/resources/shaders/waterfall.fs
@@ -1,10 +1,7 @@
 // Simplex noise-based waterfall, based on https://www.shadertoy.com/view/ttlXDN
 // Wow1 controls background fade level
 // Wow2 controls water vs. palette color mix.  (All the way up is palette compliant)
-#pragma name "Waterfall"
-#pragma iChannel1 "resources/shaders/textures/icecliff.png"
-#pragma TEControl.WOW1.Range(0.4,0.0,1.0)
-#pragma TEControl.SPEED.Value(0.75)
+// WowTrigger reverses the flow of the waterfall
 
 #define PI 3.14159265359
 

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -423,4 +423,34 @@ public class ShaderPanelsPatternConfig {
       addShader("smoke_shader.fs");
     }
   }
+
+  @LXCategory("Combo FG")
+  public static class Circuitry extends ConstructedShaderPattern {
+    public Circuitry(LX lx) {
+      super(lx, TEShaderView.ALL_POINTS);
+    }
+
+    @Override
+    protected void createShader() {
+      controls.setRange(TEControlTag.SIZE, 2, 5, 0.1);
+      controls.setRange(TEControlTag.QUANTITY, 4, 3, 6);
+
+      addShader("circuitry.fs");
+    }
+  }
+
+  @LXCategory("Combo FG")
+  public static class Waterfall extends ConstructedShaderPattern {
+    public Waterfall(LX lx) {
+      super(lx, TEShaderView.ALL_POINTS);
+    }
+
+    @Override
+    protected void createShader() {
+      controls.setRange(TEControlTag.WOW1, 0.4, 0, 1);
+      controls.setValue(TEControlTag.SPEED, 0.75);
+
+      addShader("waterfall.fs", "icecliff.png");
+    }
+  }
 }


### PR DESCRIPTION
Don't take this unless we're sure we need it!

Automatic shaders should work fine in .lxp files.  Just in case we find a circumstance where they don't, this PR moves the Circuitry and Waterfall patterns to a fixed configuration file.

(Note that taking this PR will mean we'll need to revise the current show file because class paths will have changed.  ) 
