### PR TITLE
Mothership fixtures: window shapes and positions

### DIFF
--- a/Fixtures/Mothership/window/RoundedQuad.lxf
+++ b/Fixtures/Mothership/window/RoundedQuad.lxf
@@ -1,26 +1,28 @@
 {
-  /* Triangle with Rounded Corners
-     Common geometry for triangular windows on TE Mothership */
+  /* Quadrilateral with Rounded Corners
+     Common geometry for 4-sided windows on TE Mothership */
 
-  label: "RoundedTriangle",
-  tags: [ "roundedtriangle" ],
+  label: "RoundedQuad",
+  tags: [ "roundedquad" ],
 
   parameters:  {
     # TE defaults. Can be overridden but likely do not need to be.
     "spacing": { type: "float", default: ".2", description: "LED spacing. Used for first and last edge." },
     "radius": { type: "float", default: "1.125", description: "Corner radius" },
-    "inset": { type: "float", default: "1.4", description: "Inset of LED strip from edge of triangle. Can be adjusted to match perceived location." },
+    "inset": { type: "float", default: "1.4", description: "Inset of LED strip from edge of shape. Can be adjusted to match perceived location." },
 
     # Lengths of edges *without inset*
     # For TE this can be measured in the simplified CAD model as the intersecting line between two faces
     "length1": { type: "float", default: "12", description: "Length of triangle side 1" },
     "length2": { type: "float", default: "12", description: "Length of triangle side 2" },
     "length3": { type: "float", default: "12", description: "Length of triangle side 3" },
+    "length4": { type: "float", default: "12", description: "Length of triangle side 4" },
 
     # Angles
-    "angle12": { type: "float", default: "60", description: "Angle between side 1 and side 2" },
-    "angle23": { type: "float", default: "60", description: "Angle between side 2 and side 3" },
-    "angle31": { type: "float", default: "60", description: "Angle between side 3 and side 1, aka starting corner" },
+    "angle12": { type: "float", default: "90", description: "Angle between side 1 and side 2" },
+    "angle23": { type: "float", default: "90", description: "Angle between side 2 and side 3" },
+    "angle34": { type: "float", default: "90", description: "Angle between side 3 and side 4" },
+    "angle41": { type: "float", default: "90", description: "Angle between side 4 and side 1, aka starting corner" },
 
     # LED counts
     "side1": { type: "int", default: "16", description: "Number of LEDs on side 1" },
@@ -28,6 +30,8 @@
     "side2": { type: "int", default: "16", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
     "side3": { type: "int", default: "16", description: "Number of LEDs on side 3" },
+    "corner34": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
+    "side4": { type: "int", default: "16", description: "Number of LEDs on side 4" },
 
     # Debug tools
     "outputEnabled": { type: "boolean", default: false },
@@ -96,12 +100,12 @@
         { y: "-$radius" }
       ]
     },
-    
+
     /* Side 3 */
     { type: "strip",
       tags: [ "s", "s3"],
       numPoints: "$side3",
-      spacing: "$spacing",
+      spacing: "($length3 - (($inset + $radius) / tan(0.5 * $angle23)) - (($inset + $radius) / tan(0.5 * $angle34))) / ($side3 - 1)",
       transforms: [
         { x: "$length1" },
         { roll: "180 - $angle12" },
@@ -112,13 +116,50 @@
       ]
     },
 
+    /* Corner 3-4 */
+    { type: "arc",
+      tags: [ "c", "c34"],
+      radius: "$radius",
+      degrees: "(180 - $angle34) * ($corner34 - 1) / ($corner34 + 1)",
+      numPoints: "$corner34",
+      transforms: [
+        { x: "$length1" },
+        { roll: "180 - $angle12" },
+        { x: "$length2" },
+        { roll: "180 - $angle23" },
+        { x: "$length3 - (($inset + $radius) / tan(0.5 * $angle34))" },
+        { y: "$inset" },
+        { y: "$radius" },
+        { roll: "(180 - $angle34) / ($corner34 + 1)" },
+        { y: "-$radius" }
+      ]
+    },
+
+    /* Side 4 */
+    { type: "strip",
+      tags: [ "s", "s4"],
+      numPoints: "$side4",
+      spacing: "$spacing",
+      transforms: [
+        { x: "$length1" },
+        { roll: "180 - $angle12" },
+        { x: "$length2" },
+        { roll: "180 - $angle23" },
+        { x: "$length3" },
+        { roll: "180 - $angle34" },
+        { x: "($inset + $radius) / tan(0.5 * $angle34)" },
+        { y: "$inset" }
+      ]
+    },
+
     /* DEBUG: UNCOMMENT TO CHECK OUTER EDGE ALIGNMENT
     { type: "strip", numPoints: "100", spacing: "$length1/99", transforms: [{ z: ".25" }]},
     { type: "strip", numPoints: "100", spacing: "$length2/99", transforms: [{ z: ".25" },{ x: "$length1" },{ roll: "180 - $angle12" }]},
-    { type: "strip", numPoints: "100", spacing: "$length3/99", transforms: [{ z: ".25" },{ x: "$length1" },{ roll: "180 - $angle12" },{ x: "$length2" },{ roll: "180 - $angle23" }]}
+    { type: "strip", numPoints: "100", spacing: "$length3/99", transforms: [{ z: ".25" },{ x: "$length1" },{ roll: "180 - $angle12" },{ x: "$length2" },{ roll: "180 - $angle23" }]},
+    { type: "strip", numPoints: "100", spacing: "$length4/99", transforms: [{ z: ".25" },{ x: "$length1" },{ roll: "180 - $angle12" },{ x: "$length2" },{ roll: "180 - $angle23" },{ x: "$length3" },{ roll: "180 - $angle34" },]}
     */
   ],
-  
+
   outputs: [
     { 
       enabled: "$outputEnabled",

--- a/Fixtures/Mothership/window/RoundedQuad.lxf
+++ b/Fixtures/Mothership/window/RoundedQuad.lxf
@@ -6,25 +6,25 @@
   tags: [ "roundedquad" ],
 
   parameters:  {
-    # TE defaults. Can be overridden but likely do not need to be.
+    /* TE defaults. Can be overridden but likely do not need to be. */
     "spacing": { type: "float", default: ".2", description: "LED spacing. Used for first and last edge." },
     "radius": { type: "float", default: "1.125", description: "Corner radius" },
     "inset": { type: "float", default: "1.4", description: "Inset of LED strip from edge of shape. Can be adjusted to match perceived location." },
 
-    # Lengths of edges *without inset*
-    # For TE this can be measured in the simplified CAD model as the intersecting line between two faces
+    /* Lengths of edges *without inset* */
+    /* For TE this can be measured in the simplified CAD model as the intersecting line between two faces */
     "length1": { type: "float", default: "12", description: "Length of triangle side 1" },
     "length2": { type: "float", default: "12", description: "Length of triangle side 2" },
     "length3": { type: "float", default: "12", description: "Length of triangle side 3" },
     "length4": { type: "float", default: "12", description: "Length of triangle side 4" },
 
-    # Angles
+    /* Angles */
     "angle12": { type: "float", default: "90", description: "Angle between side 1 and side 2" },
     "angle23": { type: "float", default: "90", description: "Angle between side 2 and side 3" },
     "angle34": { type: "float", default: "90", description: "Angle between side 3 and side 4" },
     "angle41": { type: "float", default: "90", description: "Angle between side 4 and side 1, aka starting corner" },
 
-    # LED counts
+    /* LED counts */
     "side1": { type: "int", default: "16", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "16", description: "Number of LEDs on side 2" },
@@ -33,12 +33,12 @@
     "corner34": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
     "side4": { type: "int", default: "16", description: "Number of LEDs on side 4" },
 
-    # Debug tools
-    "outputEnabled": { type: "boolean", default: false },
+    /* Debug tools */
+    "outputEnabled": { type: "boolean", default: "false" },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "universe": { type: "int", default: 1, label: "Universe", description: "ArtNet Universe" },
     "channel": { type: "int", default: 0, min: 0, max: 512, label: "Channel", description: "ArtNet channel" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   components: [

--- a/Fixtures/Mothership/window/RoundedTriangle.lxf
+++ b/Fixtures/Mothership/window/RoundedTriangle.lxf
@@ -6,35 +6,35 @@
   tags: [ "roundedtriangle" ],
 
   parameters:  {
-    # TE defaults. Can be overridden but likely do not need to be.
+    /* TE defaults. Can be overridden but likely do not need to be. */
     "spacing": { type: "float", default: ".2", description: "LED spacing. Used for first and last edge." },
     "radius": { type: "float", default: "1.125", description: "Corner radius" },
     "inset": { type: "float", default: "1.4", description: "Inset of LED strip from edge of triangle. Can be adjusted to match perceived location." },
 
-    # Lengths of edges *without inset*
-    # For TE this can be measured in the simplified CAD model as the intersecting line between two faces
+    /* Lengths of edges *without inset* */
+    /* For TE this can be measured in the simplified CAD model as the intersecting line between two faces */
     "length1": { type: "float", default: "12", description: "Length of triangle side 1" },
     "length2": { type: "float", default: "12", description: "Length of triangle side 2" },
     "length3": { type: "float", default: "12", description: "Length of triangle side 3" },
 
-    # Angles
+    /* Angles */
     "angle12": { type: "float", default: "60", description: "Angle between side 1 and side 2" },
     "angle23": { type: "float", default: "60", description: "Angle between side 2 and side 3" },
     "angle31": { type: "float", default: "60", description: "Angle between side 3 and side 1, aka starting corner" },
 
-    # LED counts
+    /* LED counts */
     "side1": { type: "int", default: "16", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "16", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
     "side3": { type: "int", default: "16", description: "Number of LEDs on side 3" },
 
-    # Debug tools
-    "outputEnabled": { type: "boolean", default: false },
+    /* Debug tools */
+    "outputEnabled": { type: "boolean", default: "false" },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "universe": { type: "int", default: 1, label: "Universe", description: "ArtNet Universe" },
     "channel": { type: "int", default: 0, min: 0, max: 512, label: "Channel", description: "ArtNet channel" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   components: [

--- a/Fixtures/Mothership/window/Slice.lxf
+++ b/Fixtures/Mothership/window/Slice.lxf
@@ -15,7 +15,7 @@
     "outputW8a": { type: "int", default: 3, min: 1, max: 8, label: "Output W8a", description: "Window 8a Controller Output Number 1-8" },
     "outputW8b": { type: "int", default: 2, min: 1, max: 8, label: "Output W8b", description: "Window 8b Controller Output Number 1-8" },
     "outputW9": { type: "int", default: 4, min: 1, max: 8, label: "Output W9", description: "Window 9 Controller Output Number 1-8" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   "transforms": [

--- a/Fixtures/Mothership/window/Slice.lxf
+++ b/Fixtures/Mothership/window/Slice.lxf
@@ -9,12 +9,12 @@
     "radial": { type: "int", default: 1, min: 1, max: 25, label: "Radial", description: "Clock position of this slice, 1-24" },
 
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "outputS1": { type: "int", default: 1, min: 1, max: 8, label: "S1 Output", description: "Strand 1 Controller Output Number 1-8" },
-    "outputS2": { type: "int", default: 2, min: 1, max: 8, label: "S2 Output", description: "Strand 2 Controller Output Number 1-8" },
-    "outputS3": { type: "int", default: 3, min: 1, max: 8, label: "S3 Output", description: "Strand 3 Controller Output Number 1-8" },
-    "outputS6": { type: "int", default: 6, min: 1, max: 8, label: "S6 Output", description: "Strand 6 Controller Output Number 1-8" },
-    "outputS7": { type: "int", default: 7, min: 1, max: 8, label: "S7 Output", description: "Strand 7 Controller Output Number 1-8" },
-    "outputS8": { type: "int", default: 8, min: 1, max: 8, label: "S8 Output", description: "Strand 8 Controller Output Number 1-8" },
+    "outputW1": { type: "int", default: 6, min: 1, max: 8, label: "Output W1", description: "Window 1 Controller Output Number 1-8" },
+    "outputW2": { type: "int", default: 7, min: 1, max: 8, label: "Output W2", description: "Window 2 Controller Output Number 1-8" },
+    "outputW3": { type: "int", default: 8, min: 1, max: 8, label: "Output W3", description: "Window 3 Controller Output Number 1-8" },
+    "outputW8a": { type: "int", default: 3, min: 1, max: 8, label: "Output W8a", description: "Window 8a Controller Output Number 1-8" },
+    "outputW8b": { type: "int", default: 2, min: 1, max: 8, label: "Output W8b", description: "Window 8b Controller Output Number 1-8" },
+    "outputW9": { type: "int", default: 4, min: 1, max: 8, label: "Output W9", description: "Window 9 Controller Output Number 1-8" },
     "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
@@ -39,51 +39,51 @@
 
   outputs: [
 
-    /* Strand 1 */
-    { host: "$host", universe: "$outputS1*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
-      segments: [
-        { componentId: "w9" }
-      ]
-    },
-
-    /* Strand 2 */
-    { host: "$host", universe: "$outputS2*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
-      segments: [
-        { componentId: "w8a" },
-        { componentId: "w5" }
-      ]
-    },
-
-    /* Strand 3 */
-    { host: "$host", universe: "$outputS3*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
-      segments: [
-        { componentId: "w8b" },
-        { componentId: "w6" }
-      ]
-    },
-
-    /* Strand 6 */
-    { host: "$host", universe: "$outputS6*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+    /* Window 1 (old Strand 6) */
+    { host: "$host", universe: "$outputW1*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
       segments: [
         { componentId: "w1" }
       ]
     },
 
-    /* Strand 7 */
-    { host: "$host", universe: "$outputS7*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+    /* Window 2 & 7 (old Strand 7) */
+    { host: "$host", universe: "$outputW2*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
       segments: [
         { componentId: "w2" },
         { componentId: "w7" }
       ]
     },
 
-    /* Strand 8 */
-    { host: "$host", universe: "$outputS8*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+    /* Window 3 & 4 (old Strand 8) */
+    { host: "$host", universe: "$outputW3*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
       segments: [
         { componentId: "w3" },
         { componentId: "w4" }
       ]
     },
+
+    /* Window 8a & 5 (old Strand 2) */
+    { host: "$host", universe: "$outputW8a*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+      segments: [
+        { componentId: "w8a" },
+        { componentId: "w5" }
+      ]
+    },
+
+    /* Window 8b & 6 (old Strand 3) */
+    { host: "$host", universe: "$outputW8b*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+      segments: [
+        { componentId: "w8b" },
+        { componentId: "w6" }
+      ]
+    },
+
+    /* Window 9 (old Strand 1) */
+    { host: "$host", universe: "$outputW9*10", protocol: "artnet", sequenceEnabled: "$artnetSequence",
+      segments: [
+        { componentId: "w9" }
+      ]
+    }
 
   ]
 }

--- a/Fixtures/Mothership/window/Window1.lxf
+++ b/Fixtures/Mothership/window/Window1.lxf
@@ -1,86 +1,65 @@
 {
   /* Mothership by Titanic's End
-     Window 1, Strand S6a */
+     Window 1 */
 
   label: "Window1",
-  tags: [ "w1", "window", "triangle", "s6a" ],
+  tags: [ "w1", "window", "triangle" ],
 
   parameters:  {
-    /* Default 270 LEDs */
+    # Default 270 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 270" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Remove these after calibration
-    "side1": { type: "int", default: "30", description: "Number of LEDs on side 1" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "83", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
+    "side2": { type: "int", default: "82", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
-
-    "inset": { type: "float", default: "2.4", description: "Inset of LED strip from the line where window planes meet" },
-    "spacing": { type: "float", default: ".2" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "output": { type: "int", default: 6, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-45", enabled: "$onCar" },
     { y: "96.822", enabled: "$onCar" },
-    { pitch: "63.8", enabled: "$onCar" }
+    { pitch: "63.8", enabled: "$onCar" },
+    { y: "19.822", enabled: "$onCar" },
+    { roll: "-122.75", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     /* From inside, LED strip is clockwise */
 
-    /* First edge */
-    { type: "strip",
-      numPoints: "88 - $ledOffset", 
-      spacing: "$spacing",
-      transforms: [
-        { y: "$inset" },
-        { x: "0 - (94 / 2) * $spacing" },
-        { roll: "57.3" },
-        { x: "88 * $spacing" },
-        { roll: "180" },
-        { x: "$spacing * (0.5 + $ledOffset)" }
-      ]
-    },
+    { type: "RoundedTriangle",
 
-    /* Edge against ring */
-    { type: "strip",
-      numPoints: "94",
-      spacing: "$spacing",
-      transforms: [
-        { y: "$inset" },
-        { x: "0 - (94 / 2) * $spacing" },
-        { x: "$spacing / 2" }
-      ]
-    },
+      length1: "23.567",
+      length2: "25.494",
+      length3: "23.567",
 
-    /* Last edge */
-    { type: "strip",
-      numPoints: "88 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { y: "$inset" },
-        { x: "(94 / 2) * $spacing" },
-        { roll: "180 - 57.3" },
-        { x: "$spacing / 2" }
-      ]
+      angle12: "57.3",
+      angle23: "57.3",
+      angle31: "65.5",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "270 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
-
   ],
-  
+
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window1.lxf
+++ b/Fixtures/Mothership/window/Window1.lxf
@@ -6,23 +6,23 @@
   tags: [ "w1", "window", "triangle" ],
 
   parameters:  {
-    # Default 270 LEDs
+    /* Default 270 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 270" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "83", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "82", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
-    "outputEnabled": { type: "boolean", default: false },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: "false" },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 6, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "output": { type: "int", default: "6", min: "1", max: "8", label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: "0", min: "0", max: "512", label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window2.lxf
+++ b/Fixtures/Mothership/window/Window2.lxf
@@ -1,85 +1,62 @@
 {
   /* Mothership by Titanic's End
-     Window 2, Strand S7a */
+     Window 2 */
 
   label: "Window2",
-  tags: [ "w2", "window", "triangle", "s7a" ],
+  tags: [ "w2", "window", "triangle" ],
 
   parameters:  {
-    /* Default 166 LEDs */
+    # Default 166 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 166" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Remove these after calibration
-    "side1": { type: "int", default: "30", description: "Number of LEDs on side 1" },
-    "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
-
-    "inset": { type: "float", default: "2.4", description: "Inset of LED strip from the line where window planes meet" },
-    "spacing": { type: "float", default: ".2" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "36", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "46", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "15", description: "Number of LEDs in the corner between side2 and side3" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "output": { type: "int", default: 7, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-27.215", enabled: "$onCar" },
     { y: "105.576", enabled: "$onCar" },
-    { roll: "3.8", enabled: "$onCar" },
-    { pitch: "66", enabled: "$onCar" }
+    { roll: "183.8", enabled: "$onCar" },
+    { pitch: "-66", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
-  
-    /* Top */
-    { type: "strip",
-      numPoints: "40 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-13.81 + $inset" },
-        { y: "-$inset" },
-        { x:  "$spacing * (40 - $ledOffset)" },
-        { roll: 180 } 
-      ]
-    },
-    
-    /* Side */
-    { type: "strip",
-      numPoints: "57",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-13.81 + $inset" },
-        { y: "-$inset" },
-        { roll: "-88.5" },
-        { x: "$spacing" }
-      ]
-    },
+    { type: "RoundedTriangle",
 
-    /* Diagonal */
-    { type: "strip",
-      numPoints: "69 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-13.81 + $inset" },
-        { y: "-$inset" },
-        { roll: "-88.5" },
-        { x: "(57+1) * $spacing"},
-        { roll: "144.1" }
-      ]
+      length1: "13.81",
+      length2: "19.468",
+      length3: "23.567",
+
+      angle12: "88.5",
+      angle23: "35.9",
+      angle31: "55.7",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "166 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
   ],
   
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window2.lxf
+++ b/Fixtures/Mothership/window/Window2.lxf
@@ -6,23 +6,23 @@
   tags: [ "w2", "window", "triangle" ],
 
   parameters:  {
-    # Default 166 LEDs
+    /* Default 166 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 166" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "36", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "46", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "15", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 7, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "output": { type: "int", default: "7", min: "1", max: "8", label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: "0", min: "0", max: "512", label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window3.lxf
+++ b/Fixtures/Mothership/window/Window3.lxf
@@ -6,22 +6,22 @@
   tags: [ "w3", "window", "triangle" ],
 
   parameters:  {
-    # Default 166 LEDs
+    /* Default 166 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 166" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "60", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "15", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "46", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 8, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "output": { type: "int", default: "8", min: "1", max: "8", label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: "0", min: "0", max: "512", label: "Pixel Offset", description: "ArtNet offset in pixels" },
     "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 

--- a/Fixtures/Mothership/window/Window3.lxf
+++ b/Fixtures/Mothership/window/Window3.lxf
@@ -1,86 +1,63 @@
 {
   /* Mothership by Titanic's End
-     Window 3, Strand S8a */
+     Window 3 */
 
   label: "Window3",
-  tags: [ "w3", "window", "triangle", "s8a" ],
+  tags: [ "w3", "window", "triangle" ],
 
   parameters:  {
-    /* Default 166 LEDs */
+    # Default 166 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 166" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Remove these after calibration
-    "side1": { type: "int", default: "30", description: "Number of LEDs on side 1" },
-    "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
-
-    "inset": { type: "float", default: "2.4", description: "Inset of LED strip from the line where window planes meet" },
-    "spacing": { type: "float", default: ".2" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "60", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "15", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "46", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "output": { type: "int", default: 8, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-27.215", enabled: "$onCar" },
     { y: "105.576", enabled: "$onCar" },
     { roll: "-3.8", enabled: "$onCar" },
-    { pitch: "66", enabled: "$onCar" }
+    { pitch: "66", enabled: "$onCar" },
+    { roll: "-55.7", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
+    { type: "RoundedTriangle",
 
-    /* Diagonal */
-    { type: "strip",
-      numPoints: "69 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "13.81 - $inset" },
-        { y: "-$inset" },
-        { roll: "88.5" },
-        { x: "(-57-1) * $spacing"},
-        { roll: "-144.1" },
-        { x: "-(69 - $ledOffset) * $spacing" }
-      ]
-    },
+      length1: "23.57",
+      length2: "19.468",
+      length3: "13.81",
 
-    /* Side */
-    { type: "strip",
-      numPoints: "57",
-      spacing: "$spacing",
-      transforms: [
-        { x: "13.81 - $inset" },
-        { y: "-$inset" },
-        { roll: "88.5" },
-        { x: "(-57-1) * $spacing" }
-      ]
-    },
+      angle12: "35.9",
+      angle23: "88.5",
+      angle31: "55.7",
 
-    /* Top */
-    { type: "strip",
-      numPoints: "40 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "13.81 - $inset" },
-        { y: "-$inset" },
-        { roll: 180 } 
-      ]
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "166 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
-
   ],
   
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window4.lxf
+++ b/Fixtures/Mothership/window/Window4.lxf
@@ -10,55 +10,53 @@
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 100" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Remove these after calibration
-    "side1": { type: "int", default: "30", description: "Number of LEDs on side 1" },
-    "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "20", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "14", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "28", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "16", description: "Number of LEDs in the corner between side2 and side3" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "output": { type: "int", default: 8, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 166, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-27.215", enabled: "$onCar" },
     { y: "105.576", enabled: "$onCar" },
-    { roll: "-3.7", enabled: "$onCar" },
-    { pitch: "15", enabled: "$onCar" }
+    { roll: "-3.75", enabled: "$onCar" },
+    { pitch: "15.031", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     { type: "RoundedTriangle",
-      spacing: ".2",
 
-      radius: "1.125",
-      angle12: "139.7",
-      angle23: "133.9",
+      length1: "13.81",
+      length2: "19.15",
+      length3: "12.423",
 
-      length1: "(23-1) * .2",
-      side1: "23 - $ledOffset",
-      corner12: "13",
-      side2: "30",
-      corner23: "13",
-      side3: "100 + $ledOffset + $extraLEDs - 23 - 13 - 30 - 13",
-      
-      transforms: [
-        { x: "1.4" },
-        { y: "1.4" }
-      ]
+      angle12: "40.3",
+      angle23: "46",
+      angle31: "93.6",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "100 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
   ],
   
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window4.lxf
+++ b/Fixtures/Mothership/window/Window4.lxf
@@ -6,23 +6,23 @@
   tags: [ "w4", "window", "triangle" ],
 
   parameters:  {
-    # Default 100 LEDs
+    /* Default 100 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 100" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "20", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "14", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "28", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "16", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 8, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 166, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window5.lxf
+++ b/Fixtures/Mothership/window/Window5.lxf
@@ -6,23 +6,23 @@
   tags: [ "w5", "window", "triangle" ],
 
   parameters:  {
-    # Default 114 LEDs
+    /* Default 114 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 114" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "38", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "14", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "22", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 3, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 175, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window5.lxf
+++ b/Fixtures/Mothership/window/Window5.lxf
@@ -6,97 +6,58 @@
   tags: [ "w5", "window", "triangle" ],
 
   parameters:  {
-    /* Default 114 LEDs */
+    # Default 114 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 114" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Remove these after calibration
-    "length1": { type: "float", default: "11" },
-    "side1": { type: "int", default: "24", description: "Number of LEDs on side 1" },
-    "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "38", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "14", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "22", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "output": { type: "int", default: 3, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 175, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-24", enabled: "$onCar" },
     { y: "117.576", enabled: "$onCar" },
     { roll: "-3.7", enabled: "$onCar" },
-    { pitch: "15", enabled: "$onCar" }
+    { pitch: "15", enabled: "$onCar" },
+    { roll: "-40.3", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     { type: "RoundedTriangle",
-      spacing: ".2",
 
-      radius: "1.125",
-      angle12: "126.7",
-      angle23: "93.6",
+      length1: "19.15",
+      length2: "12.423",
+      length3: "15.38",
 
-      length1: "$length1",
+      angle12: "53.3",
+      angle23: "86.4",
+      angle31: "40.3",
+
       side1: "$side1 - $ledOffset",
       corner12: "$corner12",
       side2: "$side2",
       corner23: "$corner23",
-      side3: "114 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23",
-      
-      transforms: [
-        { x: "1.4" },
-        { y: "-1.4" },
-        { roll: "-40.3" }
-      ]
+      side3: "114 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
-
-    /* Diagonal
-    { type: "strip",
-      numPoints: "46 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "15.38 - $inset - ($spacing * 37)" },
-        { y: "-$inset" },
-        { roll: "-40.3" },
-        { x: "$ledOffset * $spacing"}
-      ]
-    },
-
-     Side 
-    { type: "strip",
-      numPoints: "30",
-      spacing: "$spacing",
-      transforms: [
-        { x: "15.38 - $inset - ($spacing * 37)" },
-        { y: "-$inset" },
-        { roll: "-40.3" },
-        { x: "(46+1) * $spacing"},
-        { roll: "126.7" }
-      ]
-    },
-
-     Top 
-    { type: "strip", tag: "s2",
-      numPoints: "37 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "15.38 - $inset" },
-        { y: "-$inset" },
-        { roll: 180 } 
-      ]
-    }*/
   ],
   
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window6.lxf
+++ b/Fixtures/Mothership/window/Window6.lxf
@@ -6,23 +6,23 @@
   tags: [ "w6", "window", "triangle" ],
 
   parameters:  {
-    # Default 114 LEDs
+    /* Default 114 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 114" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "31", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "22", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 2, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 175, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window6.lxf
+++ b/Fixtures/Mothership/window/Window6.lxf
@@ -1,85 +1,62 @@
 {
   /* Mothership by Titanic's End
-     Window 6, Strand S3b */
+     Window 6 */
 
   label: "Window6",
-  tags: [ "w6", "window", "triangle", "s3b" ],
+  tags: [ "w6", "window", "triangle" ],
 
   parameters:  {
-    /* Default 114 LEDs */
+    # Default 114 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 114" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
   
-    # Remove these after calibration
-    "side1": { type: "int", default: "30", description: "Number of LEDs on side 1" },
-    "corner12": { type: "int", default: "13", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "30", description: "Number of LEDs on side 2" },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "31", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "22", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "13", description: "Number of LEDs in the corner between side2 and side3" },
-
-    "inset": { type: "float", default: "2.4", description: "Inset of LED strip from the line where window planes meet" },
-    "spacing": { type: "float", default: ".2" },
 
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "output": { type: "int", default: 2, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 175, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-24", enabled: "$onCar" },
     { y: "117.576", enabled: "$onCar" },
-    { roll: "3.7", enabled: "$onCar" },
-    { pitch: "15", enabled: "$onCar" }
+    { roll: "183.75", enabled: "$onCar" },
+    { pitch: "-15.031", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
-  
-    /* Top */
-    { type: "strip",
-      numPoints: "37 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-15.38 + $inset" },
-        { y: "-$inset" },
-        { x:  "$spacing * (37 - $ledOffset)" },
-        { roll: 180 } 
-      ]
-    },
-    
-    /* Side */
-    { type: "strip",
-      numPoints: "30",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-15.38 + $inset" },
-        { y: "-$inset" },
-        { roll: "-86.4" },
-        { x: "$spacing" }
-      ]
-    },
+    { type: "RoundedTriangle",
 
-    /* Diagonal */
-    { type: "strip",
-      numPoints: "46 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-15.38 + $inset" },
-        { y: "-$inset" },
-        { roll: "-86.4" },
-        { x: "(30+1) * $spacing"},
-        { roll: "126.7" }
-      ]
+      length1: "15.38",
+      length2: "12.423",
+      length3: "19.15",
+
+      angle12: "86.4",
+      angle23: "53.3",
+      angle31: "40.3",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "114 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
   ],
   
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window7.lxf
+++ b/Fixtures/Mothership/window/Window7.lxf
@@ -6,23 +6,23 @@
   tags: [ "w7", "window", "triangle" ],
 
   parameters:  {
-    # Default 100 LEDs
+    /* Default 100 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 100" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "20", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "16", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "28", description: "Number of LEDs on side 2" },
     "corner23": { type: "int", default: "14", description: "Number of LEDs in the corner between side2 and side3" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    /* Debug tools */
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 7, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 166, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window7.lxf
+++ b/Fixtures/Mothership/window/Window7.lxf
@@ -6,54 +6,58 @@
   tags: [ "w7", "window", "triangle" ],
 
   parameters:  {
-    /* Default 100 LEDs */
+    # Default 100 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 100" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
+    # Side and Corner lengths
+    "side1": { type: "int", default: "20", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "16", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "28", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "14", description: "Number of LEDs in the corner between side2 and side3" },
+
     # Debug tools
     "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
-    "output": { type: "int", default: 1, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
-    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" },
-    "outputEnabled": { type: "boolean", default: false }
+    "output": { type: "int", default: 7, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 166, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-27.215", enabled: "$onCar" },
     { y: "105.576", enabled: "$onCar" },
-    { roll: "3.7", enabled: "$onCar" },
-    { pitch: "15", enabled: "$onCar" },
+    { roll: "3.75", enabled: "$onCar" },
+    { pitch: "15.031", enabled: "$onCar" },
+    { roll: "86.378", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     { type: "RoundedTriangle",
-      spacing: ".2",
 
-      radius: "1.125",
-      angle12: "139.7",
-      angle23: "133.9",
+      length1: "12.423",
+      length2: "19.15",
+      length3: "13.81",
 
-      length1: "(21-1) * .2",
-      side1: "21 - $ledOffset",
-      corner12: "13",
-      side2: "30",
-      corner23: "13",
-      side3: "100 + $ledOffset + $extraLEDs - 21 - 13 - 30 - 13",
-      
-      transforms: [
-        { x: "-1.4" },
-        { y: "1.4" },
-        { roll: "90" }
-      ]
+      angle12: "46",
+      angle23: "40.3",
+      angle31: "93.6",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "100 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23"
     }
   ],
-  
+
   outputs: [
     { enabled: "$outputEnabled",
       host: "$host",
-      universe: "$output*10",
-      channel: "$pixelOffset*3",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
       protocol: "artnet",
       sequenceEnabled: "$artnetSequence"
     }

--- a/Fixtures/Mothership/window/Window8A.lxf
+++ b/Fixtures/Mothership/window/Window8A.lxf
@@ -6,11 +6,11 @@
   tags: [ "w8", "w8a", "window", "rectangle" ],
 
   parameters:  {
-    # Default 175 LEDs
+    /* Default 175 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 175" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "55", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "20", description: "Number of LEDs on side 2" },
@@ -19,12 +19,12 @@
     "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
     /* Debug tools */
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 3, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window8A.lxf
+++ b/Fixtures/Mothership/window/Window8A.lxf
@@ -1,127 +1,72 @@
 {
   /* Mothership by Titanic's End
-     Window 8A, Strand S2a */
+     Window 8A */
 
   label: "Window8A",
-  tags: [ "w8", "w8a", "window", "rectangle", "s2a" ],
+  tags: [ "w8", "w8a", "window", "rectangle" ],
 
   parameters:  {
-    /* Default 175 LEDs */
+    # Default 175 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 175" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    /* HOPEFULLY these can be the same for every window,
-       depending on how consistently the LEDs sit in the track */
-    "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "18", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
-    "side3": { type: "int", default: "58", description: "Number of LEDs on side 3" },
-    "corner34": { type: "int", default: "10", description: "Number of LEDs in the corner between side3 and side4" },
-
-    /* TODO: Immortalize these after final model has been measured */  
-    "width": { type: "int", default: 14, description: "Width of LED rectangle" },
-    "height": { type: "int", default: 6.3, description: "Height of LED rectangle" },
-    "radius": { type: "float", default: 1.125 },
-    "insetX": { type: "float", default: 1.5, description: "Inset of LED strip from the line where window planes meet" },
-    "insetY": { type: "float", default: 1.5, description: "Inset of LED strip from the line where window planes meet" },
-
-    /* Fixed, but keep as a parameter for legibility and in case the LED strip changes */
-    "spacing": { type: "float", default: .2 },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "55", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "20", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "9", description: "Number of LEDs in the corner between side2 and side3" },
+    "side3": { type: "int", default: "56", description: "Number of LEDs on side 3" },
+    "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
     /* Debug tools */
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" }
+    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
+    "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
+    "output": { type: "int", default: 3, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-24", enabled: "$onCar" },
     { y: "117.576", enabled: "$onCar" },
-    { roll: "-3.7", enabled: "$onCar" },
-    { pitch: "80.9", enabled: "$onCar" }
+    { roll: "-3.75", enabled: "$onCar" },
+    { pitch: "80.901", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     /* From inside, default wiring is clockwise */
 
-    /* Side 1, long */
-    { type: "strip",
-      numPoints: "57 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX + $width - $radius - ($spacing * (57 - $ledOffset))" },
-        { y: "$insetY" }
-      ]
-    },
+    { type: "RoundedQuad",
 
-    /* Corner 1-2 */
-    { type: "arc",
-      tag: "corner",
-      radius: "$radius",
-      degrees: "90",
-      numPoints: "$corner12",
-      transforms: [
-        { x: "$insetX + $width - $radius" },
-        { y: "$insetY" }
-      ]
-    },
+      length1: "15.38",
+      length2: "10.128",
+      length3: "15.59",
+      length4: "10.128",
 
-    /* Side 2, short */
-    { type: "strip",
-      numPoints: "$side2",
-      spacing: "($height - ($radius * 2) - ($spacing * 2)) / ($side2 - 1)",
-      transforms: [
-        { x: "$insetX + $width" },
-        { y: "$insetY + $radius + $spacing" },
-        { roll: "90" }
-      ]
-    },
+      angle12: "90.6",
+      angle23: "89.4",
+      angle34: "89.4",
+      angle41: "90.6",
 
-    /* Corner 2-3 */
-    { type: "arc",
-      tag: "corner",
-      radius: "$radius",
-      degrees: "90",
-      numPoints: "$corner23",
-      transforms: [
-        { x: "$insetX + $width" },
-        { y: "$insetY + $height - $radius" },
-        { roll: "90" }
-      ]
-    },
-
-    /* Side 3, long */
-    { type: "strip",
-      numPoints: "$side3",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX + $width - $radius - $spacing" },
-        { y: "$insetY + $height" },
-        { roll: 180 }
-      ]
-    },
-
-    /* Corner 3-4 */
-    { type: "arc",
-      tag: "corner",
-      radius: "$radius",
-      degrees: "90",
-      numPoints: "$corner34",
-      transforms: [
-        { x: "$insetX + $radius" },
-        { y: "$insetY + $height" },
-        { roll: "180" }
-      ]
-    },
-
-    /* Side 4, short */
-    { type: "strip",
-      numPoints: "175 - 57 - $corner12 - $side2 - $corner23 - $side3 - $corner34 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX" },
-        { y: "$insetY + $height - $radius - $spacing" },
-        { roll: "270" }
-      ]
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "$side3",
+      corner34: "$corner34",
+      side4: "175 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23 - $side3 - $corner34"
     }
+  ],
 
-  ]  
+  outputs: [
+    { enabled: "$outputEnabled",
+      host: "$host",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
+      protocol: "artnet",
+      sequenceEnabled: "$artnetSequence"
+    }
+  ]
 }

--- a/Fixtures/Mothership/window/Window8B.lxf
+++ b/Fixtures/Mothership/window/Window8B.lxf
@@ -1,87 +1,73 @@
 {
   /* Mothership by Titanic's End
-     Window 8B, Strand S3a */
+     Window 8B */
 
   label: "Window8B",
-  tags: [ "w8", "w8B", "window", "rectangle", "s3a" ],
+  tags: [ "w8", "w8B", "window", "rectangle" ],
 
   parameters:  {
-    /* Default 175 LEDs */
+    # Default 175 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 175" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    /* HOPEFULLY these can be the same for every window,
-       depending on how consistently the LEDs sit in the track */
-    "corner12": { type: "int", default: "10", description: "Number of LEDs in the corner between side1 and side2" },
-    "side2": { type: "int", default: "18", description: "Number of LEDs on side 2" },
-    "corner23": { type: "int", default: "10", description: "Number of LEDs in the corner between side2 and side3" },
-    "side3": { type: "int", default: "58", description: "Number of LEDs on side 3" },
-    "corner34": { type: "int", default: "10", description: "Number of LEDs in the corner between side3 and side4" },
-
-    /* TODO: Immortalize these after final model has been measured */  
-    "insetX": { type: "float", default: 2.4, description: "Inset of LED strip from the line where window planes meet" },
-    "insetY": { type: "float", default: 1.5, description: "Inset of LED strip from the line where window planes meet" },
-
-    /* Fixed, but keep as a parameter for legibility and in case the LED strip changes */
-    "spacing": { type: "float", default: .2 },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "18", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "56", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "9", description: "Number of LEDs in the corner between side2 and side3" },
+    "side3": { type: "int", default: "20", description: "Number of LEDs on side 3" },
+    "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
     /* Debug tools */
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" }
+    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
+    "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
+    "output": { type: "int", default: 2, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-24", enabled: "$onCar" },
     { y: "117.576", enabled: "$onCar" },
-    { roll: "3.7", enabled: "$onCar" },
-    { pitch: "80.9", enabled: "$onCar" }
+    { roll: "3.75", enabled: "$onCar" },
+    { pitch: "80.901", enabled: "$onCar" },
+    { roll: "90", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     /* From inside, default wiring is clockwise */
 
-    /* Side 1, short */
-    { type: "strip",
-      numPoints: "34 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-$insetX" },
-        { y: "$insetY + ($ledOffset * $spacing)" },
-        { roll: "90" }
-      ]
-    },
+    { type: "RoundedQuad",
 
-    /* Side 2, long */
-    { type: "strip",
-      numPoints: "53",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-$insetX" },
-        { y: "$insetY + ((34 + 1) * $spacing)" },
-        { roll: 180 }
-      ]
-    },
+      length1: "10.128",
+      length2: "15.59",
+      length3: "10.128",
+      length4: "15.38",
 
-    /* Side 3, short */
-    { type: "strip",
-      numPoints: "34",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-$insetX - (53 * $spacing)" },
-        { y: "$insetY + ((34 + 1) * $spacing)" },
-        { roll: "270" },
-        { x: ".5 * $spacing" }
-      ]
-    },
+      angle12: "89.4",
+      angle23: "89.4",
+      angle34: "90.6",
+      angle41: "90.6",
 
-    /* Side 4, long */
-    { type: "strip",
-      numPoints: "54 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "-$insetX - (53 * $spacing)" },
-        { y: "$insetY" }
-      ]
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "$side3",
+      corner34: "$corner34",
+      side4: "175 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23 - $side3 - $corner34"
     }
-
-  ]  
+  ],
+  
+  outputs: [
+    { enabled: "$outputEnabled",
+      host: "$host",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
+      protocol: "artnet",
+      sequenceEnabled: "$artnetSequence"
+    }
+  ]
 }

--- a/Fixtures/Mothership/window/Window8B.lxf
+++ b/Fixtures/Mothership/window/Window8B.lxf
@@ -6,11 +6,11 @@
   tags: [ "w8", "w8B", "window", "rectangle" ],
 
   parameters:  {
-    # Default 175 LEDs
+    /* Default 175 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 175" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "18", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "56", description: "Number of LEDs on side 2" },
@@ -19,12 +19,12 @@
     "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
     /* Debug tools */
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 2, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window9.lxf
+++ b/Fixtures/Mothership/window/Window9.lxf
@@ -6,11 +6,11 @@
   tags: [ "w9", "window", "rectangle" ],
 
   parameters:  {
-    # Default 368 LEDs
+    /* Default 368 LEDs */
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 368" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
 
-    # Side and Corner lengths
+    /* Side and Corner lengths */
     "side1": { type: "int", default: "56", description: "Number of LEDs on side 1" },
     "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
     "side2": { type: "int", default: "116", description: "Number of LEDs on side 2" },
@@ -19,12 +19,12 @@
     "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
     /* Debug tools */
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "onCar": { type: "boolean", default: "true", label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
     "outputEnabled": { type: "boolean", default: false },
     "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
     "output": { type: "int", default: 4, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
     "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
-    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
+    "artnetSequence": { default: "false", type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [

--- a/Fixtures/Mothership/window/Window9.lxf
+++ b/Fixtures/Mothership/window/Window9.lxf
@@ -1,82 +1,73 @@
 {
   /* Mothership by Titanic's End
-     Window 9, Strand S1a */
+     Window 9 */
 
   label: "Window9",
-  tags: [ "w9", "window", "rectangle", "s1a" ],
+  tags: [ "w9", "window", "rectangle" ],
 
   parameters:  {
-    /* Default 368 LEDs */
+    # Default 368 LEDs
     "extraLEDs": { type: "int", default: 0, min: -999, description: "Number of LEDs relative to the default of 368" },
     "ledOffset": { type: "int", default: 0, min: -999, description: "How far (in LEDs) the strip has been pushed around the track" },
-    
-    /* TODO: Immortalize these after final model has been measured */  
-    "insetX": { type: "float", default: 2.4, description: "Inset of LED strip from the line where window planes meet" },
-    "insetY": { type: "float", default: 0.9, description: "Inset of LED strip from the line where window planes meet" },
 
-    /* Fixed, but keep as a parameter for legibility and in case the LED strip changes */
-    "spacing": { type: "float", default: .2 },
+    # Side and Corner lengths
+    "side1": { type: "int", default: "56", description: "Number of LEDs on side 1" },
+    "corner12": { type: "int", default: "9", description: "Number of LEDs in the corner between side1 and side2" },
+    "side2": { type: "int", default: "116", description: "Number of LEDs on side 2" },
+    "corner23": { type: "int", default: "9", description: "Number of LEDs in the corner between side2 and side3" },
+    "side3": { type: "int", default: "54", description: "Number of LEDs on side 3" },
+    "corner34": { type: "int", default: "9", description: "Number of LEDs in the corner between side3 and side4" },
 
-    # Debug tools
-    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" }
+    /* Debug tools */
+    "onCar": { type: "boolean", default: true, label: "On Car", description: "True = Locate to position on car, False = Locate to origin" },
+    "outputEnabled": { type: "boolean", default: false },
+    "host": { type: "string", default: "localhost", label: "Host", description: "Controller IP address or hostname" },
+    "output": { type: "int", default: 4, min: 1, max: 8, label: "Output Num", description: "Controller Output Number 1-8" },
+    "pixelOffset": { type: "int", default: 0, min: 0, max: 512, label: "Pixel Offset", description: "ArtNet offset in pixels" },
+    "artnetSequence": { default: false, type: "boolean", label: "ArtNet Sequence", description: "Enable ArtNet sequence packets" }
   },
 
   transforms: [
     { z: "-14", enabled: "$onCar" },
     { y: "119.181", enabled: "$onCar" },
-    /*{ yaw: "-90", enabled: "$onCar" },*/
     { roll: "-3.75", enabled: "$onCar" },
-    { pitch: "90", enabled: "$onCar" }
+    { pitch: "90", enabled: "$onCar" },
+    { z: "-.25", enabled: "$onCar" }
   ],
 
   components: [
     /* From inside, default wiring is clockwise */
 
-    /* Short side */
-    { type: "strip",
-      numPoints: "54 - $ledOffset",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX" },
-        { y: "$insetY" },
-        { x: "(0.5 + $ledOffset) * $spacing" }
-      ]
-    },
+    { type: "RoundedQuad",
 
-    /* Long side */
-    { type: "strip",
-      numPoints: "130",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX + (54 * $spacing)" },
-        { y: "$insetY" },
-        { roll: "90" },
-        { x: "$spacing / 2" }
-      ]
-    },
-    
-    /* Short side */
-    { type: "strip",
-      numPoints: "54",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX + ((54 + 1) * $spacing)" },
-        { y: "$insetY + ((130 + 1) * $spacing)" },
-        { roll: "180" },
-        { x: "$spacing / 2" }
-      ]
-    },
+      length1: "15.38",
+      length2: "28",
+      length3: "15.59",
+      length4: "28",
 
-    /* Long side */
-    { type: "strip",
-      numPoints: "130 + $ledOffset + $extraLEDs",
-      spacing: "$spacing",
-      transforms: [
-        { x: "$insetX" },
-        { y: "$insetY + (130 * $spacing)" },
-        { roll: "270" }
-      ]
+      angle12: "90",
+      angle23: "90",
+      angle34: "90",
+      angle41: "90",
+
+      side1: "$side1 - $ledOffset",
+      corner12: "$corner12",
+      side2: "$side2",
+      corner23: "$corner23",
+      side3: "$side3",
+      corner34: "$corner34",
+      side4: "368 + $ledOffset + $extraLEDs - $side1 - $corner12 - $side2 - $corner23 - $side3 - $corner34"
     }
+  ],
 
+  outputs: [
+    { enabled: "$outputEnabled",
+      host: "$host",
+      universe: "($output * 10) + ($pixelOffset / 170)",
+      channel: "($pixelOffset % 170) * 3",
+      protocol: "artnet",
+      sequenceEnabled: "$artnetSequence"
+    }
   ]
 }
+


### PR DESCRIPTION
Mothership window fixture refinements:
- Rounded corners on all windows
- Correct pixel counts on all windows
- Pixel locations should be "about" perfect
- Outputs to controller are testing and working

![image](https://github.com/user-attachments/assets/128ea089-f4ca-4750-b00f-4cd28aff5a2d)

You may notice the start/end corner is not rounded.  These will likely stay as-in until the car is built and we see what installation anomalies we need to handle in the fixture files.  For now these straight ends make it easy to "push" the strip around the window by removing pixels from the front and adding them to the end.

I'm very happy with the new mechanism of strip placement.  It takes advantage of the perfect strip position relative to the CAD model by combining:
- Length of edges between faces, measured from CAD.
- Inset of the LED strip from the edges.
- Radius of the corners

This means the window placement should be perfect without any x/y adjustment.  To demonstrate I added a strip tracing each edge to the config files. You can see how sharp it looks:

<img width="625" alt="image" src="https://github.com/user-attachments/assets/be2d097b-002e-4a34-a95b-31b1da1d27cd">

As a bonus, the inset can be changed in one (well, two) places which will move the points closer to the edge of the window without affecting the # of pixels on each edge and corner.  This is a nice safety net if the "perceived" location of the pixel is outside of the "actual" location due to the polycarb diffuser.  In which case adjusting the `inset` parameter will look like this:

<img width="488" alt="image" src="https://github.com/user-attachments/assets/c746fcac-3db7-483a-a0a7-f6e5c7cdc560">
