### PR TITLE
Avoid NullPointerException resulted from initial null variable

### DIFF
--- a/src/main/java/titanicsend/ndi/NDIEngine.java
+++ b/src/main/java/titanicsend/ndi/NDIEngine.java
@@ -15,7 +15,7 @@ public class NDIEngine extends LXComponent implements LXLoopTask {
   private long time = 0;
   private static final int sourceRefreshInterval = 1000;
 
-  public DevolaySource[] sources;
+  public DevolaySource[] sources = new DevolaySource[0];
   protected DevolayFinder finder;
 
   public static NDIEngine get() {
@@ -27,6 +27,7 @@ public class NDIEngine extends LXComponent implements LXLoopTask {
   }
 
   public ArrayList<String> getSourceNames() {
+    // TODO: This should be refreshed when sources is updated, not on every method call.
     ArrayList<String> sourceNames = new ArrayList<String>();
     for (DevolaySource source : sources) {
       sourceNames.add(source.getSourceName());
@@ -47,9 +48,10 @@ public class NDIEngine extends LXComponent implements LXLoopTask {
    * @return True if the source is available and connection attempt was successful.
    *        False if the source is not available.
    */
-  public boolean connectByName(String sourceName,DevolayReceiver receiver) {
+  public boolean connectByName(String sourceName, DevolayReceiver receiver) {
     for (DevolaySource source : sources) {
-      if (source.getSourceName().contains(sourceName)) {
+      String name = source.getSourceName();
+      if (name != null && name.contains(sourceName)) {
         receiver.connect(source);
         return true;
       }


### PR DESCRIPTION
Fixes this error:

```
[LX 2024/04/13 16:28:47] Unexpected error in device loop titanicsend.pattern.sinas.TdNdiPattern: Cannot read the array length because "<local3>" is null
java.lang.NullPointerException: Cannot read the array length because "<local3>" is null
	at titanicsend.ndi.NDIEngine.connectByName(NDIEngine.java:51)
	at titanicsend.pattern.sinas.TdNdiPattern.onActive(TdNdiPattern.java:128)
	at heronarts.lx.pattern.LXPattern.onLoop(LXPattern.java:532)
```