### PR TITLE
Add smoothing parameter to AudioStemModulator

### DIFF
--- a/src/main/java/titanicsend/audio/AudioStemModulator.java
+++ b/src/main/java/titanicsend/audio/AudioStemModulator.java
@@ -1,21 +1,27 @@
 package titanicsend.audio;
 
+import heronarts.glx.ui.UI2dContainer;
 import heronarts.glx.ui.UI2dContainer.Position;
 import heronarts.glx.ui.component.UIKnob;
 import heronarts.glx.ui.component.UIMeter;
 import heronarts.lx.LXCategory;
 import heronarts.lx.modulator.LXModulator;
+import heronarts.lx.modulator.Smoother;
 import heronarts.lx.osc.LXOscComponent;
+import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.EnumParameter;
 import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.studio.LXStudio;
 import heronarts.lx.studio.ui.modulation.UIModulator;
 import heronarts.lx.studio.ui.modulation.UIModulatorControls;
+import heronarts.lx.utils.LXUtils;
 
 @LXModulator.Global("Audio Stem")
 @LXModulator.Device("Audio Stem")
 @LXCategory(LXCategory.AUDIO)
 public class AudioStemModulator extends LXModulator implements LXOscComponent, LXNormalizedParameter, UIModulatorControls<AudioStemModulator> {
+
+  public static final double MAX_SMOOTHING_MS = 1000;
 
   public static enum Stem {
     BASS("Bass") {
@@ -57,19 +63,37 @@ public class AudioStemModulator extends LXModulator implements LXOscComponent, L
   public final EnumParameter<Stem> stem = new EnumParameter<Stem>("Stem", Stem.BASS)
     .setDescription("Which audio stem is the source for this modulator");
 
+  public final CompoundParameter smooth = new CompoundParameter("Smooth", 0, 0, MAX_SMOOTHING_MS)
+    .setDescription("Amount of smoothing time applied to the input, in milliseconds")
+    .setExponent(2)
+    .setUnits(Units.MILLISECONDS);
+
   public AudioStemModulator() {
     this("Audio Stem");
-
-    addParameter("stem", this.stem);
   }
 
   public AudioStemModulator(String label) {
     super(label);
+
+    addParameter("stem", this.stem);
+    addParameter("smooth", this.smooth);
   }
 
   @Override
   protected double computeValue(double deltaMs) {
-    return this.stem.getEnum().getValue();
+    final double input = this.stem.getEnum().getValue();
+    final double smooth = this.smooth.getValue();
+
+    if (smooth == 0) {
+      return input;
+    } else {
+      // This math is from the LX Smoother modulator:
+      // https://github.com/heronarts/LX/blob/master/src/main/java/heronarts/lx/modulator/Smoother.java
+      return LXUtils.lerp(
+        getValue(),
+        input,
+        LXUtils.min(1, deltaMs / smooth));
+    }
   }
 
   /*
@@ -98,11 +122,15 @@ public class AudioStemModulator extends LXModulator implements LXOscComponent, L
       LXStudio.UI ui, UIModulator uiModulator, AudioStemModulator modulator) {
     uiModulator.setContentHeight(UIKnob.HEIGHT + 4);
     uiModulator.setChildSpacing(2);
-    newDropMenu(this.stem)
+    UI2dContainer.newHorizontalContainer(UIKnob.HEIGHT + 4, 4,
+      newDropMenu(this.stem)
+      .setY(10)
+      .setWidth(60),
+      this.newKnob(this.smooth)
+    )
     .setLeftMargin(10)
-    .setY(10)
-    .setWidth(60)
     .addToContainer(uiModulator, Position.LEFT);
+
     UIMeter.newVerticalMeter(ui, this, 12, UIKnob.HEIGHT)
     .addToContainer(uiModulator, Position.RIGHT);
   }

--- a/src/main/java/titanicsend/util/EMA.java
+++ b/src/main/java/titanicsend/util/EMA.java
@@ -1,0 +1,36 @@
+package titanicsend.util;
+
+/**
+ * Exponential Moving Average with adjustable smoothing time
+ */
+public class EMA {
+
+  private double periodMs;
+  private double ema;
+
+  public EMA(double periodMs) {
+    this(periodMs, 0);
+  }
+
+  public EMA(double periodMs, double initialValue) {
+    this.periodMs = periodMs;
+    this.ema = initialValue;
+  }
+
+  public EMA setPeriod(double periodMs) {
+    this.periodMs = periodMs;
+    return this;
+  }
+
+  public double update(double value, double elapsedMs) {
+    if (this.periodMs == 0) {
+      this.ema = value;
+      return this.ema;
+    }
+
+    double alpha = elapsedMs / (periodMs + elapsedMs);
+    this.ema = alpha * value + (1 - alpha) * ema;
+    return this.ema;
+  }
+
+}


### PR DESCRIPTION
Adds an adjustable smoothing time (in milliseconds) to the stem modulator output.

Math is from the LX Smoother modulator.

<img width="326" alt="image" src="https://github.com/user-attachments/assets/cb57e948-2bff-437f-a903-3cb90feec8f6">
