### PR TITLE
Refactor: legacy audio patterns use level/freq instead of wow1/2

### DIFF
--- a/resources/shaders/sigmoid_dance_audio_levels.fs
+++ b/resources/shaders/sigmoid_dance_audio_levels.fs
@@ -57,8 +57,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec3 color = vec3(0.);
     bool isColor2Black = distance(iColor2RGB, vec3(0.)) < 0.1;
 
-    float norm_y = 0.05 + bassLevel * iWow1;
-    float norm_x = 0.05 + trebleLevel * iWow1;
+    float norm_y = 0.05 + bassLevel * levelReact;
+    float norm_x = 0.05 + trebleLevel * levelReact;
     //float norm_x = iScaledLo;
     //float norm_y = iScaledHi;
 
@@ -68,8 +68,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float tx = halfBin+pixPerBin * p;
     float freq  = texelFetch(iChannel0, ivec2(tx, 0), 0).x;
 
-    norm_x += iWow2 * wave;
-    norm_y += iWow2 * freq;
+    norm_x += frequencyReact * wave;
+    norm_y += frequencyReact * freq;
 
     if (iWowTrigger) {
         norm_x *= norm_x;

--- a/resources/shaders/sigmoid_dance_audio_waveform.fs
+++ b/resources/shaders/sigmoid_dance_audio_waveform.fs
@@ -63,8 +63,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float tx = halfBin+pixPerBin * p;
     float freq  = texelFetch(iChannel0, ivec2(tx, 0), 0).x;
 
-    float norm_x = pow(wave, 1. / iWow2);
-    float norm_y = pow(freq, 1. / iWow1);
+    float norm_x = pow(wave, 1. / frequencyReact);
+    float norm_y = pow(freq, 1. / levelReact);
 
     //float norm_x = (wave / avgVolume);
     //float norm_y = (freq / avgVolume);

--- a/resources/shaders/triangle_cross_waveform.fs
+++ b/resources/shaders/triangle_cross_waveform.fs
@@ -104,10 +104,10 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord){
     float pct = 0.;
     float pct2 = 0.;
 
-    float xsize = 0.1 + iWow1 * 0.5 * trebleLevel;
-    float ysize = 0.25 - iWow1 * 0.2 * trebleLevel;
-    float outer = 1.2 + iWow1 * 1.5 * bassLevel;
-    float inner = 1.1 + iWow1 * 2.0 * bassLevel;
+    float xsize = 0.1 + levelReact * 0.5 * trebleLevel;
+    float ysize = 0.25 - levelReact * 0.2 * trebleLevel;
+    float outer = 1.2 + levelReact * 1.5 * bassLevel;
+    float inner = 1.1 + levelReact * 2.0 * bassLevel;
     //float xsize = 0.1;
     //float ysize = 0.15;
     //float outer = 1.2 + 0.2 * sin(iTime);
@@ -152,14 +152,14 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord){
 
     // scaling factor on triangle distance field
     float triangle_scale = 1.1;
-    //triangle_scale = iWow2;
+    //triangle_scale = frequencyReact;
     float triangle_dist = f / triangle_scale;
 
     // innermost step function we apply to triangle distance field
     float r = 0.15;
-    r += iWow2 * wave;
-    r += iWow1 * 0.2 * volumeRatio;
-    //r = iWow1;
+    r += frequencyReact * wave;
+    r += levelReact * 0.2 * volumeRatio;
+    //r = levelReact;
     float tri_inner_mask = r + noise1d(0.35, 3.*iTime);
 
     float tri_inner_margin = 0.04;// - 0.04 * volumeRatio;

--- a/resources/shaders/triangle_infinity_radial_waveform.fs
+++ b/resources/shaders/triangle_infinity_radial_waveform.fs
@@ -4,8 +4,8 @@
 // #iUniform float iSpeed = 0.5 in {0.25, 3.0}
 // #iUniform float iScale = 1.0 in {0.25, 5.0}
 // #iUniform float iQuantity = 3.0 in {1.0, 9.0}
-// #iUniform float iWow2 = 2.5 in {1.0, 3.0}
-// #iUniform float iWow1 = 0.9 in {0.5, 2.0}
+// #iUniform float frequencyReact = 2.5 in {1.0, 3.0}
+// #iUniform float levelReact = 0.9 in {0.5, 2.0}
 // #iUniform float iRotationAngle = 0.0 in {0.0, 6.28}
 
 #define TEXTURE_SIZE 512.0
@@ -47,13 +47,13 @@ float sdEquilateralTriangle( in vec2 p, in float r ) {
 //}
 
 float numIters = iQuantity;
-float waveFreq = 8.0 + iWow1 * 4.0 * volumeRatio;
+float waveFreq = 8.0 + levelReact * 4.0 * volumeRatio;
 const float defaultYOffset = -0.17;
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 float size = iScale;
     //size += 0.1 * bassRatio;
-    size += iWow1 * 0.2 * bassRatio;
+    size += levelReact * 0.2 * bassRatio;
 
     // normalize coordinates
     vec2 uv = fragCoord.xy / iResolution.xy;
@@ -77,7 +77,7 @@ float size = iScale;
     //float freq  = texelFetch(iChannel0, ivec2(tx, 0), 0).x;
 
     float fractFactor = 0.86;
-    fractFactor = 0.7 + iWow1 * 0.9 * trebleLevel;
+    fractFactor = 0.7 + levelReact * 0.9 * trebleLevel;
 
     vec2 uv0 = uv;
     vec3 finalColor = vec3(0.0);
@@ -88,7 +88,7 @@ float size = iScale;
         uv.y *= -1.;
 
         float d = 1.;
-        d *= sdEquilateralTriangle(uv, 0.9) + iWow2*wave;
+        d *= sdEquilateralTriangle(uv, 0.9) + frequencyReact*wave;
         d *= outerTriangleDF;
         //d += 0.3*noise(i*d, iTime*0.1);
 

--- a/resources/shaders/triangle_infinity_waveform.fs
+++ b/resources/shaders/triangle_infinity_waveform.fs
@@ -4,8 +4,8 @@
 // #iUniform float iSpeed = 0.5 in {0.25, 3.0}
 // #iUniform float iScale = 1.0 in {0.25, 5.0}
 // #iUniform float iQuantity = 3.0 in {1.0, 9.0}
-// #iUniform float iWow2 = 2.5 in {1.0, 3.0}
-// #iUniform float iWow1 = 0.9 in {0.5, 2.0}
+// #iUniform float frequencyReact = 2.5 in {1.0, 3.0}
+// #iUniform float levelReact = 0.9 in {0.5, 2.0}
 // #iUniform float iRotationAngle = 0.0 in {0.0, 6.28}
 
 #define TEXTURE_SIZE 512.0
@@ -47,12 +47,12 @@ float sdEquilateralTriangle( in vec2 p, in float r ) {
 //}
 
 float numIters = iQuantity;
-float waveFreq = 8.0 + iWow1 * 4.0 * volumeRatio;
+float waveFreq = 8.0 + levelReact * 4.0 * volumeRatio;
 const float defaultYOffset = -0.17;
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 float size = iScale;
-    size += iWow1 * 0.2 * bassRatio;
+    size += levelReact * 0.2 * bassRatio;
 
     // normalize coordinates
     vec2 uv = fragCoord.xy / iResolution.xy;
@@ -72,7 +72,7 @@ float size = iScale;
     //float freq  = texelFetch(iChannel0, ivec2(tx, 0), 0).x;
 
     float fractFactor = 0.86;
-    fractFactor = 0.7 + iWow1 * 0.9 * trebleLevel;
+    fractFactor = 0.7 + levelReact * 0.9 * trebleLevel;
 
     vec2 uv0 = uv;
     vec3 finalColor = vec3(0.0);
@@ -83,7 +83,7 @@ float size = iScale;
         uv.y *= -1.;
 
         float d = 1.;
-        d *= sdEquilateralTriangle(uv, 0.9) + iWow2*wave;
+        d *= sdEquilateralTriangle(uv, 0.9) + frequencyReact*wave;
         d *= outerTriangleDF;
         //d += 0.3*noise(i*d, iTime*0.1);
 

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
@@ -17,9 +17,8 @@ public class SigmoidDanceAudioLevels extends GLShaderPattern {
     controls.setRange(TEControlTag.LEVELREACTIVITY, 1.5, 0.0, 2.0);
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.2, 0.0, 2.0);
     controls.setRange(TEControlTag.SIZE, 0.55, 0.0, 2.0);
-
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
@@ -18,6 +18,9 @@ public class SigmoidDanceAudioLevels extends GLShaderPattern {
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.2, 0.0, 2.0);
     controls.setRange(TEControlTag.SIZE, 0.55, 0.0, 2.0);
 
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+
     addCommonControls();
 
     addShader(

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
@@ -14,8 +14,8 @@ public class SigmoidDanceAudioLevels extends GLShaderPattern {
     super(lx, TEShaderView.ALL_POINTS);
 
     controls.setRange(TEControlTag.QUANTITY, 4.0, 0.0, 4.0);
-    controls.setRange(TEControlTag.WOW1, 1.5, 0.0, 2.0);
-    controls.setRange(TEControlTag.WOW2, 0.2, 0.0, 2.0);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 1.5, 0.0, 2.0);
+    controls.setRange(TEControlTag.FREQREACTIVITY, 0.2, 0.0, 2.0);
     controls.setRange(TEControlTag.SIZE, 0.55, 0.0, 2.0);
 
     addCommonControls();

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
@@ -17,6 +17,10 @@ public class SigmoidDanceAudioWaveform extends GLShaderPattern {
     controls.setValue(TEControlTag.SIZE, 0.5);
     controls.setRange(TEControlTag.LEVELREACTIVITY, 4.0, 0.0, 8.0);
     controls.setRange(TEControlTag.FREQREACTIVITY, 1.0, 0.0, 4.0);
+
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+
     addCommonControls();
 
     addShader(

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
@@ -15,8 +15,8 @@ public class SigmoidDanceAudioWaveform extends GLShaderPattern {
 
     controls.setValue(TEControlTag.YPOS, -0.04);
     controls.setValue(TEControlTag.SIZE, 0.5);
-    controls.setRange(TEControlTag.WOW1, 4.0, 0.0, 8.0);
-    controls.setRange(TEControlTag.WOW2, 1.0, 0.0, 4.0);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 4.0, 0.0, 8.0);
+    controls.setRange(TEControlTag.FREQREACTIVITY, 1.0, 0.0, 4.0);
     addCommonControls();
 
     addShader(

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
@@ -17,9 +17,8 @@ public class SigmoidDanceAudioWaveform extends GLShaderPattern {
     controls.setValue(TEControlTag.SIZE, 0.5);
     controls.setRange(TEControlTag.LEVELREACTIVITY, 4.0, 0.0, 8.0);
     controls.setRange(TEControlTag.FREQREACTIVITY, 1.0, 0.0, 4.0);
-
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/TriangleCrossAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleCrossAudioWaveform.java
@@ -20,9 +20,8 @@ public class TriangleCrossAudioWaveform extends ConstructedShaderPattern {
     controls.setRange(TEControlTag.QUANTITY, 12.0, 1.0, 16.0);
     controls.setRange(TEControlTag.LEVELREACTIVITY, 0.3, 0.0, 1.0);
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.11, 0.0, 1.0);
-
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addShader("triangle_cross_waveform.fs");
   }

--- a/src/main/java/titanicsend/pattern/look/TriangleCrossAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleCrossAudioWaveform.java
@@ -18,8 +18,11 @@ public class TriangleCrossAudioWaveform extends ConstructedShaderPattern {
     controls.setRange(TEControlTag.XPOS, 0.07, -0.5, 0.5);
     controls.setRange(TEControlTag.YPOS, -0.04, -0.5, 0.5);
     controls.setRange(TEControlTag.QUANTITY, 12.0, 1.0, 16.0);
-    controls.setRange(TEControlTag.WOW1, 0.3, 0.0, 1.0);
-    controls.setRange(TEControlTag.WOW2, 0.11, 0.0, 1.0);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 0.3, 0.0, 1.0);
+    controls.setRange(TEControlTag.FREQREACTIVITY, 0.11, 0.0, 1.0);
+
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addShader("triangle_cross_waveform.fs");
   }

--- a/src/main/java/titanicsend/pattern/look/TriangleInfinityRadialWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleInfinityRadialWaveform.java
@@ -19,9 +19,8 @@ public class TriangleInfinityRadialWaveform extends GLShaderPattern {
     controls.setRange(TEControlTag.QUANTITY, 6.0, 2.0, 12.0);
     controls.setRange(TEControlTag.LEVELREACTIVITY, 0.11, 0.0, 0.5);
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.03, 0.0, 0.5);
-
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/TriangleInfinityRadialWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleInfinityRadialWaveform.java
@@ -17,8 +17,11 @@ public class TriangleInfinityRadialWaveform extends GLShaderPattern {
     controls.setRange(TEControlTag.SPEED, 0.03, 0.00, 0.5);
     //        controls.setRange(TEControlTag.QUANTITY, 8.0, 1.0, 24.0);
     controls.setRange(TEControlTag.QUANTITY, 6.0, 2.0, 12.0);
-    controls.setRange(TEControlTag.WOW1, 0.11, 0.0, 0.5);
-    controls.setRange(TEControlTag.WOW2, 0.03, 0.0, 0.5);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 0.11, 0.0, 0.5);
+    controls.setRange(TEControlTag.FREQREACTIVITY, 0.03, 0.0, 0.5);
+
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/TriangleInfinityWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleInfinityWaveform.java
@@ -19,9 +19,8 @@ public class TriangleInfinityWaveform extends GLShaderPattern {
     controls.setRange(TEControlTag.QUANTITY, 6.0, 2.0, 12.0);
     controls.setRange(TEControlTag.LEVELREACTIVITY, 0.09, 0.0, 0.5);
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.04, 0.0, 0.5);
-
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
-//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/TriangleInfinityWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/TriangleInfinityWaveform.java
@@ -17,8 +17,11 @@ public class TriangleInfinityWaveform extends GLShaderPattern {
     controls.setRange(TEControlTag.SIZE, 1.35, 0.2, 2.0);
     controls.setRange(TEControlTag.SPEED, 0.01, 0.00, 0.5);
     controls.setRange(TEControlTag.QUANTITY, 6.0, 2.0, 12.0);
-    controls.setRange(TEControlTag.WOW1, 0.09, 0.0, 0.5);
-    controls.setRange(TEControlTag.WOW2, 0.04, 0.0, 0.5);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 0.09, 0.0, 0.5);
+    controls.setRange(TEControlTag.FREQREACTIVITY, 0.04, 0.0, 0.5);
+
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+//    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
 
     addCommonControls();
 


### PR DESCRIPTION
I left some commented-out lines for marking those controls unused on the UI, we can uncomment those after we go through our showfile and update the configs