### PR TITLE
Replace SpiralDiamonds w/Shader

### DIFF
--- a/resources/shaders/spiral_diamonds.fs
+++ b/resources/shaders/spiral_diamonds.fs
@@ -1,0 +1,52 @@
+// MUCH FASTER replacement for the Spiral Diamonds java pattern
+//
+uniform float speedAngle;
+
+mat2 rot(float a) {
+    float s=sin(a), c=cos(a);
+    return mat2(c,s,-s,c);
+}
+
+// #define r(a) mat2(cos(a),-sin(a),sin(a),cos(a))
+
+void mainImage( out vec4 fragColor, vec2 fragCoord ) {
+    // normalize coords to the range (-1,1)
+    vec2 uv = (2.0 * fragCoord - iResolution.xy) / iResolution.xy;
+    uv.y += .5;
+
+    float warp =  30.0 * trebleRatio;
+    float warpAmt = frequencyReact * 0.08;
+
+    // warp coordinate system in a waving flag pattern w/trebleLevel.
+    // Note that this reproduces a subtle bug in the original java pattern.
+    // The already altered uv.x coordinate is used to calculate the warp for
+    // the y coordinate. It makes the coordinate distortion just a little weirder
+    // so I kept it.
+    uv.x -= warpAmt * sin(uv.y * warp);
+    uv.y += warpAmt * cos(uv.x * warp);
+
+    uv *= iScale;
+
+    // move to car center on y axis and repeat pattern over x axis
+    // at tiling interval to show two spirals at the default scale,
+    // one on each end of car.
+    float interval = 1.2;
+    uv.x = mod(uv.x,interval) - 0.5 * interval;
+
+    uv *= rot(-iRotationAngle);
+
+    // This pattern actually draws 4 symmetrical patterns of lines moving outward.
+    // To keep it looking like a spiral, we need to rotate the lines in each
+    // quadrant a little so they fit together. The required angle changes with
+    // iQuantity, so we adjust it using the expression below. (Thank you, Excel
+    // regression solver!)
+    // Note that the old java SpiralDiamonds didn't do this. It was too slow.
+    // Look at it carefully and you can see the spiral lines drift apart at the ends
+    // of squarocity's range.
+    vec2 s = sign(uv) * rot(0.6321 * pow(iQuantity, -0.8794));
+    float squarocity = speedAngle + (levelReact * bassRatio * 3.14159);
+
+    // This version does a little antialiasing that wasn't possible in the original.
+    float dx = abs(sin(iQuantity * log(dot(uv, s)) + atan(s.y,s.x) - squarocity));
+    fragColor = vec4(iColorRGB * smoothstep( .7, .5, dx),1.0);
+}

--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -243,11 +243,12 @@ public class TEApp extends LXStudio {
       lx.registry.addPattern(RainBands.class);
       lx.registry.addPattern(SimplexPosterized.class);
       lx.registry.addPattern(SpaceExplosionFX.class);
+      lx.registry.addPattern(SpiralDiamonds.class);
       lx.registry.addPattern(TEMidiFighter64DriverPattern.class);
       lx.registry.addPattern(TESparklePattern.class);
       lx.registry.addPattern(TurbulenceLines.class);
       lx.registry.addPattern(TriangleNoise.class);
-      lx.registry.addPattern(SpiralDiamonds.class);
+      lx.registry.addPattern(OldSpiralDiamonds.class);
       lx.registry.addPattern(PulsingTriangles.class);
       lx.registry.addPattern(Fire.class);
       lx.registry.addPattern(TESolidPattern.class);

--- a/src/main/java/titanicsend/pattern/jon/OldSpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/OldSpiralDiamonds.java
@@ -1,0 +1,94 @@
+package titanicsend.pattern.jon;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.LXParameter;
+import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
+import titanicsend.util.TEMath;
+
+@LXCategory("Panel FG")
+public class OldSpiralDiamonds extends TEPerformancePattern {
+
+  private static final float cosT = (float) Math.cos(TEMath.TAU / 1000);
+  private static final float sinT = (float) Math.sin(TEMath.TAU / 1000);
+
+  public OldSpiralDiamonds(LX lx) {
+    super(lx, TEShaderView.DOUBLE_LARGE);
+
+    controls.setRange(TEControlTag.FREQREACTIVITY, 0.25, 0, 0.4);
+    controls.setValue(TEControlTag.SPEED, 0.25);
+
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+    // Quantity controls density of diamonds
+    controls
+        .setRange(TEControlTag.QUANTITY, 4, 1, 7)
+        .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
+
+    addCommonControls();
+  }
+
+  @Override
+  public void runTEAudioPattern(double deltaMs) {
+
+    float t1 = (float) getRotationAngleFromSpeed();
+    double t2 = (float) getRotationAngleFromSpin();
+    float scaleFactor = (float) getSize();
+
+    float cosT2 = (float) Math.cos(t2);
+    float sinT2 = (float) Math.sin(t2);
+
+    float warp = (float) (120 * trebleLevel);
+    double warpAmt = getFrequencyReactivity() * 0.04;
+
+    int color = calcColor();
+    double squareocity = getQuantity() + (4.5 * bassLevel * getLevelReactivity());
+
+    for (LXPoint point : getModel().getPoints()) {
+      // move normalized coord origin to model center
+      float x = getXn(point) - 0.5f + (float) getXPos();
+      float y = point.yn - 0.25f + (float) getYPos();
+
+      // warp coordinate system in a waving flag pattern w/trebleLevel.
+      x -= (float) (warpAmt * Math.sin(y * warp));
+      y += (float) (warpAmt * Math.cos(x * warp));
+
+      // Scale according to size control setting
+      // NOTE: The order of translation/scaling/rotation depends on
+      // what you want your pattern to do. This pattern is definitely
+      // not an example of a universally "proper" order.
+      x *= scaleFactor;
+      y *= scaleFactor;
+
+      // repeat pattern over x axis at interval cx to make
+      // two spirals at the default scale, one on each end of car.
+      float cx = 0.3f;
+      x = TEMath.floorModf(x + 0.5f * cx, cx) - 0.5f * cx;
+
+      // rotate according to spin control setting
+      // we do this inline, using precomputed sin/cos
+      // because for this many pixels, we need the performance
+      float outX = (cosT2 * x) - (sinT2 * y);
+      y = (sinT2 * x) + (cosT2 * y);
+      x = outX;
+
+      // set up our square spiral
+      float x1 = Math.signum(x);
+      float y1 = Math.signum(y);
+
+      float sx = x1 * cosT + y1 * sinT;
+      float sy = y1 * cosT - x1 * sinT;
+
+      // t1, from the speed control, determines speed & direction of the spiral.
+      float dx =
+          (float) Math.abs(Math.sin(squareocity * Math.log(x * sx + y * sy) + point.azimuth - t1));
+      int on = ((dx * dx * dx) < 0.15) ? 1 : 0;
+
+      // finally, set color of pixel
+      colors[point.index] = color * on;
+    }
+  }
+}

--- a/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
+++ b/src/main/java/titanicsend/pattern/jon/SpiralDiamonds.java
@@ -2,24 +2,20 @@ package titanicsend.pattern.jon;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
-import heronarts.lx.model.LXPoint;
-import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
-import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.glengine.GLShader;
+import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
-import titanicsend.util.TEMath;
 
 @LXCategory("Panel FG")
-public class SpiralDiamonds extends TEPerformancePattern {
-
-  private static final float cosT = (float) Math.cos(TEMath.TAU / 1000);
-  private static final float sinT = (float) Math.sin(TEMath.TAU / 1000);
+public class SpiralDiamonds extends GLShaderPattern {
 
   public SpiralDiamonds(LX lx) {
     super(lx, TEShaderView.DOUBLE_LARGE);
 
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.25, 0, 0.4);
     controls.setValue(TEControlTag.SPEED, 0.25);
+    controls.setRange(TEControlTag.SIZE, 1.0, 0.2, 10.0);
 
     controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
     controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
@@ -30,66 +26,14 @@ public class SpiralDiamonds extends TEPerformancePattern {
         .setUnits(TEControlTag.QUANTITY, LXParameter.Units.INTEGER);
 
     addCommonControls();
-  }
 
-  @Override
-  public void runTEAudioPattern(double deltaMs) {
-
-    float t1 = (float) getRotationAngleFromSpeed();
-    double t2 = (float) getRotationAngleFromSpin();
-    float scaleFactor = (float) getSize();
-
-    float cosT2 = (float) Math.cos(t2);
-    float sinT2 = (float) Math.sin(t2);
-
-    float warp = (float) (120 * trebleLevel);
-    double warpAmt = getFrequencyReactivity() * 0.04;
-
-    int color = calcColor();
-    double squareocity = getQuantity() + (4.5 * bassLevel * getLevelReactivity());
-
-    for (LXPoint point : getModel().getPoints()) {
-      // move normalized coord origin to model center
-      float x = getXn(point) - 0.5f + (float) getXPos();
-      float y = point.yn - 0.25f + (float) getYPos();
-
-      // warp coordinate system in a waving flag pattern w/trebleLevel.
-      x -= (float) (warpAmt * Math.sin(y * warp));
-      y += (float) (warpAmt * Math.cos(x * warp));
-
-      // Scale according to size control setting
-      // NOTE: The order of translation/scaling/rotation depends on
-      // what you want your pattern to do. This pattern is definitely
-      // not an example of a universally "proper" order.
-      x *= scaleFactor;
-      y *= scaleFactor;
-
-      // repeat pattern over x axis at interval cx to make
-      // two spirals at the default scale, one on each end of car.
-      float cx = 0.3f;
-      x = TEMath.floorModf(x + 0.5f * cx, cx) - 0.5f * cx;
-
-      // rotate according to spin control setting
-      // we do this inline, using precomputed sin/cos
-      // because for this many pixels, we need the performance
-      float outX = (cosT2 * x) - (sinT2 * y);
-      y = (sinT2 * x) + (cosT2 * y);
-      x = outX;
-
-      // set up our square spiral
-      float x1 = Math.signum(x);
-      float y1 = Math.signum(y);
-
-      float sx = x1 * cosT + y1 * sinT;
-      float sy = y1 * cosT - x1 * sinT;
-
-      // t1, from the speed control, determines speed & direction of the spiral.
-      float dx =
-          (float) Math.abs(Math.sin(squareocity * Math.log(x * sx + y * sy) + point.azimuth - t1));
-      int on = ((dx * dx * dx) < 0.15) ? 1 : 0;
-
-      // finally, set color of pixel
-      colors[point.index] = color * on;
-    }
+    addShader(
+        "spiral_diamonds.fs",
+        new GLShaderFrameSetup() {
+          @Override
+          public void OnFrame(GLShader s) {
+            s.setUniform("speedAngle", (float) getRotationAngleFromSpeed());
+          }
+        });
   }
 }


### PR DESCRIPTION
- SpiralDiamonds:  Much faster now.
- OldSpiralDiamonds:  Old java version, in case it is needed

#### Discussion:
This is a 1:1 plugin replacement for the old SpiralDiamonds except:
When I looked at the java pattern to see how hard the port would be, I saw to my astonishment that it WASN'T ACTUALLY MAKING A SPIRAL.  It is supposed to.  But it was just making rings of expanding boxes. 

So I wrote a shader that fixes the math (there was a mistake when calculating the variable 'tilt' rotation term that makes the box edges join into a spiral.)   Now it actually make a spiral of diamonds, as intended.

Level reactivity is also slightly improved over the old version. 

And oh, it will no longer cause frame rate drops!