### PR TITLE
Minor audio fixes + shader cache disable.

### DIFF
--- a/resources/shaders/kaleidosonic.fs
+++ b/resources/shaders/kaleidosonic.fs
@@ -51,8 +51,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     uv = Kaleidoscope(uv, iQuantity);
 
     // levelReact controls audio-linked scaling "bounce" and minimum blob size
-    float level = levelReact * clamp(bassRatio, 0.5, 8);
-    float intensity = levelReact * clamp(volumeRatio, 0.5, 8);
+    float level = levelReact * clamp(bassRatio, 0.5, 8.);
+    float intensity = levelReact * clamp(volumeRatio, 0.5, 8.);
 
     // modulate overall scale by level just a little for more movement.
     // (too much looks jittery)

--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -19,6 +19,10 @@ public abstract class TEAudioPattern extends TEPattern {
   // The GraphicMeter holds the analyzed frequency content for the audio input
   protected final GraphicMeter eq = lx.engine.audio.meter;
 
+  // Small offset for audio signals to avoid divide by zero in ratio calculations,
+  // which can cause (possibly dramatic) visual glitches if the audio drops out.
+  protected static final double levelOffset = 0.01;
+
   // Fractions in 0..1 for the instantaneous frequency level this frame.
   // If we find this useful and track many more bands, a collection of ratio
   // tracker objects would make sense.
@@ -80,16 +84,16 @@ public abstract class TEAudioPattern extends TEPattern {
    */
   protected void computeAudio(double deltaMs) {
     // Instantaneous normalized (0..1) volume level
-    volumeLevel = eq.getNormalizedf();
+    volumeLevel = eq.getNormalizedf() + levelOffset;
 
     /* Average bass level of the bottom `bassBands` frequency bands.
      * The default lx.engine.audio.meter breaks up sound into 16 bands,
      * so a `bassBandCount` of 2 averages the bottom 12.5% of frequencies.
      */
-    bassLevel = eq.getAverage(0, bassBandCount);
+    bassLevel = eq.getAverage(0, bassBandCount) + levelOffset;
 
     // Instantaneous average level of the top half of the frequency bins
-    trebleLevel = eq.getAverage(eq.numBands / 2, eq.numBands / 2);
+    trebleLevel = eq.getAverage(eq.numBands / 2, eq.numBands / 2) + levelOffset;
 
     /* Compute the ratio of the current instantaneous frequency levels to
      * their new, updated moving averages.

--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -84,16 +84,16 @@ public abstract class TEAudioPattern extends TEPattern {
    */
   protected void computeAudio(double deltaMs) {
     // Instantaneous normalized (0..1) volume level
-    volumeLevel = eq.getNormalizedf() + levelOffset;
+    volumeLevel = Math.max(levelOffset,eq.getNormalized());
 
     /* Average bass level of the bottom `bassBands` frequency bands.
      * The default lx.engine.audio.meter breaks up sound into 16 bands,
      * so a `bassBandCount` of 2 averages the bottom 12.5% of frequencies.
      */
-    bassLevel = eq.getAverage(0, bassBandCount) + levelOffset;
+    bassLevel = Math.max(levelOffset, eq.getAverage(0, bassBandCount));
 
     // Instantaneous average level of the top half of the frequency bins
-    trebleLevel = eq.getAverage(eq.numBands / 2, eq.numBands / 2) + levelOffset;
+    trebleLevel = Math.max(levelOffset, eq.getAverage(eq.numBands / 2, eq.numBands / 2));
 
     /* Compute the ratio of the current instantaneous frequency levels to
      * their new, updated moving averages.

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPrecompiler.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPrecompiler.java
@@ -16,7 +16,7 @@ public class ShaderPrecompiler {
     int totalFiles = 0;
     int compiledFiles = 0;
 
-    TE.log("Refreshing shader cache...");
+    //TE.log("Refreshing shader cache...");
 
     // save the currently active GL context
     GLContext prevContext = GLContext.getCurrent();
@@ -26,6 +26,20 @@ public class ShaderPrecompiler {
     surface.display();
     surface.getContext().makeCurrent();
 
+    /********************************************
+     * 6/2024
+     * Disabling the shader precompiler for now because
+     * Apple has chosen not to support OpenGL binary shader file
+     * formats in MacOS Sonoma.  We can retest periodically, but
+     * performance shouldn't be affected -- the shader compiler
+     * is very fast and still only needs to be run once per loaded
+     * shader.  And app startup time will actually be slightly faster!
+     *
+     * ShaderUtils.rebuildCache(surface) will still be called from TEApp,
+     * but now it will run only the minimum code necessary to initialize
+     * our OpenGL setup for the first time.
+     ********************************************/
+    /*
     GL4 gl4 = surface.getGL().getGL4();
     int programId = gl4.glCreateProgram();
 
@@ -33,12 +47,15 @@ public class ShaderPrecompiler {
     // and try to compile them to .bin files in the
     // cache directory. (NB: This directory listing
     // method is significantly faster than the old one.)
+
+
     File[] shaderFiles =
         new File(ShaderUtils.SHADER_PATH).listFiles((dir, name) -> name.endsWith(".fs"));
     if (shaderFiles == null) {
       // TE.log("No shaders found in " + dir);
       return;
     }
+
 
     for (File file : shaderFiles) {
       if (file.getName().endsWith(".fs")) {
@@ -53,11 +70,13 @@ public class ShaderPrecompiler {
 
     // free native resources and restore the previous GL context
     gl4.glDeleteProgram(programId);
+    */
+
     surface.getContext().release();
 
     if (prevContext != null) prevContext.makeCurrent();
 
-    TE.log("%d shaders processed in %d ms.", totalFiles, System.currentTimeMillis() - timer);
+    //TE.log("%d shaders processed in %d ms.", totalFiles, System.currentTimeMillis() - timer);
     // TE.log("%d cache file%s updated.", compiledFiles, (compiledFiles == 1) ? "" : "s");
   }
 }

--- a/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
+++ b/src/main/java/titanicsend/pattern/yoffa/shader_engine/ShaderUtils.java
@@ -168,16 +168,22 @@ public class ShaderUtils {
     String cacheFile = getCacheFilename(shaderName);
 
     try {
-      byte[] outBuf = Files.readAllBytes(Path.of(cacheFile));
-      ByteBuffer shader = ByteBuffer.wrap(outBuf);
-
       // get available binary formats for shader storage
       int[] fmtCount = new int[1];
       gl4.glGetIntegerv(GL4.GL_NUM_PROGRAM_BINARY_FORMATS, fmtCount, 0);
 
+      // fast out if no binary formats are available (e.g. on MacOS)
+      if (fmtCount[0] < 1) {
+        // TE.log("Shader cache: No compatible binary shader format available.");
+        return false;
+      }
+
       // take the first available format
       int[] formatList = new int[fmtCount[0]];
       gl4.glGetIntegerv(GL4.GL_PROGRAM_BINARY_FORMATS, formatList, 0);
+
+      byte[] outBuf = Files.readAllBytes(Path.of(cacheFile));
+      ByteBuffer shader = ByteBuffer.wrap(outBuf);
 
       // attach binary to our shader program
       gl4.glProgramBinary(programId, formatList[0], shader, outBuf.length);


### PR DESCRIPTION
Small PR that:
- prevents division by zero in audio processing code if no signal is present
- disables the shader precompiler on startup because macOS Sonoma doesn't support the required binary shader format.  (This will actually make startup a little faster on macOS. )
- fixes a couple of minor bugs resulting from last minute coding at the Coachella event.

Wanted to get this one in before @jkbelcher's big dynamic model PR changes everything.