### PR TITLE
Dynamic Model axis swap & texture mapping update

### DIFF
--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -161,7 +161,7 @@ public class TEApp extends LXStudio {
       // ui.leftPane.global.getContentWidth()).addToContainer(ui.leftPane.global);
       this.dmxEngine = new DmxEngine(lx);
       this.ndiEngine = new NDIEngine(lx);
-      this.glEngine = new GLEngine(lx);
+      this.glEngine = new GLEngine(lx,staticModel);
 
       // create our loop task for outputting data to lasers
       this.laserTask = new TELaserTask(lx);

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -225,4 +225,13 @@ public abstract class TEPattern extends DmxPattern {
     }
     return rv;
   }
+
+  /**
+   * utility method for use durning the static-to-dynamic model transition.
+   * IMPORTANT:  There is a performance cost to this, so it should be
+   * removed when we no longer need to support the static model.
+   */
+   protected float getXn(LXPoint p) {
+    return (modelTE.isStatic()) ? p.zn : p.xn;
+  }
 }

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -227,11 +227,11 @@ public abstract class TEPattern extends DmxPattern {
   }
 
   /**
-   * utility method for use durning the static-to-dynamic model transition.
+   * utility method for use during the static-to-dynamic model transition.
    * IMPORTANT:  There is a performance cost to this, so it should be
    * removed when we no longer need to support the static model.
    */
-   protected float getXn(LXPoint p) {
+   public float getXn(LXPoint p) {
     return (modelTE.isStatic()) ? p.zn : p.xn;
   }
 }

--- a/src/main/java/titanicsend/pattern/glengine/GLEngine.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEngine.java
@@ -57,6 +57,13 @@ public class GLEngine extends LXComponent implements LXLoopTask {
   private GLAutoDrawable canvas = null;
   private GL4 gl4;
 
+  // Needed for housekeeping, during static-to-dynamic model transition
+  // This lets various shader components know if they're running the static model
+  // and need to swap the x and z axes.
+  // TODO - remove when we move to dynamic model
+  private final boolean isStatic;
+  public boolean isStaticModel() { return isStatic; }
+
   public GLAutoDrawable getCanvas() {
     return canvas;
   }
@@ -213,12 +220,14 @@ public class GLEngine extends LXComponent implements LXLoopTask {
         audioTextureData);
   }
 
-  public GLEngine(LX lx) {
+  public GLEngine(LX lx,boolean isStaticModel) {
 
     // register glEngine so we can access it from patterns.
     // and add it as an engine task for audio analysis and buffer management
     lx.engine.registerComponent(PATH, this);
     lx.engine.addLoopTask(this);
+
+    this.isStatic = isStaticModel;
 
     // set up audio fft and waveform handling
     // TODO - strongly consider expanding the number of FFT bands.

--- a/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -38,17 +38,17 @@ public class GLShaderEffect extends TEEffect {
   protected final ArrayList<ShaderInfo> shaderInfo = new ArrayList<>();
 
   // function to paint the final shader output to the car
-  private ShaderPaintFn painter;
+  private ShaderPainterClass painter;
 
   public GLShaderEffect(LX lx) {
     super(lx);
 
-    setPainter(new ShaderPaint3d() {});
+    setPainter(new ShaderPaint3d(modelTE.isStatic()) {});
     controlData = new GLEffectControl(this);
     imageBuffer = GLShader.allocateBackBuffer();
   }
 
-  public void setPainter(ShaderPaintFn painter) {
+  public void setPainter(ShaderPainterClass painter) {
     this.painter = painter;
   }
 

--- a/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -4,7 +4,6 @@ import heronarts.lx.LX;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 
 /**
@@ -36,7 +35,7 @@ public class GLShaderPattern extends TEPerformancePattern {
   protected final ArrayList<ShaderInfo> shaderInfo = new ArrayList<>();
 
   // function to paint the final shader output to the car
-  private ShaderPaintFn painter;
+  private ShaderPainterClass painter;
 
   public GLShaderPattern(LX lx) {
     this(lx, TEShaderView.ALL_POINTS);
@@ -44,7 +43,7 @@ public class GLShaderPattern extends TEPerformancePattern {
 
   public GLShaderPattern(LX lx, TEShaderView view) {
     super(lx, view);
-    setPainter(new ShaderPaintFn() {});
+    setPainter(new ShaderPaint2d(modelTE.isStatic()) {});
     controlData = new GLPatternControl(this);
   }
 
@@ -52,7 +51,7 @@ public class GLShaderPattern extends TEPerformancePattern {
     return controlData;
   }
 
-  public void setPainter(ShaderPaintFn painter) {
+  public void setPainter(ShaderPainterClass painter) {
     this.painter = painter;
   }
 
@@ -85,7 +84,6 @@ public class GLShaderPattern extends TEPerformancePattern {
   @Override
   public void runTEAudioPattern(double deltaMs) {
     ShaderInfo s = null;
-    ByteBuffer image = null;
     this.deltaMs = deltaMs;
 
     int n = shaderInfo.size();

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPaint2d.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPaint2d.java
@@ -4,17 +4,14 @@ import heronarts.lx.model.LXPoint;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-/**
- * Interface for painting a 2D texture onto the car.  The default implementation
- * mirrors the texture symmetrically on both sides.
- */
-public interface ShaderPaintFn {
+/** Paints a 2D texture onto the car, mirroring the texture symmetrically on both sides. */
+public class ShaderPaint2d extends ShaderPainterClass {
   int xMax = GLEngine.getWidth() - 1;
   int yMax = GLEngine.getHeight() - 1;
 
-  // for use during static-to-dynamic model transition
-  // TODO - remove when we move to dynamic model
-  boolean isStatic = false;
+  public ShaderPaint2d(boolean isStaticModel) {
+    super(isStaticModel);
+  }
 
   /**
    * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
@@ -24,8 +21,7 @@ public interface ShaderPaintFn {
    * @param image backbuffer containing image for this frame
    * @param colors array to hold colors, one for each point
    */
-  default void mapToPoints(List<LXPoint> points, ByteBuffer image, int[] colors) {
-
+  public void mapToPoints(List<LXPoint> points, ByteBuffer image, int[] colors) {
     // TODO - remove this block when we move completely to dynamic model
     // TODO - (as well as the 'Static' versions of these functions)
     if (isStatic) {
@@ -49,14 +45,13 @@ public interface ShaderPaintFn {
   }
 
   /**
-   * Map current LX point colors to a texture buffer that can be used
-   * by a shader.
+   * Map current LX point colors to a texture buffer that can be used by a shader.
+   *
    * @param points list of points to paint
    * @param image buffer for bitmap
    * @param colors array of colors, one for each point
    */
-  default void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
-
+  public void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
     // TODO - remove this block when we move completely to dynamic model
     // TODO - (as well as the 'Static' versions of these functions)
     if (isStatic) {
@@ -79,14 +74,14 @@ public interface ShaderPaintFn {
   /**
    * Static (old) model variant - remove when we move to dynamic model
    *
-   * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
+   * <p>Called after a frame has been generated, this function samples the OpenGL backbuffer to set
    * color at the specified points.
    *
    * @param points list of points to paint
    * @param image backbuffer containing image for this frame
    * @param colors array to hold colors, one for each point
    */
-  default void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  private void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
     for (LXPoint point : points) {
       float zn = 1f - point.zn;
       float yn = point.yn;
@@ -105,13 +100,13 @@ public interface ShaderPaintFn {
   /**
    * Static (old) model variant - remove when we move to dynamic model
    *
-   * Map current LX point colors to a texture buffer that can be used
-   * by a shader.
+   * <p>Map current LX point colors to a texture buffer that can be used by a shader.
+   *
    * @param points list of points to paint
    * @param image buffer for bitmap
    * @param colors array of colors, one for each point
    */
-  default void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  private void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
     // TODO - do we need to zero the buffer when we do this?
     // TODO - not if we stick to strictly to the points we're painting,
     // TODO - but maybe if we're doing something that changes coordinates.
@@ -126,6 +121,4 @@ public interface ShaderPaintFn {
       image.putInt(index, colors[point.index]);
     }
   }
-
-
 }

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPaint3d.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPaint3d.java
@@ -9,7 +9,11 @@ import java.util.List;
  * coordinate wrapping behavior, so it is recommended to use this class only with shaders that are
  * designed to work this way.
  */
-public class ShaderPaint3d implements ShaderPaintFn {
+public class ShaderPaint3d extends ShaderPainterClass {
+
+  public ShaderPaint3d(boolean isStaticModel) {
+    super(isStaticModel);
+  }
 
   /**
    * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
@@ -72,7 +76,7 @@ public class ShaderPaint3d implements ShaderPaintFn {
    * @param points list of points to paint
    * @param image backbuffer containing image for this frame
    */
-  public void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  private void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
 
     for (LXPoint point : points) {
       float zn = 0.5f * ((point.x >= 0) ? 1f + point.zn : 1f - point.zn);
@@ -89,7 +93,7 @@ public class ShaderPaint3d implements ShaderPaintFn {
     }
   }
 
-  public void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  private void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
 
     for (LXPoint point : points) {
       float zn = 0.5f * ((point.x >= 0) ? 1f + point.zn : 1f - point.zn);
@@ -102,5 +106,4 @@ public class ShaderPaint3d implements ShaderPaintFn {
       image.putInt(index, colors[point.index]);
     }
   }
-
 }

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPaint3d.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPaint3d.java
@@ -1,7 +1,6 @@
 package titanicsend.pattern.glengine;
 
 import heronarts.lx.model.LXPoint;
-
 import java.nio.ByteBuffer;
 import java.util.List;
 
@@ -22,6 +21,59 @@ public class ShaderPaint3d implements ShaderPaintFn {
    */
   public void mapToPoints(List<LXPoint> points, ByteBuffer image, int[] colors) {
 
+    // TODO - remove this block when we move completely to dynamic model
+    // TODO - (as well as the 'Static' versions of these functions)
+    if (isStatic) {
+      mapToPointsStatic(points, image, colors);
+      return;
+    }
+
+    for (LXPoint point : points) {
+      float xn = 0.5f * ((point.z >= 0) ? 1f + point.xn : 1f - point.xn);
+      float yn = point.yn;
+
+      // use normalized point coordinates to calculate x/y coordinates and then the
+      // proper index in the image buffer.  the 'z' dimension of TE corresponds
+      // with 'x' dimension of the image based on the side that we're painting.
+      int xi = (int) (0.5f + xn * xMax);
+      int yi = (int) (0.5f + yn * yMax);
+
+      int index = 4 * ((yi * GLEngine.getWidth()) + xi);
+      colors[point.index] = image.getInt(index);
+    }
+  }
+
+  public void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
+
+    // TODO - remove this block when we move completely to dynamic model
+    // TODO - (as well as the 'Static' versions of these functions)
+    if (isStatic) {
+      mapToBufferStatic(points, image, colors);
+      return;
+    }
+
+    for (LXPoint point : points) {
+      float xn = 0.5f * ((point.z >= 0) ? 1f + point.xn : 1f - point.xn);
+      float yn = point.yn;
+
+      int xi = (int) (0.5f + xn * xMax);
+      int yi = (int) (0.5f + yn * yMax);
+
+      int index = 4 * ((yi * GLEngine.getWidth()) + xi);
+      image.putInt(index, colors[point.index]);
+    }
+  }
+
+  /**
+   * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
+   * color at the specified points. This version wraps a texture around the entire car instead of
+   * the default symmetrical mirroring.
+   *
+   * @param points list of points to paint
+   * @param image backbuffer containing image for this frame
+   */
+  public void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
+
     for (LXPoint point : points) {
       float zn = 0.5f * ((point.x >= 0) ? 1f + point.zn : 1f - point.zn);
       float yn = point.yn;
@@ -37,7 +89,7 @@ public class ShaderPaint3d implements ShaderPaintFn {
     }
   }
 
-  public void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  public void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
 
     for (LXPoint point : points) {
       float zn = 0.5f * ((point.x >= 0) ? 1f + point.zn : 1f - point.zn);
@@ -50,4 +102,5 @@ public class ShaderPaint3d implements ShaderPaintFn {
       image.putInt(index, colors[point.index]);
     }
   }
+
 }

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPaintFn.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPaintFn.java
@@ -11,6 +11,11 @@ import java.util.List;
 public interface ShaderPaintFn {
   int xMax = GLEngine.getWidth() - 1;
   int yMax = GLEngine.getHeight() - 1;
+
+  // for use during static-to-dynamic model transition
+  // TODO - remove when we move to dynamic model
+  boolean isStatic = false;
+
   /**
    * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
    * color at the specified points.
@@ -20,6 +25,68 @@ public interface ShaderPaintFn {
    * @param colors array to hold colors, one for each point
    */
   default void mapToPoints(List<LXPoint> points, ByteBuffer image, int[] colors) {
+
+    // TODO - remove this block when we move completely to dynamic model
+    // TODO - (as well as the 'Static' versions of these functions)
+    if (isStatic) {
+      mapToPointsStatic(points, image, colors);
+      return;
+    }
+
+    for (LXPoint point : points) {
+      float xn = 1f - point.xn;
+      float yn = point.yn;
+
+      // use normalized point coordinates to calculate x/y coordinates and then the
+      // proper index in the image buffer.  the 'z' dimension of TE corresponds
+      // with 'x' dimension of the image based on the side that we're painting.
+      int xi = (int) (0.5 + xn * xMax);
+      int yi = (int) (0.5 + yn * yMax);
+
+      int index = 4 * ((yi * GLEngine.getWidth()) + xi);
+      colors[point.index] = image.getInt(index);
+    }
+  }
+
+  /**
+   * Map current LX point colors to a texture buffer that can be used
+   * by a shader.
+   * @param points list of points to paint
+   * @param image buffer for bitmap
+   * @param colors array of colors, one for each point
+   */
+  default void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
+
+    // TODO - remove this block when we move completely to dynamic model
+    // TODO - (as well as the 'Static' versions of these functions)
+    if (isStatic) {
+      mapToBufferStatic(points, image, colors);
+      return;
+    }
+
+    for (LXPoint point : points) {
+      float xn = 1f - point.xn;
+      float yn = point.yn;
+
+      int xi = (int) (0.5 + xn * xMax);
+      int yi = (int) (0.5 + yn * yMax);
+
+      int index = 4 * ((yi * GLEngine.getWidth()) + xi);
+      image.putInt(index, colors[point.index]);
+    }
+  }
+
+  /**
+   * Static (old) model variant - remove when we move to dynamic model
+   *
+   * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
+   * color at the specified points.
+   *
+   * @param points list of points to paint
+   * @param image backbuffer containing image for this frame
+   * @param colors array to hold colors, one for each point
+   */
+  default void mapToPointsStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
     for (LXPoint point : points) {
       float zn = 1f - point.zn;
       float yn = point.yn;
@@ -36,13 +103,15 @@ public interface ShaderPaintFn {
   }
 
   /**
+   * Static (old) model variant - remove when we move to dynamic model
+   *
    * Map current LX point colors to a texture buffer that can be used
    * by a shader.
    * @param points list of points to paint
    * @param image buffer for bitmap
    * @param colors array of colors, one for each point
    */
-  default void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors) {
+  default void mapToBufferStatic(List<LXPoint> points, ByteBuffer image, int[] colors) {
     // TODO - do we need to zero the buffer when we do this?
     // TODO - not if we stick to strictly to the points we're painting,
     // TODO - but maybe if we're doing something that changes coordinates.
@@ -57,4 +126,6 @@ public interface ShaderPaintFn {
       image.putInt(index, colors[point.index]);
     }
   }
+
+
 }

--- a/src/main/java/titanicsend/pattern/glengine/ShaderPainterClass.java
+++ b/src/main/java/titanicsend/pattern/glengine/ShaderPainterClass.java
@@ -1,0 +1,40 @@
+package titanicsend.pattern.glengine;
+
+import heronarts.lx.model.LXPoint;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Abstract class for mapping a 2D texture onto the car.
+ */
+public abstract class ShaderPainterClass {
+  protected int xMax = GLEngine.getWidth() - 1;
+  protected int yMax = GLEngine.getHeight() - 1;
+
+  // for use during static-to-dynamic model transition
+  // TODO - remove when we move to dynamic model
+  public boolean isStatic;
+
+  public ShaderPainterClass(boolean isStaticModel) {
+    this.isStatic = isStaticModel;
+  }
+
+  /**
+   * Called after a frame has been generated, this function samples the OpenGL backbuffer to set
+   * color at the specified points.
+   *
+   * @param points list of points to paint
+   * @param image backbuffer containing image for this frame
+   * @param colors array to hold colors, one for each point
+   */
+  public abstract void mapToPoints(List<LXPoint> points, ByteBuffer image, int[] colors);
+
+  /**
+   * Map current LX point colors to a texture buffer that can be used by a shader.
+   *
+   * @param points list of points to paint
+   * @param image buffer for bitmap
+   * @param colors array of colors, one for each point
+   */
+  public abstract void mapToBuffer(List<LXPoint> points, ByteBuffer image, int[] colors);
+}

--- a/src/main/java/titanicsend/pattern/jon/CarGeometryPatternTools.java
+++ b/src/main/java/titanicsend/pattern/jon/CarGeometryPatternTools.java
@@ -14,16 +14,24 @@ import titanicsend.util.TE;
 
 /** Tools for converting car model geometry for use in patterns, particularly in native shaders. */
 public class CarGeometryPatternTools {
+
   // convert from normalized physical model coords
   // to normalized 2D GL surface coords
   protected static float modelToMapX(LXPoint pt) {
-    return 2f * (-0.5f + pt.zn);
+    return 2f * (-0.5f + pt.xn);
   }
 
   // convert from normalized physical model coords
   // to aspect corrected normalized 2D GL surface coords
   protected static float modelToMapY(LXPoint pt) {
     return 2f * (-0.5f + pt.yn);
+  }
+
+  // TODO - Static model variant.  Remove when we move to dynamic model
+  // convert from normalized physical model coords
+  // to normalized 2D GL surface coords
+  protected static float modelToMapXStatic(LXPoint pt) {
+    return 2f * (-0.5f + pt.zn);
   }
 
   /**
@@ -64,17 +72,34 @@ public class CarGeometryPatternTools {
   protected static void getLineFromEdge(TEWholeModel model, float lines[][], int index, String id) {
 
     TEEdgeModel edge = model.getEdge(id);
-    if (edge != null) {
-      LXPoint v1 = edge.points[0];
-      LXPoint v2 = edge.points[edge.points.length - 1];
 
-      // set x1,y1,x2,y2 in line array
-      lines[index][0] = modelToMapX(v1);
-      lines[index][1] = modelToMapY(v1);
-      lines[index][2] = modelToMapX(v2);
-      lines[index][3] = modelToMapY(v2);
+    // TODO - Remove this madness when we move to the dynamic model
+    if (model.isStatic()) {
+      if (edge != null) {
+        LXPoint v1 = edge.points[0];
+        LXPoint v2 = edge.points[edge.points.length - 1];
+
+        // set x1,y1,x2,y2 in line array
+        lines[index][0] = modelToMapXStatic(v1);
+        lines[index][1] = modelToMapY(v1);
+        lines[index][2] = modelToMapXStatic(v2);
+        lines[index][3] = modelToMapY(v2);
+      } else {
+        TE.log("Null edge %s", id);
+      }
     } else {
-      TE.log("Null edge %s", id);
+      if (edge != null) {
+        LXPoint v1 = edge.points[0];
+        LXPoint v2 = edge.points[edge.points.length - 1];
+
+        // set x1,y1,x2,y2 in line array
+        lines[index][0] = modelToMapX(v1);
+        lines[index][1] = modelToMapY(v1);
+        lines[index][2] = modelToMapX(v2);
+        lines[index][3] = modelToMapY(v2);
+      } else {
+        TE.log("Null edge %s", id);
+      }
     }
   }
 }

--- a/src/main/java/titanicsend/pattern/jon/ModelBender.java
+++ b/src/main/java/titanicsend/pattern/jon/ModelBender.java
@@ -3,11 +3,7 @@ package titanicsend.pattern.jon;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import java.util.ArrayList;
-
-import titanicsend.model.TEEdgeModel;
-import titanicsend.model.TEPanelModel;
-import titanicsend.model.TEWholeModel;
-import titanicsend.model.TEWholeModelStatic;
+import titanicsend.model.*;
 
 public class ModelBender {
   private final String[] endEdgeIds = {
@@ -40,8 +36,8 @@ public class ModelBender {
     "126-129"
   };
 
-  protected ArrayList<Float> modelZ;
-  protected float endXMax;
+  protected ArrayList<Float> savedModelCoord;
+  protected float endDepthMax;
 
   /**
    * Get a list of points on the ends of the car
@@ -82,15 +78,15 @@ public class ModelBender {
     // after all views are created.  endXMax is the largest x coordinate at
     // the boundary of side and end (more-or-less).  We use it as the
     // starting x for our taper.
-    modelZ = new ArrayList<Float>();
-    endXMax = Math.abs(model.vertexesById.get(116).x);
+    savedModelCoord = new ArrayList<Float>();
+    endDepthMax = Math.abs(model.vertexesById.get(116).x);
     for (LXPoint p : model.getPoints()) {
-      modelZ.add(p.z);
+      savedModelCoord.add(p.z);
     }
 
     // set new z bounds for our modified model
-    model.zMax += endXMax;
-    model.zMin -= endXMax;
+    model.zMax += endDepthMax;
+    model.zMin -= endDepthMax;
     model.zRange = model.zMax - model.zMin;
 
     // adjust the z coordinates of the end points to taper them
@@ -101,7 +97,7 @@ public class ModelBender {
       // kick out gap points or they'll break normalization.
       if (model.isGapPoint(p)) continue;
 
-      double zOffset = endXMax - Math.abs(p.x);
+      double zOffset = endDepthMax - Math.abs(p.x);
       p.z += (p.z >= 0) ? zOffset : -zOffset;
     }
     model.normalizePoints();
@@ -109,13 +105,62 @@ public class ModelBender {
 
   public void restoreModel(TEWholeModelStatic model) {
     // restore the model's original z bounds
-    model.zMax -= endXMax;
-    model.zMin += endXMax;
+    model.zMax -= endDepthMax;
+    model.zMin += endDepthMax;
     model.zRange = model.zMax - model.zMin;
 
     int i = 0;
     for (LXPoint p : model.getPoints()) {
-      p.z = modelZ.get(i++);
+      p.z = savedModelCoord.get(i++);
+    }
+  }
+
+  // Dynamic model version
+  public void adjustEndGeometry(TEWholeModelDynamic model, LXModel baseModel) {
+
+    // save the model's original x (width) coordinates so we can restore them
+    // after all views are created.  endDepthMax is the largest z coordinate at
+    // the boundary of side and end (more-or-less).  We use it as the
+    // starting z for our taper.
+    // TODO - replace estimate w/appropriate real value when model.getVertex() is working.
+    endDepthMax = 0.85f * baseModel.zMax; //Math.abs(model.getVertex(116).z);
+    System.out.println("endDepthMax: " + endDepthMax);
+
+    savedModelCoord = new ArrayList<Float>();
+    for (LXPoint p : baseModel.getPoints()) {
+      savedModelCoord.add(p.x);
+    }
+
+    // set new x bounds for our modified model
+    baseModel.xMax += endDepthMax;
+    baseModel.xMin -= endDepthMax;
+    baseModel.xRange = baseModel.xMax - baseModel.xMin;
+
+    // adjust the x coordinates of the end points to taper them
+    // with decreasing z. This gives the model a slightly pointy
+    // nose and makes texture mapping easier and better looking.
+    ArrayList<LXPoint> endPoints = getEndPoints(model);
+    for (LXPoint p : endPoints) {
+      // kick out gap points or they'll break normalization.
+      if (model.isGapPoint(p)) continue;
+
+      float xOffset = endDepthMax - Math.abs(p.z);
+      p.x += (p.x >= 0) ? xOffset : -xOffset;
+    }
+
+    baseModel.normalizePoints();
+  }
+
+  // Dynamic model version
+  public void restoreModel(TEWholeModelDynamic model, LXModel baseModel) {
+    // restore the model's original width (x) bounds
+    baseModel.xMax -= endDepthMax;
+    baseModel.xMin += endDepthMax;
+    baseModel.xRange = baseModel.xMax - baseModel.xMin;
+
+    int i = 0;
+    for (LXPoint p : baseModel.getPoints()) {
+      p.x = savedModelCoord.get(i++);
     }
   }
 }

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -50,7 +50,7 @@ public class SpiralDiamonds extends TEPerformancePattern {
 
     for (LXPoint point : getModel().getPoints()) {
       // move normalized coord origin to model center
-      float x = point.zn - 0.5f + (float) getXPos();
+      float x = getXn(point) - 0.5f + (float) getXPos();
       float y = point.yn - 0.25f + (float) getYPos();
 
       // warp coordinate system in a waving flag pattern w/trebleLevel.

--- a/src/main/java/titanicsend/pattern/yoffa/effect/ShimmeringEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/ShimmeringEffect.java
@@ -101,7 +101,9 @@ public class ShimmeringEffect extends PatternEffect {
     double target;
     int direction = (int) (Math.abs(pattern.getStaticRotationAngle()) / (.5 * Math.PI));
     target = basis;
-    current = direction == 0 || direction == 2 ? point.yn : point.zn;
+
+    // TODO - change call to getXn() back to point.x when we finish moving to dynamic model
+    current = direction == 0 || direction == 2 ? point.yn : pattern.getXn(point);
     if (direction > 1) {
       current = 1 - current;
     }

--- a/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
+++ b/src/main/java/titanicsend/pattern/yoffa/effect/shaders/FragmentShaderEffect.java
@@ -49,7 +49,9 @@ public abstract class FragmentShaderEffect extends PatternEffect {
 
   private int getColorForPoint(LXPoint point, double timeSec) {
     float alpha;
-    double[] fragCoordinates = new double[] {point.zn, point.yn};
+
+    // TODO - change pattern.getXn() back to point.x when we finish moving to dynamic model
+    double[] fragCoordinates = new double[] {pattern.getXn(point), point.yn};
     double[] resolution = new double[] {1, 1};
     double[] colorRgb = getColorForPoint(fragCoordinates, resolution, timeSec);
 


### PR DESCRIPTION
The Z and X axes were swapped in the change to dynamic model.   Patterns and shaders now know which model they're running with and adjust appropriately.   This was done with the following priorities:
- minimize performance impact
- make the test/swap code as simple and as easily removable as possible.

Even so, note that there is a small performance cost to supporting both models, so we should remove the test/swap code once we fully commit to the new model.

2d and 3d texture mapping (the ModelBender thing) will also now work correctly with both static and dynamic models.