### PR TITLE
Fix car end normalization in all views

### DIFF
--- a/src/main/java/titanicsend/model/TEWholeModelDynamic.java
+++ b/src/main/java/titanicsend/model/TEWholeModelDynamic.java
@@ -262,14 +262,20 @@ public class TEWholeModelDynamic implements TEWholeModel, LX.Listener {
 
     // adjust model geometry to improve texture mapping of ends in all views.
     ModelBender mb = new ModelBender();
-    mb.adjustEndGeometry(this, this.lx.getModel());
-
-    // method in heronarts.lx.structure.view.LXViewEngine:
-    // iterate over the views and rebuild them (with the "adjusted" model)
-    lx.structure.views.modelGenerationChanged(lx, this.lx.getModel());
+    boolean rebuildViews = mb.adjustEndGeometry(this, lx.getModel());
+    
+    // if the TE main car is part of this model, iterate over the views
+    // and rebuild them (with the "adjusted" end geometry)
+    // To do this, we call a method in heronarts.lx.structure.view.LXViewEngine
+    //
+    // NOTE that this method, though public, is mainly used internally by Chromatik,
+    // and its behavior might change without warning in a future version.
+    if (rebuildViews) {
+      lx.structure.views.modelGenerationChanged(lx, lx.getModel());
+    }
 
     // restore the model to its original state
-    mb.restoreModel(this, this.lx.getModel());
+    mb.restoreModel(this, lx.getModel());
 
     /* TE.log("Model changed. Found " +
     this.edges.size() + " edges, " +

--- a/src/main/java/titanicsend/model/TEWholeModelDynamic.java
+++ b/src/main/java/titanicsend/model/TEWholeModelDynamic.java
@@ -260,13 +260,16 @@ public class TEWholeModelDynamic implements TEWholeModel, LX.Listener {
     this.mutableChildren.addAll(this.panelModels.keySet());
     this.children = this.mutableChildren.toArray(new LXModel[0]);
 
-    // adjust model geometry for easy texture mapping in views
+    // adjust model geometry to improve texture mapping of ends in all views.
     ModelBender mb = new ModelBender();
     mb.adjustEndGeometry(this, this.lx.getModel());
-    mb.restoreModel(this, this.lx.getModel());
 
-    // Update 3D ui elements (now with extra thread safety!)
-    UI3DManager.current.rebuild();
+    // method in heronarts.lx.structure.view.LXViewEngine:
+    // iterate over the views and rebuild them (with the "adjusted" model)
+    lx.structure.views.modelGenerationChanged(lx, this.lx.getModel());
+
+    // restore the model to its original state
+    mb.restoreModel(this, this.lx.getModel());
 
     /* TE.log("Model changed. Found " +
     this.edges.size() + " edges, " +
@@ -278,6 +281,9 @@ public class TEWholeModelDynamic implements TEWholeModel, LX.Listener {
     for (TEListener listener : this.listeners) {
       listener.modelTEChanged(this);
     }
+
+    // Update 3D ui elements (now with extra thread safety!)
+    UI3DManager.current.rebuild();
 
     // Run the garbage collector to prevent buildup of old-generation objects?
   }

--- a/src/main/java/titanicsend/pattern/jon/ModelBender.java
+++ b/src/main/java/titanicsend/pattern/jon/ModelBender.java
@@ -3,6 +3,8 @@ package titanicsend.pattern.jon;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import java.util.ArrayList;
+
+import heronarts.lx.studio.TEApp;
 import titanicsend.model.*;
 
 public class ModelBender {
@@ -36,11 +38,52 @@ public class ModelBender {
     "126-129"
   };
 
-  protected ArrayList<Float> savedModelCoord;
+  // Class used to save the original width coordinate of the points
+  // we're going to change. We keep a reference to the original point
+  // object so that if someone reorders the points in the model, we can
+  // still restore it correctly.
+  protected class SavedPoint {
+    private LXPoint p;
+    private float v;
+
+    public SavedPoint(LXPoint p, float v) {
+      this.p = p;
+      this.v = v;
+    }
+
+    public void restore() {
+      if (TEApp.wholeModel.isStatic()) {
+        p.z = v;
+      } else {
+        p.x = v;
+      }
+    }
+  }
+
+  protected final ArrayList<SavedPoint> savedModelCoord = new ArrayList<SavedPoint>();
+
+  // endDepthMax is the largest depth (x or z) coordinate at the boundary of
+  // side and end.  We use it as the starting depth for our taper.
   protected float endDepthMax;
 
+  // carLengthMin and carLengthMax are the min and max lengths coordinates
+  // of the main car (as opposed to the whole model, which may contain
+  // other vehicles or objects).
+  //
+  // NOTE: For this purpose, we are assuming that only the Titanic's End main
+  // car model has metadata identifying the end panels and edges, so we can
+  // use it to find the model extents for just the car, even in a larger model.
+  // If we add similar metadata to the Mothership, we'll need to revisit this.
+  protected float carLengthMin;
+  protected float carLengthMax;
+
+  protected float oldLengthMin;
+  protected float oldLengthMax;
+
   /**
-   * Get a list of points on the ends of the car
+   * Get a list of points on the ends of the car,
+   * and find the min and max length (z or x) axis values for the
+   * car (as opposed to the whole model).
    *
    * @param model
    * @return list of points
@@ -48,11 +91,26 @@ public class ModelBender {
   protected ArrayList<LXPoint> getEndPoints(TEWholeModel model) {
     ArrayList<LXPoint> endPoints = new ArrayList<LXPoint>();
 
+    // reset car length min and max
+    carLengthMin = Float.MAX_VALUE;
+    carLengthMax = Float.MIN_VALUE;
+
+    boolean isStatic = model.isStatic();
+
     // add end panel points
     for (TEPanelModel panel : model.getPanels()) {
       String id = panel.getId();
       if (id.startsWith("F") || id.startsWith("A")) {
         for (LXPoint point : panel.model.getPoints()) {
+          if (isStatic) {
+            carLengthMin = Math.min(carLengthMin, point.z);
+            carLengthMax = Math.max(carLengthMax, point.z);
+            endDepthMax =  Math.max(endDepthMax, Math.abs(point.x));
+          } else {
+            carLengthMin = Math.min(carLengthMin, point.x);
+            carLengthMax = Math.max(carLengthMax, point.x);
+            endDepthMax =  Math.max(endDepthMax, Math.abs(point.z));
+          }
           endPoints.add(point);
         }
       }
@@ -64,6 +122,15 @@ public class ModelBender {
       endEdge = model.getEdge(edgeId);
       if (endEdge != null) {
         for (LXPoint point : endEdge.model.getPoints()) {
+          if (isStatic) {
+            carLengthMin = Math.min(carLengthMin, point.z);
+            carLengthMax = Math.max(carLengthMax, point.z);
+            endDepthMax =  Math.max(endDepthMax, Math.abs(point.x));
+          } else {
+            carLengthMin = Math.min(carLengthMin, point.x);
+            carLengthMax = Math.max(carLengthMax, point.x);
+            endDepthMax =  Math.max(endDepthMax, Math.abs(point.z));
+          }
           endPoints.add(point);
         }
       }
@@ -72,28 +139,36 @@ public class ModelBender {
     return endPoints;
   }
 
-  public void adjustEndGeometry(TEWholeModelStatic model) {
+  /**
+   * Adjust the geometry of the end of the car to taper it.
+   * STATIC MODEL VERSION
+   * @param model pointer to the (static) model
+   * @return true if the model was adjusted and requires view
+   *        renormalization, false otherwise.
+   */
+  public boolean adjustEndGeometry(TEWholeModelStatic model) {
 
-    // save the model's original z coordinates so we can restore them
-    // after all views are created.  endXMax is the largest x coordinate at
-    // the boundary of side and end (more-or-less).  We use it as the
-    // starting x for our taper.
-    savedModelCoord = new ArrayList<Float>();
-    endDepthMax = Math.abs(model.vertexesById.get(116).x);
-    for (LXPoint p : model.getPoints()) {
-      savedModelCoord.add(p.z);
-    }
+    // get the list of points we need to adjust and find the
+    // car dimensions needed to build the taper.
+    ArrayList<LXPoint> endPoints = getEndPoints(model);
 
     // set new z bounds for our modified model
-    model.zMax += endDepthMax;
-    model.zMin -= endDepthMax;
+    oldLengthMin = model.zMin;
+    oldLengthMax = model.zMax;
+
+    model.zMax = carLengthMax + endDepthMax;
+    model.zMin -= carLengthMin - endDepthMax;
     model.zRange = model.zMax - model.zMin;
 
     // adjust the z coordinates of the end points to taper them
     // with decreasing x. This gives the model a slightly pointy
     // nose and makes texture mapping easier and better looking.
-    ArrayList<LXPoint> endPoints = getEndPoints(model);
+
     for (LXPoint p : endPoints) {
+      // save the original coordinate for each point we're modifying
+      // so we can restore it later
+      savedModelCoord.add(new SavedPoint(p, p.z));
+
       // kick out gap points or they'll break normalization.
       if (model.isGapPoint(p)) continue;
 
@@ -101,65 +176,86 @@ public class ModelBender {
       p.z += (p.z >= 0) ? zOffset : -zOffset;
     }
     model.normalizePoints();
+
+    return true;
   }
 
   public void restoreModel(TEWholeModelStatic model) {
     // restore the model's original z bounds
-    model.zMax -= endDepthMax;
-    model.zMin += endDepthMax;
+    model.zMax = oldLengthMax;
+    model.zMin = oldLengthMin;
     model.zRange = model.zMax - model.zMin;
 
-    int i = 0;
-    for (LXPoint p : model.getPoints()) {
-      p.z = savedModelCoord.get(i++);
+    // restore the original z coordinates
+    for (SavedPoint sp : savedModelCoord) {
+      sp.restore();
     }
   }
 
-  // Dynamic model version
-  public void adjustEndGeometry(TEWholeModelDynamic model, LXModel baseModel) {
+  /**
+   * Adjust the geometry of the end of the car to taper it to improve
+   * texture mapping.
+   * DYNAMIC MODEL VERSION
+   * @param model pointer to the (dynamic) model
+   * @return true if the model was adjusted and requires view
+   *        renormalization, false otherwise.
+   */
+  public boolean adjustEndGeometry(TEWholeModelDynamic model, LXModel baseModel) {
 
-    // save the model's original x (width) coordinates so we can restore them
-    // after all views are created.  endDepthMax is the largest z coordinate at
-    // the boundary of side and end (more-or-less).  We use it as the
-    // starting z for our taper.
-    // TODO - replace estimate w/appropriate real value when model.getVertex() is working.
-    endDepthMax = 0.85f * baseModel.zMax; //Math.abs(model.getVertex(116).z);
+    // get the list of points we need to adjust and find the
+    // car dimensions needed to build the taper.
+    ArrayList<LXPoint> endPoints = getEndPoints(model);
 
-    savedModelCoord = new ArrayList<Float>();
-    for (LXPoint p : baseModel.getPoints()) {
-      savedModelCoord.add(p.x);
+    // if the model doesn't include the main car, nothing more to do.
+    if (endPoints.size() == 0) {
+      return false;
     }
 
     // set new x bounds for our modified model
-    baseModel.xMax += endDepthMax;
-    baseModel.xMin -= endDepthMax;
+    oldLengthMin = baseModel.xMax;
+    oldLengthMax = baseModel.xMin;
+
+    // adjust the model's x bounds to make room for the taper
+    // if the car is part of a larger model space, check to see if there
+    // is already enough room for the taper without adjusting the bounds.
+    baseModel.xMax = Math.max(baseModel.xMax, carLengthMax + endDepthMax);
+    baseModel.xMin = Math.min(baseModel.xMin, carLengthMin - endDepthMax);
     baseModel.xRange = baseModel.xMax - baseModel.xMin;
 
     // adjust the x coordinates of the end points to taper them
     // with decreasing z. This gives the model a slightly pointy
     // nose and makes texture mapping easier and better looking.
-    ArrayList<LXPoint> endPoints = getEndPoints(model);
     for (LXPoint p : endPoints) {
+      // save the original coordinate for each point we're modifying
+      // so we can restore it later
+      savedModelCoord.add(new SavedPoint(p, p.x));
+
       // kick out gap points or they'll break normalization.
       if (model.isGapPoint(p)) continue;
 
       float xOffset = endDepthMax - Math.abs(p.z);
       p.x += (p.x >= 0) ? xOffset : -xOffset;
     }
-
     baseModel.normalizePoints();
+
+    return true;
   }
 
   // Dynamic model version
   public void restoreModel(TEWholeModelDynamic model, LXModel baseModel) {
-    // restore the model's original width (x) bounds
-    baseModel.xMax -= endDepthMax;
-    baseModel.xMin += endDepthMax;
+    // if nothing is saved, we don't need to restore it.
+    if (savedModelCoord.size() == 0) {
+      return;
+    }
+
+    // restore the model's original boundaries and range
+    baseModel.xMax = oldLengthMax;
+    baseModel.xMin = oldLengthMin;
     baseModel.xRange = baseModel.xMax - baseModel.xMin;
 
-    int i = 0;
-    for (LXPoint p : baseModel.getPoints()) {
-      p.x = savedModelCoord.get(i++);
+    // restore the original x coordinates for the end points
+    for (SavedPoint sp : savedModelCoord) {
+      sp.restore();
     }
   }
 }

--- a/src/main/java/titanicsend/pattern/jon/ModelBender.java
+++ b/src/main/java/titanicsend/pattern/jon/ModelBender.java
@@ -215,8 +215,8 @@ public class ModelBender {
     }
 
     // set new x bounds for our modified model
-    oldLengthMin = baseModel.xMax;
-    oldLengthMax = baseModel.xMin;
+    oldLengthMin = baseModel.xMin;
+    oldLengthMax = baseModel.xMax;
 
     // adjust the model's x bounds to make room for the taper
     // if the car is part of a larger model space, check to see if there

--- a/src/main/java/titanicsend/ui/UIBackings.java
+++ b/src/main/java/titanicsend/ui/UIBackings.java
@@ -151,7 +151,9 @@ public class UIBackings extends UI3dComponent {
       b.dispose();
     }
     this.panels.clear();
-    this.colorBuffer.dispose();
+
+    // free borrowed BGFX resources if they exist
+    if (this.colorBuffer != null) this.colorBuffer.dispose();
     MemoryUtil.memFree(this.modelMatrixBuf);
     super.dispose();
   }

--- a/src/main/java/titanicsend/ui/UIBackings.java
+++ b/src/main/java/titanicsend/ui/UIBackings.java
@@ -147,6 +147,19 @@ public class UIBackings extends UI3dComponent {
 
   @Override
   public void dispose() {
+    // make sure we're not in the middle of a model rebuild when we
+    // start destroying objects.
+    while (UI3DManager.isLocked()) {
+      try {
+        Thread.sleep(5);
+      } catch (InterruptedException e) {
+        ;
+      }
+    }
+
+    // Take draw lock to keep the model from being rebuilt while we're
+    // disposing of objects.
+    UI3DManager.beginDraw();
     for (PanelBuffer b : this.panels) {
       b.dispose();
     }
@@ -156,5 +169,6 @@ public class UIBackings extends UI3dComponent {
     if (this.colorBuffer != null) this.colorBuffer.dispose();
     MemoryUtil.memFree(this.modelMatrixBuf);
     super.dispose();
+    UI3DManager.endDraw();
   }
 }


### PR DESCRIPTION
Finally figured out how to get this working:

On project load/model changes, all views are now rebuilt with appropriate adjustments so they will look good on the car ends.

Not so important for Framework-style shows where the ends mostly don't matter, but pretty important for Burning Man where people can see the whole car.

Before (fixture view):
![image](https://github.com/user-attachments/assets/b519f8d0-4c8f-4cf7-adac-1160d9d0b44c)

After:
![image](https://github.com/user-attachments/assets/3c49e288-f797-46cf-91fe-ef9fa9cc4f34)

