### PR TITLE
Add legacy Edge and Panel tags to fixtures

### DIFF
--- a/Fixtures/TE/edge/Edge10-100.lxf
+++ b/Fixtures/TE/edge/Edge10-100.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 10-100",
-  tags: [ "edge10_100", "edge", "m11" ],
+  tags: [ "edge10_100", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 48, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge10-11.lxf
+++ b/Fixtures/TE/edge/Edge10-11.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 10-11",
-  tags: [ "edge10_11", "edge", "m11" ],
+  tags: [ "edge10_11", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 188, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge10-115.lxf
+++ b/Fixtures/TE/edge/Edge10-115.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 10-115",
-  tags: [ "edge10_115", "edge", "m11" ],
+  tags: [ "edge10_115", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 119, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge10-117.lxf
+++ b/Fixtures/TE/edge/Edge10-117.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 10-117",
-  tags: [ "edge10_117", "edge", "m11" ],
+  tags: [ "edge10_117", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 158, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge100-115.lxf
+++ b/Fixtures/TE/edge/Edge100-115.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 100-115",
-  tags: [ "edge100_115", "edge", "m11" ],
+  tags: [ "edge100_115", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 76, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge101-102.lxf
+++ b/Fixtures/TE/edge/Edge101-102.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 101-102",
-  tags: [ "edge101_102", "edge", "m3" ],
+  tags: [ "edge101_102", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge101-121.lxf
+++ b/Fixtures/TE/edge/Edge101-121.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 101-121",
-  tags: [ "edge101_121", "edge", "m3" ],
+  tags: [ "edge101_121", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 107, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge102-111.lxf
+++ b/Fixtures/TE/edge/Edge102-111.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 102-111",
-  tags: [ "edge102_111", "edge", "m3" ],
+  tags: [ "edge102_111", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 116, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge102-119.lxf
+++ b/Fixtures/TE/edge/Edge102-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 102-119",
-  tags: [ "edge102_119", "edge", "m3" ],
+  tags: [ "edge102_119", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 147, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge102-121.lxf
+++ b/Fixtures/TE/edge/Edge102-121.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 102-121",
-  tags: [ "edge102_121", "edge", "m3" ],
+  tags: [ "edge102_121", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 154, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge109-110.lxf
+++ b/Fixtures/TE/edge/Edge109-110.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 109-110",
-  tags: [ "edge109_110", "edge", "m20" ],
+  tags: [ "edge109_110", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 83, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge109-111.lxf
+++ b/Fixtures/TE/edge/Edge109-111.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 109-111",
-  tags: [ "edge109_111", "edge", "m20" ],
+  tags: [ "edge109_111", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 83, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge109-112.lxf
+++ b/Fixtures/TE/edge/Edge109-112.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 109-112",
-  tags: [ "edge109_112", "edge", "m20" ],
+  tags: [ "edge109_112", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge109-113.lxf
+++ b/Fixtures/TE/edge/Edge109-113.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 109-113",
-  tags: [ "edge109_113", "edge", "m20" ],
+  tags: [ "edge109_113", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge11-100.lxf
+++ b/Fixtures/TE/edge/Edge11-100.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 11-100",
-  tags: [ "edge11_100", "edge", "m11" ],
+  tags: [ "edge11_100", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 209, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge11-98.lxf
+++ b/Fixtures/TE/edge/Edge11-98.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 11-98",
-  tags: [ "edge11_98", "edge", "m11" ],
+  tags: [ "edge11_98", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 105, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge110-111.lxf
+++ b/Fixtures/TE/edge/Edge110-111.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 110-111",
-  tags: [ "edge110_111", "edge", "m20" ],
+  tags: [ "edge110_111", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 128, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge110-119.lxf
+++ b/Fixtures/TE/edge/Edge110-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 110-119",
-  tags: [ "edge110_119", "edge", "m17" ],
+  tags: [ "edge110_119", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 147, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge111-119.lxf
+++ b/Fixtures/TE/edge/Edge111-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 111-119",
-  tags: [ "edge111_119", "edge", "m3" ],
+  tags: [ "edge111_119", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 147, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge112-113.lxf
+++ b/Fixtures/TE/edge/Edge112-113.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 112-113",
-  tags: [ "edge112_113", "edge", "m20" ],
+  tags: [ "edge112_113", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 185, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge112-114.lxf
+++ b/Fixtures/TE/edge/Edge112-114.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 112-114",
-  tags: [ "edge112_114", "edge", "m19" ],
+  tags: [ "edge112_114", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge112-116.lxf
+++ b/Fixtures/TE/edge/Edge112-116.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 112-116",
-  tags: [ "edge112_116", "edge", "m19" ],
+  tags: [ "edge112_116", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge112-124.lxf
+++ b/Fixtures/TE/edge/Edge112-124.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 112-124",
-  tags: [ "edge112_124", "edge", "m19" ],
+  tags: [ "edge112_124", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge113-115.lxf
+++ b/Fixtures/TE/edge/Edge113-115.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 113-115",
-  tags: [ "edge113_115", "edge", "m11" ],
+  tags: [ "edge113_115", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge113-117.lxf
+++ b/Fixtures/TE/edge/Edge113-117.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 113-117",
-  tags: [ "edge113_117", "edge", "m11" ],
+  tags: [ "edge113_117", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge113-124.lxf
+++ b/Fixtures/TE/edge/Edge113-124.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 113-124",
-  tags: [ "edge113_124", "edge", "m11" ],
+  tags: [ "edge113_124", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge114-116.lxf
+++ b/Fixtures/TE/edge/Edge114-116.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 114-116",
-  tags: [ "edge114_116", "edge", "m19" ],
+  tags: [ "edge114_116", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge115-117.lxf
+++ b/Fixtures/TE/edge/Edge115-117.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 115-117",
-  tags: [ "edge115_117", "edge", "m11" ],
+  tags: [ "edge115_117", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge116-124.lxf
+++ b/Fixtures/TE/edge/Edge116-124.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 116-124",
-  tags: [ "edge116_124", "edge", "m19" ],
+  tags: [ "edge116_124", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 104, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge117-124.lxf
+++ b/Fixtures/TE/edge/Edge117-124.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 117-124",
-  tags: [ "edge117_124", "edge", "m11" ],
+  tags: [ "edge117_124", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 104, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge118-119.lxf
+++ b/Fixtures/TE/edge/Edge118-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 118-119",
-  tags: [ "edge118_119", "edge", "m4" ],
+  tags: [ "edge118_119", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 175, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge119-120.lxf
+++ b/Fixtures/TE/edge/Edge119-120.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 119-120",
-  tags: [ "edge119_120", "edge", "m4" ],
+  tags: [ "edge119_120", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge119-121.lxf
+++ b/Fixtures/TE/edge/Edge119-121.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 119-121",
-  tags: [ "edge119_121", "edge", "m4" ],
+  tags: [ "edge119_121", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge12-83.lxf
+++ b/Fixtures/TE/edge/Edge12-83.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 12-83",
-  tags: [ "edge12_83", "edge", "m19" ],
+  tags: [ "edge12_83", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 209, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge12-85.lxf
+++ b/Fixtures/TE/edge/Edge12-85.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 12-85",
-  tags: [ "edge12_85", "edge", "m19" ],
+  tags: [ "edge12_85", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge125-126.lxf
+++ b/Fixtures/TE/edge/Edge125-126.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 125-126",
-  tags: [ "edge125_126", "edge", "m10" ],
+  tags: [ "edge125_126", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 104, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge125-127.lxf
+++ b/Fixtures/TE/edge/Edge125-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 125-127",
-  tags: [ "edge125_127", "edge", "m10" ],
+  tags: [ "edge125_127", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge126-129.lxf
+++ b/Fixtures/TE/edge/Edge126-129.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 126-129",
-  tags: [ "edge126_129", "edge", "m1" ],
+  tags: [ "edge126_129", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 104, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge128-129.lxf
+++ b/Fixtures/TE/edge/Edge128-129.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 128-129",
-  tags: [ "edge128_129", "edge", "m1" ],
+  tags: [ "edge128_129", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-110.lxf
+++ b/Fixtures/TE/edge/Edge25-110.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-110",
-  tags: [ "edge25_110", "edge", "m17" ],
+  tags: [ "edge25_110", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-114.lxf
+++ b/Fixtures/TE/edge/Edge25-114.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-114",
-  tags: [ "edge25_114", "edge", "m18" ],
+  tags: [ "edge25_114", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 116, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-27.lxf
+++ b/Fixtures/TE/edge/Edge25-27.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-27",
-  tags: [ "edge25_27", "edge", "m17" ],
+  tags: [ "edge25_27", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 90, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-83.lxf
+++ b/Fixtures/TE/edge/Edge25-83.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-83",
-  tags: [ "edge25_83", "edge", "m18" ],
+  tags: [ "edge25_83", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 155, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-84.lxf
+++ b/Fixtures/TE/edge/Edge25-84.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-84",
-  tags: [ "edge25_84", "edge", "m17" ],
+  tags: [ "edge25_84", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 120, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge25-88.lxf
+++ b/Fixtures/TE/edge/Edge25-88.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 25-88",
-  tags: [ "edge25_88", "edge", "m17" ],
+  tags: [ "edge25_88", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 61, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-100.lxf
+++ b/Fixtures/TE/edge/Edge26-100.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-100",
-  tags: [ "edge26_100", "edge", "m2" ],
+  tags: [ "edge26_100", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 151, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-102.lxf
+++ b/Fixtures/TE/edge/Edge26-102.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-102",
-  tags: [ "edge26_102", "edge", "m3" ],
+  tags: [ "edge26_102", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 61, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-111.lxf
+++ b/Fixtures/TE/edge/Edge26-111.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-111",
-  tags: [ "edge26_111", "edge", "m3" ],
+  tags: [ "edge26_111", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 119, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-115.lxf
+++ b/Fixtures/TE/edge/Edge26-115.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-115",
-  tags: [ "edge26_115", "edge", "m2" ],
+  tags: [ "edge26_115", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-28.lxf
+++ b/Fixtures/TE/edge/Edge26-28.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-28",
-  tags: [ "edge26_28", "edge", "m3" ],
+  tags: [ "edge26_28", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge26-99.lxf
+++ b/Fixtures/TE/edge/Edge26-99.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 26-99",
-  tags: [ "edge26_99", "edge", "m3" ],
+  tags: [ "edge26_99", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 120, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge27-109.lxf
+++ b/Fixtures/TE/edge/Edge27-109.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 27-109",
-  tags: [ "edge27_109", "edge", "m20" ],
+  tags: [ "edge27_109", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 71, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge27-110.lxf
+++ b/Fixtures/TE/edge/Edge27-110.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 27-110",
-  tags: [ "edge27_110", "edge", "m17" ],
+  tags: [ "edge27_110", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 58, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge27-112.lxf
+++ b/Fixtures/TE/edge/Edge27-112.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 27-112",
-  tags: [ "edge27_112", "edge", "m18" ],
+  tags: [ "edge27_112", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge27-114.lxf
+++ b/Fixtures/TE/edge/Edge27-114.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 27-114",
-  tags: [ "edge27_114", "edge", "m18" ],
+  tags: [ "edge27_114", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge28-109.lxf
+++ b/Fixtures/TE/edge/Edge28-109.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 28-109",
-  tags: [ "edge28_109", "edge", "m20" ],
+  tags: [ "edge28_109", "edge", "Edge", "m20" ],
 
   parameters: {
     "points": { default: 71, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge28-111.lxf
+++ b/Fixtures/TE/edge/Edge28-111.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 28-111",
-  tags: [ "edge28_111", "edge", "m3" ],
+  tags: [ "edge28_111", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 58, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge28-113.lxf
+++ b/Fixtures/TE/edge/Edge28-113.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 28-113",
-  tags: [ "edge28_113", "edge", "m2" ],
+  tags: [ "edge28_113", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge28-115.lxf
+++ b/Fixtures/TE/edge/Edge28-115.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 28-115",
-  tags: [ "edge28_115", "edge", "m2" ],
+  tags: [ "edge28_115", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge30-118.lxf
+++ b/Fixtures/TE/edge/Edge30-118.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 30-118",
-  tags: [ "edge30_118", "edge", "m4" ],
+  tags: [ "edge30_118", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 86, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge30-31.lxf
+++ b/Fixtures/TE/edge/Edge30-31.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 30-31",
-  tags: [ "edge30_31", "edge", "m4" ],
+  tags: [ "edge30_31", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 168, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge30-33.lxf
+++ b/Fixtures/TE/edge/Edge30-33.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 30-33",
-  tags: [ "edge30_33", "edge", "m4" ],
+  tags: [ "edge30_33", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge30-38.lxf
+++ b/Fixtures/TE/edge/Edge30-38.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 30-38",
-  tags: [ "edge30_38", "edge", "m4" ],
+  tags: [ "edge30_38", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge30-42.lxf
+++ b/Fixtures/TE/edge/Edge30-42.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 30-42",
-  tags: [ "edge30_42", "edge", "m4" ],
+  tags: [ "edge30_42", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 168, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge31-118.lxf
+++ b/Fixtures/TE/edge/Edge31-118.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 31-118",
-  tags: [ "edge31_118", "edge", "m4" ],
+  tags: [ "edge31_118", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 121, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge31-119.lxf
+++ b/Fixtures/TE/edge/Edge31-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 31-119",
-  tags: [ "edge31_119", "edge", "m4" ],
+  tags: [ "edge31_119", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 189, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge31-121.lxf
+++ b/Fixtures/TE/edge/Edge31-121.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 31-121",
-  tags: [ "edge31_121", "edge", "m4" ],
+  tags: [ "edge31_121", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge31-33.lxf
+++ b/Fixtures/TE/edge/Edge31-33.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 31-33",
-  tags: [ "edge31_33", "edge", "m4" ],
+  tags: [ "edge31_33", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 109, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge31-39.lxf
+++ b/Fixtures/TE/edge/Edge31-39.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 31-39",
-  tags: [ "edge31_39", "edge", "m5" ],
+  tags: [ "edge31_39", "edge", "Edge", "m5" ],
 
   parameters: {
     "points": { default: 109, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge33-37.lxf
+++ b/Fixtures/TE/edge/Edge33-37.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 33-37",
-  tags: [ "edge33_37", "edge", "m5" ],
+  tags: [ "edge33_37", "edge", "Edge", "m5" ],
 
   parameters: {
     "points": { default: 237, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge33-38.lxf
+++ b/Fixtures/TE/edge/Edge33-38.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 33-38",
-  tags: [ "edge33_38", "edge", "m4" ],
+  tags: [ "edge33_38", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 45, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge33-39.lxf
+++ b/Fixtures/TE/edge/Edge33-39.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 33-39",
-  tags: [ "edge33_39", "edge", "m5" ],
+  tags: [ "edge33_39", "edge", "Edge", "m5" ],
 
   parameters: {
     "points": { default: 168, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-123.lxf
+++ b/Fixtures/TE/edge/Edge36-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-123",
-  tags: [ "edge36_123", "edge", "m6" ],
+  tags: [ "edge36_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 51, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-37.lxf
+++ b/Fixtures/TE/edge/Edge36-37.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-37",
-  tags: [ "edge36_37", "edge", "m6" ],
+  tags: [ "edge36_37", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 77, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-38.lxf
+++ b/Fixtures/TE/edge/Edge36-38.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-38",
-  tags: [ "edge36_38", "edge", "m15" ],
+  tags: [ "edge36_38", "edge", "Edge", "m15" ],
 
   parameters: {
     "points": { default: 237, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-43.lxf
+++ b/Fixtures/TE/edge/Edge36-43.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-43",
-  tags: [ "edge36_43", "edge", "m6" ],
+  tags: [ "edge36_43", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 131, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-56.lxf
+++ b/Fixtures/TE/edge/Edge36-56.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-56",
-  tags: [ "edge36_56", "edge", "m6" ],
+  tags: [ "edge36_56", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 60, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge36-57.lxf
+++ b/Fixtures/TE/edge/Edge36-57.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 36-57",
-  tags: [ "edge36_57", "edge", "m6" ],
+  tags: [ "edge36_57", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 121, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge37-123.lxf
+++ b/Fixtures/TE/edge/Edge37-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 37-123",
-  tags: [ "edge37_123", "edge", "m6" ],
+  tags: [ "edge37_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 51, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge37-39.lxf
+++ b/Fixtures/TE/edge/Edge37-39.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 37-39",
-  tags: [ "edge37_39", "edge", "m6" ],
+  tags: [ "edge37_39", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 131, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge37-44.lxf
+++ b/Fixtures/TE/edge/Edge37-44.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 37-44",
-  tags: [ "edge37_44", "edge", "m6" ],
+  tags: [ "edge37_44", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 121, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge37-50.lxf
+++ b/Fixtures/TE/edge/Edge37-50.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 37-50",
-  tags: [ "edge37_50", "edge", "m6" ],
+  tags: [ "edge37_50", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 60, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge38-42.lxf
+++ b/Fixtures/TE/edge/Edge38-42.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 38-42",
-  tags: [ "edge38_42", "edge", "m4" ],
+  tags: [ "edge38_42", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 109, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge38-43.lxf
+++ b/Fixtures/TE/edge/Edge38-43.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 38-43",
-  tags: [ "edge38_43", "edge", "m15" ],
+  tags: [ "edge38_43", "edge", "Edge", "m15" ],
 
   parameters: {
     "points": { default: 168, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge39-101.lxf
+++ b/Fixtures/TE/edge/Edge39-101.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 39-101",
-  tags: [ "edge39_101", "edge", "m6" ],
+  tags: [ "edge39_101", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 129, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge39-121.lxf
+++ b/Fixtures/TE/edge/Edge39-121.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 39-121",
-  tags: [ "edge39_121", "edge", "m6" ],
+  tags: [ "edge39_121", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge39-44.lxf
+++ b/Fixtures/TE/edge/Edge39-44.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 39-44",
-  tags: [ "edge39_44", "edge", "m6" ],
+  tags: [ "edge39_44", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 177, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge42-118.lxf
+++ b/Fixtures/TE/edge/Edge42-118.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 42-118",
-  tags: [ "edge42_118", "edge", "m4" ],
+  tags: [ "edge42_118", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 121, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge42-119.lxf
+++ b/Fixtures/TE/edge/Edge42-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 42-119",
-  tags: [ "edge42_119", "edge", "m4" ],
+  tags: [ "edge42_119", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 189, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge42-120.lxf
+++ b/Fixtures/TE/edge/Edge42-120.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 42-120",
-  tags: [ "edge42_120", "edge", "m4" ],
+  tags: [ "edge42_120", "edge", "Edge", "m4" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge42-43.lxf
+++ b/Fixtures/TE/edge/Edge42-43.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 42-43",
-  tags: [ "edge42_43", "edge", "m15" ],
+  tags: [ "edge42_43", "edge", "Edge", "m15" ],
 
   parameters: {
     "points": { default: 109, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge43-120.lxf
+++ b/Fixtures/TE/edge/Edge43-120.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 43-120",
-  tags: [ "edge43_120", "edge", "m6" ],
+  tags: [ "edge43_120", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge43-57.lxf
+++ b/Fixtures/TE/edge/Edge43-57.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 43-57",
-  tags: [ "edge43_57", "edge", "m6" ],
+  tags: [ "edge43_57", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 177, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge43-86.lxf
+++ b/Fixtures/TE/edge/Edge43-86.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 43-86",
-  tags: [ "edge43_86", "edge", "m6" ],
+  tags: [ "edge43_86", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 144, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge44-101.lxf
+++ b/Fixtures/TE/edge/Edge44-101.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 44-101",
-  tags: [ "edge44_101", "edge", "m6" ],
+  tags: [ "edge44_101", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 185, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge44-47.lxf
+++ b/Fixtures/TE/edge/Edge44-47.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 44-47",
-  tags: [ "edge44_47", "edge", "m6" ],
+  tags: [ "edge44_47", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 177, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge44-50.lxf
+++ b/Fixtures/TE/edge/Edge44-50.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 44-50",
-  tags: [ "edge44_50", "edge", "m6" ],
+  tags: [ "edge44_50", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge45-122.lxf
+++ b/Fixtures/TE/edge/Edge45-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 45-122",
-  tags: [ "edge45_122", "edge", "m6" ],
+  tags: [ "edge45_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 133, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge45-123.lxf
+++ b/Fixtures/TE/edge/Edge45-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 45-123",
-  tags: [ "edge45_123", "edge", "m6" ],
+  tags: [ "edge45_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge45-46.lxf
+++ b/Fixtures/TE/edge/Edge45-46.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 45-46",
-  tags: [ "edge45_46", "edge", "m6" ],
+  tags: [ "edge45_46", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 45, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge45-47.lxf
+++ b/Fixtures/TE/edge/Edge45-47.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 45-47",
-  tags: [ "edge45_47", "edge", "m6" ],
+  tags: [ "edge45_47", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 93, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge45-50.lxf
+++ b/Fixtures/TE/edge/Edge45-50.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 45-50",
-  tags: [ "edge45_50", "edge", "m6" ],
+  tags: [ "edge45_50", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 111, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge46-122.lxf
+++ b/Fixtures/TE/edge/Edge46-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 46-122",
-  tags: [ "edge46_122", "edge", "m6" ],
+  tags: [ "edge46_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge46-123.lxf
+++ b/Fixtures/TE/edge/Edge46-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 46-123",
-  tags: [ "edge46_123", "edge", "m6" ],
+  tags: [ "edge46_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge46-56.lxf
+++ b/Fixtures/TE/edge/Edge46-56.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 46-56",
-  tags: [ "edge46_56", "edge", "m6" ],
+  tags: [ "edge46_56", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 111, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge46-58.lxf
+++ b/Fixtures/TE/edge/Edge46-58.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 46-58",
-  tags: [ "edge46_58", "edge", "m6" ],
+  tags: [ "edge46_58", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 100, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge47-122.lxf
+++ b/Fixtures/TE/edge/Edge47-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 47-122",
-  tags: [ "edge47_122", "edge", "m6" ],
+  tags: [ "edge47_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 214, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge47-50.lxf
+++ b/Fixtures/TE/edge/Edge47-50.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 47-50",
-  tags: [ "edge47_50", "edge", "m6" ],
+  tags: [ "edge47_50", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge47-51.lxf
+++ b/Fixtures/TE/edge/Edge47-51.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 47-51",
-  tags: [ "edge47_51", "edge", "m8" ],
+  tags: [ "edge47_51", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 135, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge47-54.lxf
+++ b/Fixtures/TE/edge/Edge47-54.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 47-54",
-  tags: [ "edge47_54", "edge", "m6" ],
+  tags: [ "edge47_54", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 128, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge47-90.lxf
+++ b/Fixtures/TE/edge/Edge47-90.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 47-90",
-  tags: [ "edge47_90", "edge", "m8" ],
+  tags: [ "edge47_90", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 67, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge50-123.lxf
+++ b/Fixtures/TE/edge/Edge50-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 50-123",
-  tags: [ "edge50_123", "edge", "m6" ],
+  tags: [ "edge50_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 84, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge51-54.lxf
+++ b/Fixtures/TE/edge/Edge51-54.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 51-54",
-  tags: [ "edge51_54", "edge", "m6" ],
+  tags: [ "edge51_54", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 83, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge51-69.lxf
+++ b/Fixtures/TE/edge/Edge51-69.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 51-69",
-  tags: [ "edge51_69", "edge", "m8" ],
+  tags: [ "edge51_69", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 61, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge51-82.lxf
+++ b/Fixtures/TE/edge/Edge51-82.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 51-82",
-  tags: [ "edge51_82", "edge", "m8" ],
+  tags: [ "edge51_82", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 117, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge51-90.lxf
+++ b/Fixtures/TE/edge/Edge51-90.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 51-90",
-  tags: [ "edge51_90", "edge", "m8" ],
+  tags: [ "edge51_90", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge52-55.lxf
+++ b/Fixtures/TE/edge/Edge52-55.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 52-55",
-  tags: [ "edge52_55", "edge", "m6" ],
+  tags: [ "edge52_55", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 82, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge52-58.lxf
+++ b/Fixtures/TE/edge/Edge52-58.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 52-58",
-  tags: [ "edge52_58", "edge", "m13" ],
+  tags: [ "edge52_58", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 135, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge52-75.lxf
+++ b/Fixtures/TE/edge/Edge52-75.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 52-75",
-  tags: [ "edge52_75", "edge", "m13" ],
+  tags: [ "edge52_75", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 61, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge52-92.lxf
+++ b/Fixtures/TE/edge/Edge52-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 52-92",
-  tags: [ "edge52_92", "edge", "m13" ],
+  tags: [ "edge52_92", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 117, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge52-96.lxf
+++ b/Fixtures/TE/edge/Edge52-96.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 52-96",
-  tags: [ "edge52_96", "edge", "m13" ],
+  tags: [ "edge52_96", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge54-122.lxf
+++ b/Fixtures/TE/edge/Edge54-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 54-122",
-  tags: [ "edge54_122", "edge", "m6" ],
+  tags: [ "edge54_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge54-82.lxf
+++ b/Fixtures/TE/edge/Edge54-82.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 54-82",
-  tags: [ "edge54_82", "edge", "m6" ],
+  tags: [ "edge54_82", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 151, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge55-122.lxf
+++ b/Fixtures/TE/edge/Edge55-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 55-122",
-  tags: [ "edge55_122", "edge", "m6" ],
+  tags: [ "edge55_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge55-58.lxf
+++ b/Fixtures/TE/edge/Edge55-58.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 55-58",
-  tags: [ "edge55_58", "edge", "m6" ],
+  tags: [ "edge55_58", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 128, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge55-92.lxf
+++ b/Fixtures/TE/edge/Edge55-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 55-92",
-  tags: [ "edge55_92", "edge", "m6" ],
+  tags: [ "edge55_92", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 144, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge56-123.lxf
+++ b/Fixtures/TE/edge/Edge56-123.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 56-123",
-  tags: [ "edge56_123", "edge", "m6" ],
+  tags: [ "edge56_123", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 84, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge56-57.lxf
+++ b/Fixtures/TE/edge/Edge56-57.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 56-57",
-  tags: [ "edge56_57", "edge", "m6" ],
+  tags: [ "edge56_57", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge56-58.lxf
+++ b/Fixtures/TE/edge/Edge56-58.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 56-58",
-  tags: [ "edge56_58", "edge", "m6" ],
+  tags: [ "edge56_58", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge57-58.lxf
+++ b/Fixtures/TE/edge/Edge57-58.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 57-58",
-  tags: [ "edge57_58", "edge", "m6" ],
+  tags: [ "edge57_58", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 177, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge57-86.lxf
+++ b/Fixtures/TE/edge/Edge57-86.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 57-86",
-  tags: [ "edge57_86", "edge", "m6" ],
+  tags: [ "edge57_86", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 179, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge58-122.lxf
+++ b/Fixtures/TE/edge/Edge58-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 58-122",
-  tags: [ "edge58_122", "edge", "m6" ],
+  tags: [ "edge58_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 214, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge58-96.lxf
+++ b/Fixtures/TE/edge/Edge58-96.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 58-96",
-  tags: [ "edge58_96", "edge", "m13" ],
+  tags: [ "edge58_96", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 67, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge60-125.lxf
+++ b/Fixtures/TE/edge/Edge60-125.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 60-125",
-  tags: [ "edge60_125", "edge", "m10" ],
+  tags: [ "edge60_125", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 158, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge60-127.lxf
+++ b/Fixtures/TE/edge/Edge60-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 60-127",
-  tags: [ "edge60_127", "edge", "m10" ],
+  tags: [ "edge60_127", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 119, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge60-65.lxf
+++ b/Fixtures/TE/edge/Edge60-65.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 60-65",
-  tags: [ "edge60_65", "edge", "m10" ],
+  tags: [ "edge60_65", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 188, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge60-93.lxf
+++ b/Fixtures/TE/edge/Edge60-93.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 60-93",
-  tags: [ "edge60_93", "edge", "m10" ],
+  tags: [ "edge60_93", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 48, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge65-67.lxf
+++ b/Fixtures/TE/edge/Edge65-67.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 65-67",
-  tags: [ "edge65_67", "edge", "m10" ],
+  tags: [ "edge65_67", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 105, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge65-93.lxf
+++ b/Fixtures/TE/edge/Edge65-93.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 65-93",
-  tags: [ "edge65_93", "edge", "m10" ],
+  tags: [ "edge65_93", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 209, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge67-90.lxf
+++ b/Fixtures/TE/edge/Edge67-90.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 67-90",
-  tags: [ "edge67_90", "edge", "m9" ],
+  tags: [ "edge67_90", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 160, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge67-93.lxf
+++ b/Fixtures/TE/edge/Edge67-93.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 67-93",
-  tags: [ "edge67_93", "edge", "m10" ],
+  tags: [ "edge67_93", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge69-127.lxf
+++ b/Fixtures/TE/edge/Edge69-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 69-127",
-  tags: [ "edge69_127", "edge", "m9" ],
+  tags: [ "edge69_127", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge69-70.lxf
+++ b/Fixtures/TE/edge/Edge69-70.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 69-70",
-  tags: [ "edge69_70", "edge", "m8" ],
+  tags: [ "edge69_70", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 90, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge69-82.lxf
+++ b/Fixtures/TE/edge/Edge69-82.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 69-82",
-  tags: [ "edge69_82", "edge", "m8" ],
+  tags: [ "edge69_82", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge69-90.lxf
+++ b/Fixtures/TE/edge/Edge69-90.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 69-90",
-  tags: [ "edge69_90", "edge", "m8" ],
+  tags: [ "edge69_90", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 120, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge69-93.lxf
+++ b/Fixtures/TE/edge/Edge69-93.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 69-93",
-  tags: [ "edge69_93", "edge", "m9" ],
+  tags: [ "edge69_93", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 155, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge70-127.lxf
+++ b/Fixtures/TE/edge/Edge70-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 70-127",
-  tags: [ "edge70_127", "edge", "m9" ],
+  tags: [ "edge70_127", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge70-81.lxf
+++ b/Fixtures/TE/edge/Edge70-81.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 70-81",
-  tags: [ "edge70_81", "edge", "m21" ],
+  tags: [ "edge70_81", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 71, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge70-82.lxf
+++ b/Fixtures/TE/edge/Edge70-82.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 70-82",
-  tags: [ "edge70_82", "edge", "m8" ],
+  tags: [ "edge70_82", "edge", "Edge", "m8" ],
 
   parameters: {
     "points": { default: 58, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge70-89.lxf
+++ b/Fixtures/TE/edge/Edge70-89.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 70-89",
-  tags: [ "edge70_89", "edge", "m9" ],
+  tags: [ "edge70_89", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge73-128.lxf
+++ b/Fixtures/TE/edge/Edge73-128.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 73-128",
-  tags: [ "edge73_128", "edge", "m12" ],
+  tags: [ "edge73_128", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 142, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge73-75.lxf
+++ b/Fixtures/TE/edge/Edge73-75.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 73-75",
-  tags: [ "edge73_75", "edge", "m13" ],
+  tags: [ "edge73_75", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 90, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge73-81.lxf
+++ b/Fixtures/TE/edge/Edge73-81.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 73-81",
-  tags: [ "edge73_81", "edge", "m21" ],
+  tags: [ "edge73_81", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 71, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge73-91.lxf
+++ b/Fixtures/TE/edge/Edge73-91.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 73-91",
-  tags: [ "edge73_91", "edge", "m12" ],
+  tags: [ "edge73_91", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge73-92.lxf
+++ b/Fixtures/TE/edge/Edge73-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 73-92",
-  tags: [ "edge73_92", "edge", "m13" ],
+  tags: [ "edge73_92", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 58, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge75-128.lxf
+++ b/Fixtures/TE/edge/Edge75-128.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 75-128",
-  tags: [ "edge75_128", "edge", "m12" ],
+  tags: [ "edge75_128", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge75-92.lxf
+++ b/Fixtures/TE/edge/Edge75-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 75-92",
-  tags: [ "edge75_92", "edge", "m13" ],
+  tags: [ "edge75_92", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 123, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge75-96.lxf
+++ b/Fixtures/TE/edge/Edge75-96.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 75-96",
-  tags: [ "edge75_96", "edge", "m13" ],
+  tags: [ "edge75_96", "edge", "Edge", "m13" ],
 
   parameters: {
     "points": { default: 120, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge75-97.lxf
+++ b/Fixtures/TE/edge/Edge75-97.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 75-97",
-  tags: [ "edge75_97", "edge", "m12" ],
+  tags: [ "edge75_97", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 155, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge78-128.lxf
+++ b/Fixtures/TE/edge/Edge78-128.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 78-128",
-  tags: [ "edge78_128", "edge", "m1" ],
+  tags: [ "edge78_128", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 119, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge78-129.lxf
+++ b/Fixtures/TE/edge/Edge78-129.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 78-129",
-  tags: [ "edge78_129", "edge", "m1" ],
+  tags: [ "edge78_129", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 158, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge78-79.lxf
+++ b/Fixtures/TE/edge/Edge78-79.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 78-79",
-  tags: [ "edge78_79", "edge", "m1" ],
+  tags: [ "edge78_79", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 188, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge78-97.lxf
+++ b/Fixtures/TE/edge/Edge78-97.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 78-97",
-  tags: [ "edge78_97", "edge", "m1" ],
+  tags: [ "edge78_97", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 48, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge79-80.lxf
+++ b/Fixtures/TE/edge/Edge79-80.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 79-80",
-  tags: [ "edge79_80", "edge", "m1" ],
+  tags: [ "edge79_80", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 105, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge79-97.lxf
+++ b/Fixtures/TE/edge/Edge79-97.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 79-97",
-  tags: [ "edge79_97", "edge", "m1" ],
+  tags: [ "edge79_97", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 209, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge80-96.lxf
+++ b/Fixtures/TE/edge/Edge80-96.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 80-96",
-  tags: [ "edge80_96", "edge", "m12" ],
+  tags: [ "edge80_96", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 160, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge80-97.lxf
+++ b/Fixtures/TE/edge/Edge80-97.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 80-97",
-  tags: [ "edge80_97", "edge", "m1" ],
+  tags: [ "edge80_97", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 129, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge81-82.lxf
+++ b/Fixtures/TE/edge/Edge81-82.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 81-82",
-  tags: [ "edge81_82", "edge", "m21" ],
+  tags: [ "edge81_82", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 83, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge81-89.lxf
+++ b/Fixtures/TE/edge/Edge81-89.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 81-89",
-  tags: [ "edge81_89", "edge", "m21" ],
+  tags: [ "edge81_89", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge81-91.lxf
+++ b/Fixtures/TE/edge/Edge81-91.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 81-91",
-  tags: [ "edge81_91", "edge", "m21" ],
+  tags: [ "edge81_91", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge81-92.lxf
+++ b/Fixtures/TE/edge/Edge81-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 81-92",
-  tags: [ "edge81_92", "edge", "m21" ],
+  tags: [ "edge81_92", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 89, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge82-122.lxf
+++ b/Fixtures/TE/edge/Edge82-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 82-122",
-  tags: [ "edge82_122", "edge", "m6" ],
+  tags: [ "edge82_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 218, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge82-92.lxf
+++ b/Fixtures/TE/edge/Edge82-92.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 82-92",
-  tags: [ "edge82_92", "edge", "m21" ],
+  tags: [ "edge82_92", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 128, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge83-114.lxf
+++ b/Fixtures/TE/edge/Edge83-114.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 83-114",
-  tags: [ "edge83_114", "edge", "m19" ],
+  tags: [ "edge83_114", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 76, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge83-84.lxf
+++ b/Fixtures/TE/edge/Edge83-84.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 83-84",
-  tags: [ "edge83_84", "edge", "m18" ],
+  tags: [ "edge83_84", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 165, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge83-85.lxf
+++ b/Fixtures/TE/edge/Edge83-85.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 83-85",
-  tags: [ "edge83_85", "edge", "m19" ],
+  tags: [ "edge83_85", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 133, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge84-85.lxf
+++ b/Fixtures/TE/edge/Edge84-85.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 84-85",
-  tags: [ "edge84_85", "edge", "m18" ],
+  tags: [ "edge84_85", "edge", "Edge", "m18" ],
 
   parameters: {
     "points": { default: 159, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge84-86.lxf
+++ b/Fixtures/TE/edge/Edge84-86.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 84-86",
-  tags: [ "edge84_86", "edge", "m17" ],
+  tags: [ "edge84_86", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 68, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge84-88.lxf
+++ b/Fixtures/TE/edge/Edge84-88.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 84-88",
-  tags: [ "edge84_88", "edge", "m17" ],
+  tags: [ "edge84_88", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge86-120.lxf
+++ b/Fixtures/TE/edge/Edge86-120.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 86-120",
-  tags: [ "edge86_120", "edge", "m17" ],
+  tags: [ "edge86_120", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 107, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge86-88.lxf
+++ b/Fixtures/TE/edge/Edge86-88.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 86-88",
-  tags: [ "edge86_88", "edge", "m17" ],
+  tags: [ "edge86_88", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 138, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge88-110.lxf
+++ b/Fixtures/TE/edge/Edge88-110.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 88-110",
-  tags: [ "edge88_110", "edge", "m17" ],
+  tags: [ "edge88_110", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 116, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge88-119.lxf
+++ b/Fixtures/TE/edge/Edge88-119.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 88-119",
-  tags: [ "edge88_119", "edge", "m17" ],
+  tags: [ "edge88_119", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 147, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge88-120.lxf
+++ b/Fixtures/TE/edge/Edge88-120.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 88-120",
-  tags: [ "edge88_120", "edge", "m17" ],
+  tags: [ "edge88_120", "edge", "Edge", "m17" ],
 
   parameters: {
     "points": { default: 154, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge89-125.lxf
+++ b/Fixtures/TE/edge/Edge89-125.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 89-125",
-  tags: [ "edge89_125", "edge", "m10" ],
+  tags: [ "edge89_125", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge89-126.lxf
+++ b/Fixtures/TE/edge/Edge89-126.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 89-126",
-  tags: [ "edge89_126", "edge", "m10" ],
+  tags: [ "edge89_126", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge89-127.lxf
+++ b/Fixtures/TE/edge/Edge89-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 89-127",
-  tags: [ "edge89_127", "edge", "m10" ],
+  tags: [ "edge89_127", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge89-91.lxf
+++ b/Fixtures/TE/edge/Edge89-91.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 89-91",
-  tags: [ "edge89_91", "edge", "m21" ],
+  tags: [ "edge89_91", "edge", "Edge", "m21" ],
 
   parameters: {
     "points": { default: 185, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge9-114.lxf
+++ b/Fixtures/TE/edge/Edge9-114.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 9-114",
-  tags: [ "edge9_114", "edge", "m19" ],
+  tags: [ "edge9_114", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 119, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge9-116.lxf
+++ b/Fixtures/TE/edge/Edge9-116.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 9-116",
-  tags: [ "edge9_116", "edge", "m19" ],
+  tags: [ "edge9_116", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 158, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge9-12.lxf
+++ b/Fixtures/TE/edge/Edge9-12.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 9-12",
-  tags: [ "edge9_12", "edge", "m19" ],
+  tags: [ "edge9_12", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 188, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge9-83.lxf
+++ b/Fixtures/TE/edge/Edge9-83.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 9-83",
-  tags: [ "edge9_83", "edge", "m19" ],
+  tags: [ "edge9_83", "edge", "Edge", "m19" ],
 
   parameters: {
     "points": { default: 48, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge90-93.lxf
+++ b/Fixtures/TE/edge/Edge90-93.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 90-93",
-  tags: [ "edge90_93", "edge", "m9" ],
+  tags: [ "edge90_93", "edge", "Edge", "m9" ],
 
   parameters: {
     "points": { default: 166, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge91-126.lxf
+++ b/Fixtures/TE/edge/Edge91-126.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 91-126",
-  tags: [ "edge91_126", "edge", "m1" ],
+  tags: [ "edge91_126", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 145, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge91-128.lxf
+++ b/Fixtures/TE/edge/Edge91-128.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 91-128",
-  tags: [ "edge91_128", "edge", "m1" ],
+  tags: [ "edge91_128", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 132, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge91-129.lxf
+++ b/Fixtures/TE/edge/Edge91-129.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 91-129",
-  tags: [ "edge91_129", "edge", "m1" ],
+  tags: [ "edge91_129", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 133, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge92-122.lxf
+++ b/Fixtures/TE/edge/Edge92-122.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 92-122",
-  tags: [ "edge92_122", "edge", "m6" ],
+  tags: [ "edge92_122", "edge", "Edge", "m6" ],
 
   parameters: {
     "points": { default: 218, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge93-127.lxf
+++ b/Fixtures/TE/edge/Edge93-127.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 93-127",
-  tags: [ "edge93_127", "edge", "m10" ],
+  tags: [ "edge93_127", "edge", "Edge", "m10" ],
 
   parameters: {
     "points": { default: 76, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge96-97.lxf
+++ b/Fixtures/TE/edge/Edge96-97.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 96-97",
-  tags: [ "edge96_97", "edge", "m12" ],
+  tags: [ "edge96_97", "edge", "Edge", "m12" ],
 
   parameters: {
     "points": { default: 166, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge97-128.lxf
+++ b/Fixtures/TE/edge/Edge97-128.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 97-128",
-  tags: [ "edge97_128", "edge", "m1" ],
+  tags: [ "edge97_128", "edge", "Edge", "m1" ],
 
   parameters: {
     "points": { default: 76, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge98-100.lxf
+++ b/Fixtures/TE/edge/Edge98-100.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 98-100",
-  tags: [ "edge98_100", "edge", "m11" ],
+  tags: [ "edge98_100", "edge", "Edge", "m11" ],
 
   parameters: {
     "points": { default: 129, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge98-99.lxf
+++ b/Fixtures/TE/edge/Edge98-99.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 98-99",
-  tags: [ "edge98_99", "edge", "m2" ],
+  tags: [ "edge98_99", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 159, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge99-100.lxf
+++ b/Fixtures/TE/edge/Edge99-100.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 99-100",
-  tags: [ "edge99_100", "edge", "m2" ],
+  tags: [ "edge99_100", "edge", "Edge", "m2" ],
 
   parameters: {
     "points": { default: 165, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge99-101.lxf
+++ b/Fixtures/TE/edge/Edge99-101.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 99-101",
-  tags: [ "edge99_101", "edge", "m3" ],
+  tags: [ "edge99_101", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 68, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/edge/Edge99-102.lxf
+++ b/Fixtures/TE/edge/Edge99-102.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Edge 99-102",
-  tags: [ "edge99_102", "edge", "m3" ],
+  tags: [ "edge99_102", "edge", "Edge", "m3" ],
 
   parameters: {
     "points": { default: 113, type: "int", min: 1, label: "Points", description: "Number of points in the edge" },

--- a/Fixtures/TE/panel/AA.lxf
+++ b/Fixtures/TE/panel/AA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel AA",
-  tags: [ "AA", "panel", "m20" ],
+  tags: [ "AA", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 7.913386899999999, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/AB.lxf
+++ b/Fixtures/TE/panel/AB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel AB",
-  tags: [ "AB", "panel", "m20" ],
+  tags: [ "AB", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 8.89763885, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/APA.lxf
+++ b/Fixtures/TE/panel/APA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel APA",
-  tags: [ "APA", "panel", "m19" ],
+  tags: [ "APA", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 7.482972419630819, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/APB.lxf
+++ b/Fixtures/TE/panel/APB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel APB",
-  tags: [ "APB", "panel", "m20" ],
+  tags: [ "APB", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 9.83395498624759, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/APC.lxf
+++ b/Fixtures/TE/panel/APC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel APC",
-  tags: [ "APC", "panel", "m20" ],
+  tags: [ "APC", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 7.584538455639745, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/ASA.lxf
+++ b/Fixtures/TE/panel/ASA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel ASA",
-  tags: [ "ASA", "panel", "m11" ],
+  tags: [ "ASA", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 6.0938298584250035, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/ASB.lxf
+++ b/Fixtures/TE/panel/ASB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel ASB",
-  tags: [ "ASB", "panel", "m20" ],
+  tags: [ "ASB", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 9.83395498624759, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/ASC.lxf
+++ b/Fixtures/TE/panel/ASC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel ASC",
-  tags: [ "ASC", "panel", "m20" ],
+  tags: [ "ASC", "panel", "Panel", "m20" ],
 
   parameters: {
     "xOffset": { default: 7.584538455639745, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FA.lxf
+++ b/Fixtures/TE/panel/FA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FA",
-  tags: [ "FA", "panel", "m21" ],
+  tags: [ "FA", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 7.913386899999999, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FB.lxf
+++ b/Fixtures/TE/panel/FB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FB",
-  tags: [ "FB", "panel", "m21" ],
+  tags: [ "FB", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 8.89763885, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FPA.lxf
+++ b/Fixtures/TE/panel/FPA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FPA",
-  tags: [ "FPA", "panel", "m1" ],
+  tags: [ "FPA", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 7.482972419630819, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FPB.lxf
+++ b/Fixtures/TE/panel/FPB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FPB",
-  tags: [ "FPB", "panel", "m21" ],
+  tags: [ "FPB", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 9.83395498624759, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FPC.lxf
+++ b/Fixtures/TE/panel/FPC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FPC",
-  tags: [ "FPC", "panel", "m21" ],
+  tags: [ "FPC", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 8.568790405639746, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FSA.lxf
+++ b/Fixtures/TE/panel/FSA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FSA",
-  tags: [ "FSA", "panel", "m10" ],
+  tags: [ "FSA", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 6.0938298584250035, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FSB.lxf
+++ b/Fixtures/TE/panel/FSB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FSB",
-  tags: [ "FSB", "panel", "m21" ],
+  tags: [ "FSB", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 9.83395498624759, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/FSC.lxf
+++ b/Fixtures/TE/panel/FSC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel FSC",
-  tags: [ "FSC", "panel", "m21" ],
+  tags: [ "FSC", "panel", "Panel", "m21" ],
 
   parameters: {
     "xOffset": { default: 8.568790405639746, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PAA.lxf
+++ b/Fixtures/TE/panel/PAA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PAA",
-  tags: [ "PAA", "panel", "m1" ],
+  tags: [ "PAA", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 8.680486035656315, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PAB.lxf
+++ b/Fixtures/TE/panel/PAB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PAB",
-  tags: [ "PAB", "panel", "m12" ],
+  tags: [ "PAB", "panel", "Panel", "m12" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PAC.lxf
+++ b/Fixtures/TE/panel/PAC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PAC",
-  tags: [ "PAC", "panel", "m12" ],
+  tags: [ "PAC", "panel", "Panel", "m12" ],
 
   parameters: {
     "xOffset": { default: 7.646774075799009, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PAD.lxf
+++ b/Fixtures/TE/panel/PAD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PAD",
-  tags: [ "PAD", "panel", "m13" ],
+  tags: [ "PAD", "panel", "Panel", "m13" ],
 
   parameters: {
     "xOffset": { default: 12.445379467271444, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PBA.lxf
+++ b/Fixtures/TE/panel/PBA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PBA",
-  tags: [ "PBA", "panel", "m1" ],
+  tags: [ "PBA", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 9.530516779284355, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PBB.lxf
+++ b/Fixtures/TE/panel/PBB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PBB",
-  tags: [ "PBB", "panel", "m1" ],
+  tags: [ "PBB", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 15.387288486489936, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PBC.lxf
+++ b/Fixtures/TE/panel/PBC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PBC",
-  tags: [ "PBC", "panel", "m12" ],
+  tags: [ "PBC", "panel", "Panel", "m12" ],
 
   parameters: {
     "xOffset": { default: 9.90309768291283, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PBD.lxf
+++ b/Fixtures/TE/panel/PBD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PBD",
-  tags: [ "PBD", "panel", "m12" ],
+  tags: [ "PBD", "panel", "Panel", "m12" ],
 
   parameters: {
     "xOffset": { default: 10.036975807217253, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PBE.lxf
+++ b/Fixtures/TE/panel/PBE.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PBE",
-  tags: [ "PBE", "panel", "m13" ],
+  tags: [ "PBE", "panel", "Panel", "m13" ],
 
   parameters: {
     "xOffset": { default: 9.939991665201504, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PCA.lxf
+++ b/Fixtures/TE/panel/PCA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PCA",
-  tags: [ "PCA", "panel", "m1" ],
+  tags: [ "PCA", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 17.108061399883056, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PCB.lxf
+++ b/Fixtures/TE/panel/PCB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PCB",
-  tags: [ "PCB", "panel", "m1" ],
+  tags: [ "PCB", "panel", "Panel", "m1" ],
 
   parameters: {
     "xOffset": { default: 16.123809449883055, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PCC.lxf
+++ b/Fixtures/TE/panel/PCC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PCC",
-  tags: [ "PCC", "panel", "m12" ],
+  tags: [ "PCC", "panel", "Panel", "m12" ],
 
   parameters: {
     "xOffset": { default: 7.369670095469779, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PDA.lxf
+++ b/Fixtures/TE/panel/PDA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PDA",
-  tags: [ "PDA", "panel", "m19" ],
+  tags: [ "PDA", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 18.104323214327877, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PDB.lxf
+++ b/Fixtures/TE/panel/PDB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PDB",
-  tags: [ "PDB", "panel", "m19" ],
+  tags: [ "PDB", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 15.151567364327875, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PDC.lxf
+++ b/Fixtures/TE/panel/PDC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PDC",
-  tags: [ "PDC", "panel", "m18" ],
+  tags: [ "PDC", "panel", "Panel", "m18" ],
 
   parameters: {
     "xOffset": { default: 6.938027792133468, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PEA.lxf
+++ b/Fixtures/TE/panel/PEA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PEA",
-  tags: [ "PEA", "panel", "m19" ],
+  tags: [ "PEA", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 9.530516779280937, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PEB.lxf
+++ b/Fixtures/TE/panel/PEB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PEB",
-  tags: [ "PEB", "panel", "m19" ],
+  tags: [ "PEB", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 15.387300247507135, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PEC.lxf
+++ b/Fixtures/TE/panel/PEC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PEC",
-  tags: [ "PEC", "panel", "m18" ],
+  tags: [ "PEC", "panel", "Panel", "m18" ],
 
   parameters: {
     "xOffset": { default: 9.919804135425046, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PED.lxf
+++ b/Fixtures/TE/panel/PED.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PED",
-  tags: [ "PED", "panel", "m18" ],
+  tags: [ "PED", "panel", "Panel", "m18" ],
 
   parameters: {
     "xOffset": { default: 8.612097550823094, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PEE.lxf
+++ b/Fixtures/TE/panel/PEE.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PEE",
-  tags: [ "PEE", "panel", "m17" ],
+  tags: [ "PEE", "panel", "Panel", "m17" ],
 
   parameters: {
     "xOffset": { default: 9.854858664372607, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PFA.lxf
+++ b/Fixtures/TE/panel/PFA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PFA",
-  tags: [ "PFA", "panel", "m19" ],
+  tags: [ "PFA", "panel", "Panel", "m19" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PFB.lxf
+++ b/Fixtures/TE/panel/PFB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PFB",
-  tags: [ "PFB", "panel", "m18" ],
+  tags: [ "PFB", "panel", "Panel", "m18" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PFC.lxf
+++ b/Fixtures/TE/panel/PFC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PFC",
-  tags: [ "PFC", "panel", "m18" ],
+  tags: [ "PFC", "panel", "Panel", "m18" ],
 
   parameters: {
     "xOffset": { default: 6.188870548524061, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PFD.lxf
+++ b/Fixtures/TE/panel/PFD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PFD",
-  tags: [ "PFD", "panel", "m17" ],
+  tags: [ "PFD", "panel", "Panel", "m17" ],
 
   parameters: {
     "xOffset": { default: 12.445379467271444, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PUA.lxf
+++ b/Fixtures/TE/panel/PUA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PUA",
-  tags: [ "PUA", "panel", "m6" ],
+  tags: [ "PUA", "panel", "Panel", "m6" ],
 
   parameters: {
     "xOffset": { default: 7.599933210260126, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/PUF.lxf
+++ b/Fixtures/TE/panel/PUF.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel PUF",
-  tags: [ "PUF", "panel", "m6" ],
+  tags: [ "PUF", "panel", "Panel", "m6" ],
 
   parameters: {
     "xOffset": { default: 8.57917424606299, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SAA.lxf
+++ b/Fixtures/TE/panel/SAA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SAA",
-  tags: [ "SAA", "panel", "m11" ],
+  tags: [ "SAA", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 8.680486035656315, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SAB.lxf
+++ b/Fixtures/TE/panel/SAB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SAB",
-  tags: [ "SAB", "panel", "m2" ],
+  tags: [ "SAB", "panel", "Panel", "m2" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SAC.lxf
+++ b/Fixtures/TE/panel/SAC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SAC",
-  tags: [ "SAC", "panel", "m2" ],
+  tags: [ "SAC", "panel", "Panel", "m2" ],
 
   parameters: {
     "xOffset": { default: 8.631026025799002, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SAD.lxf
+++ b/Fixtures/TE/panel/SAD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SAD",
-  tags: [ "SAD", "panel", "m3" ],
+  tags: [ "SAD", "panel", "Panel", "m3" ],
 
   parameters: {
     "xOffset": { default: 12.445379467271444, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SBA.lxf
+++ b/Fixtures/TE/panel/SBA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SBA",
-  tags: [ "SBA", "panel", "m11" ],
+  tags: [ "SBA", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 8.546264829280936, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SBB.lxf
+++ b/Fixtures/TE/panel/SBB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SBB",
-  tags: [ "SBB", "panel", "m11" ],
+  tags: [ "SBB", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 15.387300247507135, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SBC.lxf
+++ b/Fixtures/TE/panel/SBC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SBC",
-  tags: [ "SBC", "panel", "m2" ],
+  tags: [ "SBC", "panel", "Panel", "m2" ],
 
   parameters: {
     "xOffset": { default: 9.919804135425046, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SBD.lxf
+++ b/Fixtures/TE/panel/SBD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SBD",
-  tags: [ "SBD", "panel", "m2" ],
+  tags: [ "SBD", "panel", "Panel", "m2" ],
 
   parameters: {
     "xOffset": { default: 8.612097550823094, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SBE.lxf
+++ b/Fixtures/TE/panel/SBE.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SBE",
-  tags: [ "SBE", "panel", "m3" ],
+  tags: [ "SBE", "panel", "Panel", "m3" ],
 
   parameters: {
     "xOffset": { default: 8.870606714372606, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SCA.lxf
+++ b/Fixtures/TE/panel/SCA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SCA",
-  tags: [ "SCA", "panel", "m11" ],
+  tags: [ "SCA", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 18.104323214327877, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SCB.lxf
+++ b/Fixtures/TE/panel/SCB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SCB",
-  tags: [ "SCB", "panel", "m11" ],
+  tags: [ "SCB", "panel", "Panel", "m11" ],
 
   parameters: {
     "xOffset": { default: 16.135819314327875, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SCC.lxf
+++ b/Fixtures/TE/panel/SCC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SCC",
-  tags: [ "SCC", "panel", "m2" ],
+  tags: [ "SCC", "panel", "Panel", "m2" ],
 
   parameters: {
     "xOffset": { default: 6.938027792133468, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SDA.lxf
+++ b/Fixtures/TE/panel/SDA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SDA",
-  tags: [ "SDA", "panel", "m10" ],
+  tags: [ "SDA", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 17.108061399883056, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SDB.lxf
+++ b/Fixtures/TE/panel/SDB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SDB",
-  tags: [ "SDB", "panel", "m10" ],
+  tags: [ "SDB", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 15.139557499883054, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SDC.lxf
+++ b/Fixtures/TE/panel/SDC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SDC",
-  tags: [ "SDC", "panel", "m9" ],
+  tags: [ "SDC", "panel", "Panel", "m9" ],
 
   parameters: {
     "xOffset": { default: 7.369670095469779, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SEA.lxf
+++ b/Fixtures/TE/panel/SEA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SEA",
-  tags: [ "SEA", "panel", "m10" ],
+  tags: [ "SEA", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 9.530516779280937, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SEB.lxf
+++ b/Fixtures/TE/panel/SEB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SEB",
-  tags: [ "SEB", "panel", "m10" ],
+  tags: [ "SEB", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 14.403048297507134, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SEC.lxf
+++ b/Fixtures/TE/panel/SEC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SEC",
-  tags: [ "SEC", "panel", "m9" ],
+  tags: [ "SEC", "panel", "Panel", "m9" ],
 
   parameters: {
     "xOffset": { default: 9.90309768291283, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SED.lxf
+++ b/Fixtures/TE/panel/SED.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SED",
-  tags: [ "SED", "panel", "m9" ],
+  tags: [ "SED", "panel", "Panel", "m9" ],
 
   parameters: {
     "xOffset": { default: 9.052723857217252, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SEE.lxf
+++ b/Fixtures/TE/panel/SEE.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SEE",
-  tags: [ "SEE", "panel", "m8" ],
+  tags: [ "SEE", "panel", "Panel", "m8" ],
 
   parameters: {
     "xOffset": { default: 8.955739715201503, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SFA.lxf
+++ b/Fixtures/TE/panel/SFA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SFA",
-  tags: [ "SFA", "panel", "m10" ],
+  tags: [ "SFA", "panel", "Panel", "m10" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SFB.lxf
+++ b/Fixtures/TE/panel/SFB.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SFB",
-  tags: [ "SFB", "panel", "m9" ],
+  tags: [ "SFB", "panel", "Panel", "m9" ],
 
   parameters: {
     "xOffset": { default: 7.6962340856563145, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SFC.lxf
+++ b/Fixtures/TE/panel/SFC.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SFC",
-  tags: [ "SFC", "panel", "m9" ],
+  tags: [ "SFC", "panel", "Panel", "m9" ],
 
   parameters: {
     "xOffset": { default: 7.646774075799009, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SFD.lxf
+++ b/Fixtures/TE/panel/SFD.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SFD",
-  tags: [ "SFD", "panel", "m8" ],
+  tags: [ "SFD", "panel", "Panel", "m8" ],
 
   parameters: {
     "xOffset": { default: 11.461127517271443, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SUA.lxf
+++ b/Fixtures/TE/panel/SUA.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SUA",
-  tags: [ "SUA", "panel", "m6" ],
+  tags: [ "SUA", "panel", "Panel", "m6" ],
 
   parameters: {
     "xOffset": { default: 7.599933210260126, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/Fixtures/TE/panel/SUF.lxf
+++ b/Fixtures/TE/panel/SUF.lxf
@@ -1,7 +1,7 @@
 {
   /* Titanic's End Fixture File */
   label: "Panel SUF",
-  tags: [ "SUF", "panel", "m6" ],
+  tags: [ "SUF", "panel", "Panel", "m6" ],
 
   parameters: {
     "xOffset": { default: 8.57917424606299, type: float, description: "Adjust X position within the plane of the panel. Use to fine-tune position after installation" },

--- a/script/fixture_tags/add_tag.py
+++ b/script/fixture_tags/add_tag.py
@@ -1,0 +1,54 @@
+#! /usr/bin/env python
+
+import os
+import re
+
+def edit_lxf_files(directory, existing_tag, new_tag):
+    # Define the regex pattern to find the line with "tags:" and the existing string
+    tag_line_pattern = re.compile(r'^\s*tags:.*"' + re.escape(existing_tag) + r'",')
+
+    added = 0
+    found = 0
+
+    # Iterate over all files in the given directory
+    for filename in os.listdir(directory):
+        # Check if the file ends with .lxf
+        if filename.endswith(".lxf"):
+            filepath = os.path.join(directory, filename)
+            try:
+                # Read the file content
+                with open(filepath, 'r') as file:
+                    content = file.readlines()
+
+                # Flag to track if any modification is made
+                modified = False
+
+                # Process each line
+                for i, line in enumerate(content):
+                    if tag_line_pattern.match(line):
+                        if f'"{new_tag}",' not in line:
+                            # Insert '"new_string",' after '"existing_string",'
+                            content[i] = line.replace(f'"{existing_tag}",', f'"{existing_tag}", "{new_tag}",')
+                            modified = True
+                            added += 1
+                            # print(f"Edited line {i} in {filepath}")
+                        else:
+                            found += 1
+                        break
+
+                # If modifications were made, write the new content back to the file
+                if modified:
+                    with open(filepath, 'w') as file:
+                        file.writelines(content)
+
+            except Exception as e:
+                print(f"Failed to edit {filepath}: {e}")
+
+    print(f"Added tag to {added} files. Tag already existed in {found} files.")
+
+# Add a tag to LXF files if it does not exist
+directory_path = '../../Fixtures/TE/edge'
+existing_tag = 'edge'
+new_tag = 'Edge'
+
+edit_lxf_files(directory_path, existing_tag, new_tag)


### PR DESCRIPTION
Added capitalized "Edge" tag to edge LXFs and "Panel" tag to panel LXFs.

This fixes the Edges and Panels views in older project files.  Going forward I'd vote we use all lowercase for tags.