### PR TITLE
Fix model axes for HandTracker pattern

### DIFF
--- a/resources/docs/ShaderFramework.md
+++ b/resources/docs/ShaderFramework.md
@@ -60,7 +60,7 @@ uniform float frequencyReact; // reactivity to audio frequency content
 // Current values from audio stems 
 uniform float stemBass;
 uniform float stemDrums;
-uniform float stemVocal;
+uniform float stemVocals;
 uniform float stemOther;
 
 // TE color
@@ -194,16 +194,16 @@ Depending on the model used by the audio stem splitter, values should
 range from -1.0 to 1.0
 
 #### uniform float stemBass;
-Level of the bass stem - low frequency, non-percussion instruments.
+RMS energy of the bass stem - low frequency, non-percussion instruments.
 
 #### uniform float stemDrums;
-Level of the drum stem - percussion instruments.
+RMS energy of the drum stem - percussion instruments.
 
-#### uniform float stemVocal;
-Level of the vocal stem - human voices, possibly other midrange melodic instruments.
+#### uniform float stemVocals;
+RMS energy of the vocal stem - human voices, possibly other midrange melodic instruments.
 
 #### uniform float stemOther;
-Level of all other audio content.
+RMS energy of all other audio content.
 
 -----
 

--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -23,7 +23,7 @@ uniform float frequencyReact;
 // Current values from audio stems
 uniform float stemBass;
 uniform float stemDrums;
-uniform float stemVocal;
+uniform float stemVocals;
 uniform float stemOther;
 
 // TE Colors


### PR DESCRIPTION
HandTracker is needed for debugging during build, and got missed in the first axis-swap pass because it uses "real" model coords instead of the normalized set.

It should work normally now, on both static and dynamic models.

Also fixed a stray vocal/vocals stem-related variable name that was hiding in the shader framework.  (And changed it in the docs, too.)