### PR TITLE
Fix for race condition in 3D UI  element initialization

### DIFF
--- a/src/main/java/titanicsend/ui/UI3DManager.java
+++ b/src/main/java/titanicsend/ui/UI3DManager.java
@@ -8,7 +8,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 // update them easily when the model changes
 public class UI3DManager  {
   public static UI3DManager current;
-  public static final AtomicBoolean inRebuild = new AtomicBoolean(false);
+  public static final AtomicBoolean inRebuild = new AtomicBoolean(true);
   public static final AtomicBoolean inDraw = new AtomicBoolean(false);
 
   public final UIModelLabels modelLabels;


### PR DESCRIPTION
Title is longer than the fix!   

This change blocks drawing of our custom 3D UI elements until startup model initialization is complete.  