### PR TITLE
Color offset within gradient, per pattern

### DIFF
--- a/Colors/te_colors_2024.lxc
+++ b/Colors/te_colors_2024.lxc
@@ -1,0 +1,900 @@
+{
+  "swatches": [
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "PlumIce",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 40.0,
+            "primary/saturation": 95.0,
+            "primary/hue": 294.0,
+            "secondary/brightness": 94.99999237060547,
+            "secondary/saturation": 42.5,
+            "secondary/hue": 188.99998474121094
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 24.0,
+            "primary/brightness": 91.0,
+            "primary/saturation": 61.0,
+            "primary/hue": 194.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 95.83333587646484,
+            "secondary/hue": 60.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "IceGrad",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 61.00000087171793,
+            "primary/hue": 192.58998466096818,
+            "secondary/brightness": 73.33330535888672,
+            "secondary/saturation": 65.0,
+            "secondary/hue": 204.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 47.0,
+            "primary/hue": 258.0,
+            "secondary/brightness": 98.33332824707031,
+            "secondary/saturation": 28.333335876464844,
+            "secondary/hue": 273.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "IceYelGrad",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 91.0,
+            "primary/saturation": 61.0,
+            "primary/hue": 194.0,
+            "secondary/brightness": 94.99999237060547,
+            "secondary/saturation": 42.5,
+            "secondary/hue": 188.99998474121094
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 24.0,
+            "primary/brightness": 100.0,
+            "primary/saturation": 20.833328247070312,
+            "primary/hue": 225.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 95.83333587646484,
+            "secondary/hue": 288.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "GreenRod",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 32.0,
+            "primary/brightness": 95.49999237060547,
+            "primary/saturation": 80.83333587646484,
+            "primary/hue": 78.0,
+            "secondary/brightness": 94.99999237060547,
+            "secondary/saturation": 82.5,
+            "secondary/hue": 96.00000762939453
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 24.0,
+            "primary/brightness": 96.0,
+            "primary/saturation": 95.83333587646484,
+            "primary/hue": 99.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 98.33333587646484,
+            "secondary/hue": 72.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "SunWave",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 100.0,
+            "primary/saturation": 55.83333206176758,
+            "primary/hue": 204.0,
+            "secondary/brightness": 84.99996185302734,
+            "secondary/saturation": 85.0,
+            "secondary/hue": 210.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 24.0,
+            "primary/brightness": 96.0,
+            "primary/saturation": 72.5,
+            "primary/hue": 273.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 77.5,
+            "secondary/hue": 300.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "SynWv",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 89.0,
+            "primary/saturation": 75.0,
+            "primary/hue": 323.0,
+            "secondary/brightness": 84.99996185302734,
+            "secondary/saturation": 71.66666412353516,
+            "secondary/hue": 9.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 8.0,
+            "primary/brightness": 75.00000046938658,
+            "primary/saturation": 77.25000762939453,
+            "primary/hue": 256.0,
+            "secondary/brightness": 76.66666412353516,
+            "secondary/saturation": 77.25000762939453,
+            "secondary/hue": 258.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "SynWvDyn",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 89.0,
+            "primary/saturation": 75.0,
+            "primary/hue": 323.0,
+            "secondary/brightness": 84.99996185302734,
+            "secondary/saturation": 38.33333206176758,
+            "secondary/hue": 330.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 8.0,
+            "primary/brightness": 75.00000046938658,
+            "primary/saturation": 78.91667175292969,
+            "primary/hue": 249.0,
+            "secondary/brightness": 44.9999885559082,
+            "secondary/saturation": 77.25000762939453,
+            "secondary/hue": 258.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Sunset",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 30.0,
+            "primary/brightness": 69.33331298828125,
+            "primary/saturation": 96.66666412353516,
+            "primary/hue": 267.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 100.0,
+            "secondary/hue": 120.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 30.0,
+            "primary/brightness": 63.33330154418945,
+            "primary/saturation": 75.0,
+            "primary/hue": 323.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 100.0,
+            "secondary/hue": 120.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-13",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 71.66666412353516,
+            "primary/hue": 201.0,
+            "secondary/brightness": 59.99995040893555,
+            "secondary/saturation": 58.333335876464844,
+            "secondary/hue": 225.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 98.33333587646484,
+            "primary/hue": 219.0,
+            "secondary/brightness": 38.3332633972168,
+            "secondary/saturation": 71.66666412353516,
+            "secondary/hue": 219.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-14",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 56.66666793823242,
+            "primary/hue": 195.0,
+            "secondary/brightness": 73.33330535888672,
+            "secondary/saturation": 77.5,
+            "secondary/hue": 258.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 62.5,
+            "primary/hue": 174.0,
+            "secondary/brightness": 64.16655731201172,
+            "secondary/saturation": 70.0,
+            "secondary/hue": 186.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-15",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 30.0,
+            "primary/hue": 300.0,
+            "secondary/brightness": 61.6666145324707,
+            "secondary/saturation": 59.16666793823242,
+            "secondary/hue": 303.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 68.333251953125,
+            "primary/saturation": 73.33332824707031,
+            "primary/hue": 318.0,
+            "secondary/brightness": 98.33332824707031,
+            "secondary/saturation": 40.833335876464844,
+            "secondary/hue": 312.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-16",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 32.0,
+            "primary/brightness": 89.01960754394531,
+            "primary/saturation": 97.5,
+            "primary/hue": 159.0,
+            "secondary/brightness": 94.99999237060547,
+            "secondary/saturation": 68.08334350585938,
+            "secondary/hue": 90.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 24.0,
+            "primary/brightness": 62.30385208129883,
+            "primary/saturation": 96.66666412353516,
+            "primary/hue": 165.0,
+            "secondary/brightness": 100.0,
+            "secondary/saturation": 95.83333587646484,
+            "secondary/hue": 60.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-17",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 58.333335876464844,
+            "primary/hue": 188.99998474121094,
+            "secondary/brightness": 49.99996566772461,
+            "secondary/saturation": 65.0,
+            "secondary/hue": 180.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 72.5,
+            "primary/hue": 201.0,
+            "secondary/brightness": 84.99995422363281,
+            "secondary/saturation": 61.66666793823242,
+            "secondary/hue": 219.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-18",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 75.0,
+            "primary/hue": 198.0,
+            "secondary/brightness": 73.33330535888672,
+            "secondary/saturation": 77.5,
+            "secondary/hue": 258.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 1,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 77.5,
+            "primary/hue": 216.00001525878906,
+            "secondary/brightness": 66.66657257080078,
+            "secondary/saturation": 69.16666412353516,
+            "secondary/hue": 225.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-19",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 95.83333587646484,
+            "primary/hue": 192.00001525878906,
+            "secondary/brightness": 62.49994659423828,
+            "secondary/saturation": 77.5,
+            "secondary/hue": 195.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 70.0,
+            "primary/hue": 212.99998474121094,
+            "secondary/brightness": 98.33332824707031,
+            "secondary/saturation": 48.333335876464844,
+            "secondary/hue": 204.0
+          },
+          "children": {}
+        }
+      ]
+    },
+    {
+      "class": "heronarts.lx.color.LXSwatch",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Swatch-20",
+        "recall": false,
+        "autoCycleEligible": true
+      },
+      "children": {},
+      "colors": [
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 91.00000020116568,
+            "primary/saturation": 55.0,
+            "primary/hue": 342.0,
+            "secondary/brightness": 73.33330535888672,
+            "secondary/saturation": 77.5,
+            "secondary/hue": 258.0
+          },
+          "children": {}
+        },
+        {
+          "class": "heronarts.lx.color.LXDynamicColor",
+          "internal": {
+            "modulationColor": 0,
+            "modulationControlsExpanded": true,
+            "modulationsExpanded": true
+          },
+          "parameters": {
+            "label": "LX",
+            "mode": 0,
+            "period": 16.0,
+            "primary/brightness": 95.0,
+            "primary/saturation": 51.66666793823242,
+            "primary/hue": 333.0,
+            "secondary/brightness": 66.66656494140625,
+            "secondary/saturation": 55.83333206176758,
+            "secondary/hue": 324.0
+          },
+          "children": {}
+        }
+      ]
+    }
+  ]
+}

--- a/Projects/CoachellaMaster.lxp
+++ b/Projects/CoachellaMaster.lxp
@@ -1,6 +1,6 @@
 {
   "version": "1.0.1.TE.1-SNAPSHOT",
-  "timestamp": 1721930522917,
+  "timestamp": 1723237868233,
   "model": {
     "id": 2,
     "class": "heronarts.lx.structure.LXStructure",
@@ -7699,7 +7699,7 @@
           "pitch": 0.0,
           "roll": 0.0,
           "scale": 1.0,
-          "selected": true,
+          "selected": false,
           "deactivate": false,
           "enabled": true,
           "brightness": 1.0,
@@ -11512,7 +11512,7 @@
           "pitch": 0.0,
           "roll": 0.0,
           "scale": 1.0,
-          "selected": false,
+          "selected": true,
           "deactivate": false,
           "enabled": true,
           "brightness": 1.0,
@@ -11579,618 +11579,6 @@
               "modulationsExpanded": true
             },
             "parameters": {
-              "label": "SWATCH A",
-              "recall": false,
-              "autoCycleEligible": true
-            },
-            "children": {},
-            "colors": [
-              {
-                "id": 8,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 43784,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 43786,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 16.0,
-                  "primary/brightness": 100.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 0.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 75.83333587646484,
-                  "secondary/hue": 51.0
-                },
-                "children": {}
-              },
-              {
-                "id": 43788,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 100.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 180.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 43790,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 240.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              }
-            ]
-          }
-        },
-        "swatches": [
-          {
-            "id": 44612,
-            "class": "heronarts.lx.color.LXSwatch",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "SWATCH A",
-              "recall": false,
-              "autoCycleEligible": true
-            },
-            "children": {},
-            "colors": [
-              {
-                "id": 44613,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44615,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44617,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 16.0,
-                  "primary/brightness": 100.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 0.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 75.83333587646484,
-                  "secondary/hue": 51.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44619,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 100.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 180.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44621,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 240.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              }
-            ]
-          },
-          {
-            "id": 44623,
-            "class": "heronarts.lx.color.LXSwatch",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "YelOrn",
-              "recall": false,
-              "autoCycleEligible": true
-            },
-            "children": {},
-            "colors": [
-              {
-                "id": 44624,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44626,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44628,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 1,
-                  "period": 16.0,
-                  "primary/brightness": 96.0,
-                  "primary/saturation": 74.0,
-                  "primary/hue": 40.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 77.5,
-                  "secondary/hue": 33.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44630,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44632,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 99.16666412353516,
-                  "primary/hue": 188.99998474121094,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              }
-            ]
-          },
-          {
-            "id": 44634,
-            "class": "heronarts.lx.color.LXSwatch",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "IceOlate",
-              "recall": false,
-              "autoCycleEligible": true
-            },
-            "children": {},
-            "colors": [
-              {
-                "id": 44635,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44637,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44639,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 1,
-                  "period": 16.0,
-                  "primary/brightness": 91.00000020116568,
-                  "primary/saturation": 61.00000087171793,
-                  "primary/hue": 192.58998466096818,
-                  "secondary/brightness": 58.33328628540039,
-                  "secondary/saturation": 70.83333587646484,
-                  "secondary/hue": 195.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44641,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44643,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 99.16666412353516,
-                  "primary/hue": 188.99998474121094,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              }
-            ]
-          },
-          {
-            "id": 44645,
-            "class": "heronarts.lx.color.LXSwatch",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "BluePurp",
-              "recall": false,
-              "autoCycleEligible": true
-            },
-            "children": {},
-            "colors": [
-              {
-                "id": 44646,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44648,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44650,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 1,
-                  "period": 16.0,
-                  "primary/brightness": 62.49992370605469,
-                  "primary/saturation": 66.66666412353516,
-                  "primary/hue": 192.00001525878906,
-                  "secondary/brightness": 70.83332824707031,
-                  "secondary/saturation": 59.16666793823242,
-                  "secondary/hue": 192.00001525878906
-                },
-                "children": {}
-              },
-              {
-                "id": 44652,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44654,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 99.16666412353516,
-                  "primary/hue": 188.99998474121094,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              }
-            ]
-          },
-          {
-            "id": 44656,
-            "class": "heronarts.lx.color.LXSwatch",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
               "label": "PlumIce",
               "recall": false,
               "autoCycleEligible": true
@@ -12198,49 +11586,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44657,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44659,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 95.0,
-                  "primary/hue": 294.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44661,
+                "id": 8,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12261,7 +11607,7 @@
                 "children": {}
               },
               {
-                "id": 44663,
+                "id": 43784,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12280,9 +11626,28 @@
                   "secondary/hue": 60.0
                 },
                 "children": {}
-              },
+              }
+            ]
+          }
+        },
+        "swatches": [
+          {
+            "id": 243821,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "PlumIce",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
               {
-                "id": 44665,
+                "id": 243822,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12292,20 +11657,41 @@
                 "parameters": {
                   "label": "LX",
                   "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 54.166664123535156,
-                  "primary/hue": 66.0,
+                  "period": 16.0,
+                  "primary/brightness": 40.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 294.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 243824,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
                   "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
                 },
                 "children": {}
               }
             ]
           },
           {
-            "id": 44667,
+            "id": 243826,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12320,49 +11706,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44668,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44670,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44672,
+                "id": 243827,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12383,7 +11727,7 @@
                 "children": {}
               },
               {
-                "id": 44674,
+                "id": 243829,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12402,32 +11746,11 @@
                   "secondary/hue": 273.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44676,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44678,
+            "id": 243831,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12442,49 +11765,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44679,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44681,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44683,
+                "id": 243832,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12505,7 +11786,7 @@
                 "children": {}
               },
               {
-                "id": 44685,
+                "id": 243834,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12524,32 +11805,11 @@
                   "secondary/hue": 288.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44687,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 54.166664123535156,
-                  "primary/hue": 66.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44689,
+            "id": 243836,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12564,49 +11824,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44690,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44692,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44694,
+                "id": 243837,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12627,7 +11845,7 @@
                 "children": {}
               },
               {
-                "id": 44696,
+                "id": 243839,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12646,32 +11864,11 @@
                   "secondary/hue": 72.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44698,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 39.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44700,
+            "id": 243841,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12686,49 +11883,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44701,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44703,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44705,
+                "id": 243842,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12749,7 +11904,7 @@
                 "children": {}
               },
               {
-                "id": 44707,
+                "id": 243844,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12768,32 +11923,11 @@
                   "secondary/hue": 300.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44709,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 27.000001907348633,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44711,
+            "id": 243846,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12808,49 +11942,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44712,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44714,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44716,
+                "id": 243847,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12871,7 +11963,7 @@
                 "children": {}
               },
               {
-                "id": 44718,
+                "id": 243849,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12890,32 +11982,11 @@
                   "secondary/hue": 258.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44720,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 27.000001907348633,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44722,
+            "id": 243851,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -12930,49 +12001,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44723,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44725,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44727,
+                "id": 243852,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -12993,7 +12022,7 @@
                 "children": {}
               },
               {
-                "id": 44729,
+                "id": 243854,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13012,32 +12041,11 @@
                   "secondary/hue": 258.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44731,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 27.000001907348633,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44733,
+            "id": 243856,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13052,49 +12060,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44734,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 2,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 67.5,
-                  "primary/hue": 324.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44736,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 2,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 98.33333587646484,
-                  "primary/hue": 324.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44738,
+                "id": 243857,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13115,7 +12081,7 @@
                 "children": {}
               },
               {
-                "id": 44740,
+                "id": 243859,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13134,32 +12100,11 @@
                   "secondary/hue": 120.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44742,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 64.0,
-                  "primary/hue": 229.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44744,
+            "id": 243861,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13174,49 +12119,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44745,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44747,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44749,
+                "id": 243862,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13237,7 +12140,7 @@
                 "children": {}
               },
               {
-                "id": 44751,
+                "id": 243864,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13256,32 +12159,11 @@
                   "secondary/hue": 219.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44753,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44755,
+            "id": 243866,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13296,49 +12178,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44756,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44758,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44760,
+                "id": 243867,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13359,7 +12199,7 @@
                 "children": {}
               },
               {
-                "id": 44762,
+                "id": 243869,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13378,32 +12218,11 @@
                   "secondary/hue": 186.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44764,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44766,
+            "id": 243871,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13418,49 +12237,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44767,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44769,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44771,
+                "id": 243872,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13481,7 +12258,7 @@
                 "children": {}
               },
               {
-                "id": 44773,
+                "id": 243874,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13500,32 +12277,11 @@
                   "secondary/hue": 312.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44775,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44777,
+            "id": 243876,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13540,49 +12296,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44778,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44780,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 186.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44782,
+                "id": 243877,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13603,7 +12317,7 @@
                 "children": {}
               },
               {
-                "id": 44784,
+                "id": 243879,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13622,32 +12336,11 @@
                   "secondary/hue": 60.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44786,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 39.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44788,
+            "id": 243881,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13662,49 +12355,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44789,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44791,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44793,
+                "id": 243882,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13725,7 +12376,7 @@
                 "children": {}
               },
               {
-                "id": 44795,
+                "id": 243884,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13744,32 +12395,11 @@
                   "secondary/hue": 219.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44797,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44799,
+            "id": 243886,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13784,49 +12414,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44800,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44802,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44804,
+                "id": 243887,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13847,7 +12435,7 @@
                 "children": {}
               },
               {
-                "id": 44806,
+                "id": 243889,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13866,32 +12454,11 @@
                   "secondary/hue": 225.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44808,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44810,
+            "id": 243891,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -13906,49 +12473,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44811,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44813,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44815,
+                "id": 243892,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13969,7 +12494,7 @@
                 "children": {}
               },
               {
-                "id": 44817,
+                "id": 243894,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -13988,32 +12513,11 @@
                   "secondary/hue": 204.0
                 },
                 "children": {}
-              },
-              {
-                "id": 44819,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
               }
             ]
           },
           {
-            "id": 44821,
+            "id": 243896,
             "class": "heronarts.lx.color.LXSwatch",
             "internal": {
               "modulationColor": 0,
@@ -14028,49 +12532,7 @@
             "children": {},
             "colors": [
               {
-                "id": 44822,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 100.0,
-                  "primary/hue": 183.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44824,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 96.66666412353516,
-                  "primary/hue": 195.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44826,
+                "id": 243897,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -14091,7 +12553,7 @@
                 "children": {}
               },
               {
-                "id": 44828,
+                "id": 243899,
                 "class": "heronarts.lx.color.LXDynamicColor",
                 "internal": {
                   "modulationColor": 0,
@@ -14108,27 +12570,6 @@
                   "secondary/brightness": 66.66656494140625,
                   "secondary/saturation": 55.83333206176758,
                   "secondary/hue": 324.0
-                },
-                "children": {}
-              },
-              {
-                "id": 44830,
-                "class": "heronarts.lx.color.LXDynamicColor",
-                "internal": {
-                  "modulationColor": 0,
-                  "modulationControlsExpanded": true,
-                  "modulationsExpanded": true
-                },
-                "parameters": {
-                  "label": "LX",
-                  "mode": 0,
-                  "period": 30.0,
-                  "primary/brightness": 0.0,
-                  "primary/saturation": 75.83333587646484,
-                  "primary/hue": 267.0,
-                  "secondary/brightness": 100.0,
-                  "secondary/saturation": 100.0,
-                  "secondary/hue": 120.0
                 },
                 "children": {}
               }
@@ -14763,22 +13204,22 @@
               "attack": 0.0,
               "release": 215.0309717563906,
               "slope": 6.0,
-              "band-1": 0.0,
-              "band-2": 0.0,
-              "band-3": 0.0,
-              "band-4": 0.0,
-              "band-5": 0.0,
-              "band-6": 0.0,
-              "band-7": 0.0,
-              "band-8": 0.0,
-              "band-9": 0.0,
-              "band-10": 0.0,
-              "band-11": 0.0,
-              "band-12": 0.0,
-              "band-13": 0.0,
-              "band-14": 0.0,
-              "band-15": 0.0,
-              "band-16": 0.0
+              "band-1": 0.8619265270246962,
+              "band-2": 0.9111373714663897,
+              "band-3": 1.0,
+              "band-4": 1.0,
+              "band-5": 1.0,
+              "band-6": 1.0,
+              "band-7": 1.0,
+              "band-8": 1.0,
+              "band-9": 1.0,
+              "band-10": 1.0,
+              "band-11": 0.966622485026741,
+              "band-12": 0.9045897261284663,
+              "band-13": 0.7589172427637431,
+              "band-14": 0.7753614768129111,
+              "band-15": 0.6377056369264722,
+              "band-16": 0.5502911990678083
             },
             "children": {}
           }
@@ -15267,10 +13708,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 175.25984251968504,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15307,7 +13746,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15358,10 +13797,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15398,7 +13835,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15449,10 +13886,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15489,7 +13924,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15540,10 +13975,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15580,7 +14013,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15631,10 +14064,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15671,7 +14102,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15722,10 +14153,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15762,7 +14191,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15813,10 +14242,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -15854,7 +14281,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15905,10 +14332,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -15945,7 +14370,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -15996,10 +14421,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16036,7 +14459,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16087,10 +14510,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16127,7 +14548,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16178,10 +14599,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16218,7 +14637,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16269,10 +14688,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16309,7 +14726,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16360,10 +14777,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16400,7 +14815,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16451,10 +14866,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -16492,7 +14905,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16543,10 +14956,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16583,7 +14994,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16634,10 +15045,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16674,7 +15083,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16725,10 +15134,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16765,7 +15172,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16816,10 +15223,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16856,7 +15261,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16907,10 +15312,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -16947,7 +15350,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -16998,10 +15401,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17038,7 +15439,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17089,10 +15490,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17129,7 +15528,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17180,10 +15579,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17220,7 +15617,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17271,10 +15668,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17311,7 +15706,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17362,10 +15757,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17402,7 +15795,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17453,10 +15846,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -17495,7 +15886,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17546,10 +15937,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17586,7 +15975,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17637,10 +16026,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17677,7 +16064,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17728,10 +16115,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17768,7 +16153,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17819,10 +16204,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17859,7 +16242,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -17910,10 +16293,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -17950,7 +16331,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18001,10 +16382,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18041,7 +16420,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -18141,10 +16520,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 175.25984251968504,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18181,7 +16558,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18232,10 +16609,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18272,7 +16647,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18323,10 +16698,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18363,7 +16736,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18414,10 +16787,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18454,7 +16825,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18505,10 +16876,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18545,7 +16914,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18596,10 +16965,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18636,7 +17003,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18687,10 +17054,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -18728,7 +17093,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18779,10 +17144,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18819,7 +17182,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18870,10 +17233,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -18910,7 +17271,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -18961,10 +17322,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19001,7 +17360,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19052,10 +17411,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19092,7 +17449,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19143,10 +17500,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19183,7 +17538,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19234,10 +17589,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19274,7 +17627,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19325,10 +17678,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -19366,7 +17717,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19417,10 +17768,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19457,7 +17806,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19508,10 +17857,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19548,7 +17895,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19599,10 +17946,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19639,7 +17984,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19690,10 +18035,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19730,7 +18073,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19781,10 +18124,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19821,7 +18162,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19872,10 +18213,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -19912,7 +18251,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -19963,10 +18302,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20003,7 +18340,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20054,10 +18391,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20094,7 +18429,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20145,10 +18480,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20185,7 +18518,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20236,10 +18569,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20276,7 +18607,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20327,10 +18658,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -20369,7 +18698,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20420,10 +18749,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20460,7 +18787,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20511,10 +18838,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20551,7 +18876,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20602,10 +18927,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20642,7 +18965,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20693,10 +19016,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20733,7 +19054,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20784,10 +19105,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20824,7 +19143,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -20875,10 +19194,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -20915,7 +19232,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -21015,10 +19332,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 175.25984251968504,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21055,7 +19370,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21106,10 +19421,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21146,7 +19459,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21197,10 +19510,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21237,7 +19548,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21288,10 +19599,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21328,7 +19637,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21379,10 +19688,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21419,7 +19726,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21470,10 +19777,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21510,7 +19815,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21561,10 +19866,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -21602,7 +19905,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21653,10 +19956,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21693,7 +19994,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21744,10 +20045,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21784,7 +20083,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21835,10 +20134,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21875,7 +20172,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -21926,10 +20223,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -21966,7 +20261,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22017,10 +20312,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22057,7 +20350,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22108,10 +20401,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22148,7 +20439,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22199,10 +20490,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -22240,7 +20529,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22291,10 +20580,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22331,7 +20618,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22382,10 +20669,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22422,7 +20707,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22473,10 +20758,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22513,7 +20796,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22564,10 +20847,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22604,7 +20885,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22655,10 +20936,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22695,7 +20974,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22746,10 +21025,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22786,7 +21063,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22837,10 +21114,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22877,7 +21152,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -22928,10 +21203,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -22968,7 +21241,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23019,10 +21292,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23059,7 +21330,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23110,10 +21381,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23150,7 +21419,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23201,10 +21470,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -23243,7 +21510,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23294,10 +21561,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23334,7 +21599,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23385,10 +21650,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23425,7 +21688,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23476,10 +21739,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23516,7 +21777,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23567,10 +21828,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23607,7 +21866,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23658,10 +21917,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23698,7 +21955,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23749,10 +22006,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23789,7 +22044,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -23889,10 +22144,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 175.25984251968504,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -23929,7 +22182,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -23980,10 +22233,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24020,7 +22271,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24071,10 +22322,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24111,7 +22360,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24162,10 +22411,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24202,7 +22449,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24253,10 +22500,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24293,7 +22538,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24344,10 +22589,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24384,7 +22627,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24435,10 +22678,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -24476,7 +22717,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24527,10 +22768,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24567,7 +22806,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24602,7 +22841,7 @@
                   "te_speed": 0.21774714394182926,
                   "te_xpos": 0.0,
                   "te_ypos": 0.0,
-                  "te_size": 0.01,
+                  "te_size": 0.2,
                   "te_quantity": 7.0,
                   "te_spin": 0.014644781413556851,
                   "te_brightness": 1.0,
@@ -24618,10 +22857,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24658,7 +22895,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24709,10 +22946,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24749,7 +22984,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24800,10 +23035,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24840,7 +23073,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24891,10 +23124,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -24931,7 +23162,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -24982,10 +23213,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -25023,7 +23252,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25074,10 +23303,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25114,7 +23341,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25165,10 +23392,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25205,7 +23430,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25256,10 +23481,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25296,7 +23519,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25347,10 +23570,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25387,7 +23608,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25438,10 +23659,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25478,7 +23697,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25529,10 +23748,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25569,7 +23786,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25620,10 +23837,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25660,7 +23875,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25711,10 +23926,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25751,7 +23964,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25802,10 +24015,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25842,7 +24053,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25893,10 +24104,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -25933,7 +24142,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -25984,10 +24193,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26024,7 +24231,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26075,10 +24282,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -26117,7 +24322,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26168,10 +24373,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26208,7 +24411,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26259,10 +24462,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26299,7 +24500,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26350,10 +24551,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26390,7 +24589,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26441,10 +24640,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26481,7 +24678,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26532,10 +24729,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26572,7 +24767,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26623,10 +24818,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26663,7 +24856,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -26763,10 +24956,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26803,7 +24994,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26854,10 +25045,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26894,7 +25083,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -26945,10 +25134,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -26985,7 +25172,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27036,10 +25223,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27076,7 +25261,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27127,10 +25312,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27167,7 +25350,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27218,10 +25401,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27258,7 +25439,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27309,10 +25490,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27349,7 +25528,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27400,10 +25579,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -27441,7 +25618,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27492,10 +25669,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27532,7 +25707,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27583,10 +25758,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27623,7 +25796,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27674,10 +25847,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27714,7 +25885,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27765,10 +25936,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27805,7 +25974,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27856,10 +26025,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27896,7 +26063,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -27947,10 +26114,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -27987,7 +26152,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28038,10 +26203,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28078,7 +26241,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28129,10 +26292,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28169,7 +26330,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28220,10 +26381,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28260,7 +26419,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28311,10 +26470,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -28353,7 +26510,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28404,10 +26561,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28444,7 +26599,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28495,10 +26650,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28535,7 +26688,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28586,10 +26739,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28626,7 +26777,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28677,10 +26828,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28717,7 +26866,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28768,10 +26917,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28808,7 +26955,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28859,10 +27006,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28899,7 +27044,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -28950,10 +27095,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -28990,7 +27133,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -29090,10 +27233,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29130,7 +27271,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29181,10 +27322,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29221,7 +27360,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29272,10 +27411,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29312,7 +27449,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29363,10 +27500,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29403,7 +27538,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29454,10 +27589,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29494,7 +27627,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29545,10 +27678,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29585,7 +27716,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29636,10 +27767,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29676,7 +27805,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29727,10 +27856,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "width": 0.5
                 },
                 "children": {
@@ -29768,7 +27895,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29819,10 +27946,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29859,7 +27984,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -29910,10 +28035,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -29950,7 +28073,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30001,10 +28124,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30041,7 +28162,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30092,10 +28213,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30132,7 +28251,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30183,10 +28302,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30223,7 +28340,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30274,10 +28391,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30314,7 +28429,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30365,10 +28480,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30405,7 +28518,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30456,10 +28569,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30496,7 +28607,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30547,10 +28658,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30587,7 +28696,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30638,10 +28747,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -30680,7 +28787,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30731,10 +28838,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30771,7 +28876,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30822,10 +28927,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30862,7 +28965,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -30913,10 +29016,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -30953,7 +29054,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -31004,10 +29105,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31044,7 +29143,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -31095,10 +29194,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31135,7 +29232,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -31186,10 +29283,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31226,7 +29321,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -31277,10 +29372,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31317,7 +29410,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -31597,10 +29690,8 @@
                   "te_color/saturation": 0.0,
                   "te_color/hue": 359.0,
                   "te_color/solidSource": 0,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31637,7 +29728,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -31796,10 +29887,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -31836,7 +29925,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -32017,10 +30106,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32057,7 +30144,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32108,10 +30195,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32148,7 +30233,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32199,10 +30284,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32239,7 +30322,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32290,10 +30373,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32452,7 +30533,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32503,10 +30584,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32543,7 +30622,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32594,10 +30673,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "enableEdges": true,
                   "enablePanels": true
                 },
@@ -32636,7 +30713,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32687,10 +30764,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32727,7 +30802,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32778,10 +30853,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32818,7 +30891,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32869,10 +30942,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -32909,7 +30980,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -32960,10 +31031,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33000,7 +31069,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33051,10 +31120,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33091,7 +31158,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33142,10 +31209,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33182,7 +31247,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33233,10 +31298,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33273,7 +31336,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -33374,10 +31437,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33414,7 +31475,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33465,10 +31526,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33505,7 +31564,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33556,10 +31615,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33596,7 +31653,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33647,10 +31704,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33687,7 +31742,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33738,10 +31793,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33778,7 +31831,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33829,10 +31882,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33869,7 +31920,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -33920,10 +31971,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -33960,7 +32009,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34011,10 +32060,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34051,7 +32098,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34102,10 +32149,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34142,7 +32187,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34193,10 +32238,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34233,7 +32276,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34284,10 +32327,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "noise": 2.0,
                   "noise2": 2.0
                 },
@@ -34326,7 +32367,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34377,10 +32418,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34417,7 +32456,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34468,10 +32507,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34508,7 +32545,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -34559,10 +32596,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -34599,7 +32634,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -34952,10 +32987,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "enableEdges": false,
                   "enablePanels": true
                 },
@@ -34994,7 +33027,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35045,10 +33078,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "hideBlocks": false,
                   "speed": 0.7,
                   "ySpread": 1.6,
@@ -35090,7 +33121,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35141,10 +33172,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35181,7 +33210,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35232,10 +33261,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35272,7 +33299,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35323,10 +33350,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35363,7 +33388,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35414,10 +33439,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35454,7 +33477,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35505,15 +33528,13 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
-                  "Double Speed": false,
                   "Glow": 0.1,
-                  "Width": 0.5,
+                  "Double Speed": false,
+                  "Double Layer": false,
                   "Energy": 0.0,
-                  "Double Layer": false
+                  "Width": 0.5
                 },
                 "children": {
                   "modulation": {
@@ -35550,7 +33571,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35601,10 +33622,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35641,7 +33660,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35692,10 +33711,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35732,7 +33749,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35783,10 +33800,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35823,7 +33838,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -35874,10 +33889,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -35914,7 +33927,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36030,10 +34043,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
                   "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5,
                   "enableEdges": true,
                   "enablePanels": true
                 },
@@ -36072,7 +34083,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36123,10 +34134,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36163,7 +34172,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36214,10 +34223,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36254,7 +34261,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36305,10 +34312,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36345,7 +34350,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36396,10 +34401,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36436,7 +34439,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36487,10 +34490,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36527,7 +34528,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36578,10 +34579,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36618,7 +34617,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -36669,10 +34668,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 1,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -36709,7 +34706,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -37032,10 +35029,8 @@
                   "te_color/saturation": 0.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 0,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -37072,7 +35067,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -37364,10 +35359,8 @@
                   "te_color/saturation": 0.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 0,
-                  "te_color/gradient": 2,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -37404,7 +35397,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -37455,10 +35448,8 @@
                   "te_color/saturation": 0.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 0,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.5
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -37495,7 +35486,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               }
@@ -37596,10 +35587,8 @@
                   "te_color/saturation": 100.0,
                   "te_color/hue": 0.0,
                   "te_color/solidSource": 0,
-                  "te_color/gradient": 0,
                   "te_color/blendMode": 0,
-                  "te_color/offset": 0.0,
-                  "te_color/color2offset": 0.4847656451165676
+                  "te_color/offset": 0.0
                 },
                 "children": {
                   "modulation": {
@@ -37636,7 +35625,7 @@
                   "/te_wow1",
                   "/te_wow2",
                   "/te_wowtrigger",
-                  null
+                  "/te_color/offset"
                 ],
                 "effects": []
               },
@@ -37963,7 +35952,7 @@
               "exp": 0.0
             },
             "children": {},
-            "basis": 0.895346463229705
+            "basis": 0.6585480942668032
           }
         ],
         "modulations": [
@@ -38177,33 +36166,6 @@
               "toggleMode": 0,
               "momentaryToggleMode": 0,
               "toggleMomentaryMode": 0
-            },
-            "children": {}
-          },
-          {
-            "source": {
-              "componentId": 111303,
-              "parameterPath": "macro1",
-              "path": "/modulation/modulator/1/macro1"
-            },
-            "target": {
-              "componentId": 44722,
-              "parameterPath": "recall",
-              "path": "/palette/swatches/11/recall"
-            },
-            "id": 111318,
-            "class": "heronarts.lx.modulation.LXTriggerModulation",
-            "internal": {
-              "modulationColor": 0,
-              "modulationControlsExpanded": true,
-              "modulationsExpanded": true
-            },
-            "parameters": {
-              "label": "LX",
-              "enabled": true,
-              "toggleMode": 0,
-              "momentaryToggleMode": 0,
-              "toggleMomentaryMode": 1
             },
             "children": {}
           },
@@ -38570,23 +36532,23 @@
           "hue": 0.0,
           "saturation": 100.0,
           "brightness": 100.0,
-          "paletteStrategy": 4,
+          "paletteStrategy": 0,
           "color1/brightness": 100.0,
           "color1/saturation": 100.0,
           "color1/hue": 0.0,
           "color2/brightness": 100.0,
           "color2/saturation": 100.0,
-          "color2/hue": 180.0,
-          "color3/brightness": 0.0,
+          "color2/hue": 0.0,
+          "color3/brightness": 100.0,
           "color3/saturation": 100.0,
-          "color3/hue": 240.0,
+          "color3/hue": 0.0,
           "pushSwatch": false,
           "pinSwatch": false
         },
         "children": {}
       },
       "focus": {
-        "id": 126,
+        "id": 125,
         "class": "titanicsend.osc.CrutchOSC",
         "internal": {
           "modulationColor": 0,
@@ -38599,7 +36561,7 @@
         "children": {}
       },
       "director": {
-        "id": 127,
+        "id": 126,
         "class": "titanicsend.app.director.Director",
         "internal": {
           "modulationColor": 0,
@@ -38622,7 +36584,7 @@
   },
   "externals": {
     "ui": {
-      "leftPaneActiveSection": 1,
+      "leftPaneActiveSection": 2,
       "audioExpanded": true,
       "envelopExpanded": true,
       "reaperExpanded": true,
@@ -38640,7 +36602,7 @@
         "depth": 1.0,
         "camera": {
           "active": false,
-          "radius": 544.0729208867624,
+          "radius": 557.9291896215981,
           "theta": 6.427118362626061,
           "phi": 8.774992830585688,
           "x": 164.61456254054792,
@@ -38650,7 +36612,7 @@
         "cue": [
           {
             "active": false,
-            "radius": 544.0729208867624,
+            "radius": 557.9291896215981,
             "theta": 6.427118362626061,
             "phi": 8.774992830585688,
             "x": 164.61456254054792,

--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -42,6 +42,7 @@ import titanicsend.audio.AudioStemModulator;
 import titanicsend.audio.AudioStems;
 import titanicsend.audio.UIAudioStems;
 import titanicsend.color.ColorPaletteManager;
+import titanicsend.color.TEGradientSource;
 import titanicsend.dmx.DmxEngine;
 import titanicsend.dmx.effect.BeaconStrobeEffect;
 import titanicsend.dmx.pattern.BeaconDirectPattern;
@@ -180,6 +181,8 @@ public class TEApp extends LXStudio {
       } else {
         this.paletteManagerB = null;
       }
+
+      new TEGradientSource(lx);
 
       // create our loop task for outputting data to lasers
       this.laserTask = new TELaserTask(lx);

--- a/src/main/java/titanicsend/color/ColorPaletteManager.java
+++ b/src/main/java/titanicsend/color/ColorPaletteManager.java
@@ -20,6 +20,7 @@ public class ColorPaletteManager extends LXComponent {
 
   public static final String DEFAULT_SWATCH_NAME = "SWATCH A";
   public static final int DEFAULT_SWATCH_INDEX = 0;
+  public static final int SWATCH_COLORS = 3;
 
   public enum PaletteStrategy {
     MONO,
@@ -139,8 +140,8 @@ public class ColorPaletteManager extends LXComponent {
     }
     this.managedSwatch = this.lx.engine.palette.swatches.get(this.swatchIndex);
     this.managedSwatch.label.setValue(this.swatchName);
-    if (this.managedSwatch.colors.size() < LXSwatch.MAX_COLORS) {
-      for (int i = this.managedSwatch.colors.size(); i < LXSwatch.MAX_COLORS; ++i) {
+    if (this.managedSwatch.colors.size() < SWATCH_COLORS) {
+      for (int i = this.managedSwatch.colors.size(); i < SWATCH_COLORS; ++i) {
         this.managedSwatch.addColor();
       }
       // TODO: set the first two TEColorTypes, background and transition
@@ -198,7 +199,7 @@ public class ColorPaletteManager extends LXComponent {
     refreshManagedSwatch();
     setColorAtPosition(TEColorType.PRIMARY, this.color1.getColor());
     setColorAtPosition(TEColorType.SECONDARY, this.color2.getColor());
-    setColorAtPosition(TEColorType.SECONDARY_BACKGROUND, this.color3.getColor());
+    setColorAtPosition(TEColorType.TERTIARY, this.color3.getColor());
   }
 
   private void setColorAtPosition(TEColorType teColorType, int color) {

--- a/src/main/java/titanicsend/color/TEColorType.java
+++ b/src/main/java/titanicsend/color/TEColorType.java
@@ -4,13 +4,9 @@ package titanicsend.color;
 // https://docs.google.com/document/d/16FGnQ8jopCGwQ0qZizqILt3KYiLo0LPYkDYtnYzY7gI/edit
 public enum TEColorType {
   // These are 1-based UI indices; to get to a 0-based palette swatch index, subtract 1
-  BACKGROUND(1), // Background color - should usually be black or transparent
-  TRANSITION(2), // Transitions a background to the primary, commonly just the background again
-  PRIMARY(3), // Primary color of any edge or panel pattern
-  SECONDARY(4), // Secondary color; optional, commonly set to SECONDARY_BACKGROUND or PRIMARY
-  SECONDARY_BACKGROUND(
-      5); // Background color if transitioning from SECONDARY. Commonly set to same color as
-  // BACKGROUND.
+  PRIMARY(1), // Primary color of any edge or panel pattern
+  SECONDARY(2), // Secondary color; optional, commonly set to SECONDARY_BACKGROUND or PRIMARY
+  TERTIARY(3); // 3rd color, now that ColorPaletteManager sometimes provides three
 
   public final int index; // The UI index (1-indexed)
 

--- a/src/main/java/titanicsend/color/TEGradient.java
+++ b/src/main/java/titanicsend/color/TEGradient.java
@@ -1,10 +1,8 @@
 package titanicsend.color;
 
 public enum TEGradient {
-  FULL_PALETTE("Full Palette"),
-  PRIMARY("Primary"),
-  SECONDARY("Secondary"),
-  FOREGROUND("Foreground");
+  NORMAL("Normal"),
+  DARK("Dark");
 
   public final String label;
 

--- a/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import titanicsend.color.TEColorParameter;
+import titanicsend.color.TEGradientSource;
 import titanicsend.pattern.jon.TEControl;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.jon._CommonControlGetter;
@@ -362,7 +363,6 @@ public class TECommonControls {
   protected void setRemoteControls() {
     this.pattern.setCustomRemoteControls(
         new LXListenableNormalizedParameter[] {
-          //this.color.offset,
           //this.color.gradient,
           getControl(TEControlTag.LEVELREACTIVITY).control,
           getControl(TEControlTag.FREQREACTIVITY).control,
@@ -379,14 +379,15 @@ public class TECommonControls {
           getControl(TEControlTag.WOW1).control,
           getControl(TEControlTag.WOW2).control,
           getControl(TEControlTag.WOWTRIGGER).control,
-          null  // former shader-specific explode control
+          this.color.offset
+          // former shader-specific explode control
           // To be SHIFT, not implemented yet
         });
   }
 
   protected TEColorParameter registerColorControl(String prefix) {
     color =
-        new TEColorParameter(this.pattern.gradientSource, prefix + "Color")
+        new TEColorParameter(TEGradientSource.get(), prefix + "Color")
             .setDescription("TE Color");
     // "addParameter(java.lang.String, heronarts.lx.parameter.LXParameter)' has protected access in
     // 'heronarts.lx.LXComponent'"
@@ -400,11 +401,9 @@ public class TECommonControls {
    */
   protected void onPanic() {
     // For color, reset everything but Hue
-    this.color.gradient.reset();
     this.color.blendMode.reset();
-    this.color.solidSource.reset();
+    this.color.colorSource.reset();
     this.color.offset.reset();
-    this.color.color2offset.reset();
     this.color.saturation.setNormalized(1);
     this.color.brightness.setNormalized(1);
 

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -12,14 +12,11 @@ import heronarts.lx.model.LXPoint;
 import heronarts.lx.studio.TEApp;
 import java.util.*;
 import titanicsend.color.TEColorType;
-import titanicsend.color.TEGradientSource;
 import titanicsend.dmx.pattern.DmxPattern;
-import titanicsend.lx.LXGradientUtils;
 import titanicsend.model.TELaserModel;
 import titanicsend.model.TEPanelModel;
 import titanicsend.model.TEWholeModel;
 import titanicsend.util.TEColor;
-import titanicsend.util.TEMath;
 
 public abstract class TEPattern extends DmxPattern {
   private final TEPanelModel sua;
@@ -31,21 +28,12 @@ public abstract class TEPattern extends DmxPattern {
     return this.modelTE;
   }
 
-  // TODO(JKB): we could have one of these, instead of one per pattern.
-  protected final TEGradientSource gradientSource = new TEGradientSource();
-
   protected TEPattern(LX lx) {
     super(lx);
-    // NOTE(mcslee): in newer LX version, colors array does not exist at instantiation
-    // time. If this call was truly necessary, it will need to be refactored to happen elsewhere
-    // this.clearPixels();
-
     this.modelTE = TEApp.wholeModel;
 
     this.sua = this.modelTE.getPanel("SUA");
     this.sdc = this.modelTE.getPanel("SDC");
-
-    updateGradients();
   }
 
   @Override
@@ -79,24 +67,6 @@ public abstract class TEPattern extends DmxPattern {
   }
 
   /**
-   * Given a value in 0..1 (and wrapped back outside that range) Return a color within the
-   * primaryGradient
-   *
-   * @param lerp as a frac
-   * @return LXColor
-   */
-  @Deprecated
-  public int getPrimaryGradientColor(float lerp) {
-    /* HSV2 mode wraps returned colors around the color wheel via the shortest
-     * hue distance. In other words, we usually want a gradient to go from yellow
-     * to red via orange, not via lime, green, cyan, blue, purple, red.
-     */
-    return this.gradientSource.primaryGradient.getColor(
-        TEMath.trianglef(lerp / 2), // Allow wrapping
-        LXGradientUtils.BlendMode.HSVM.function);
-  }
-
-  /**
    * Get a ColorType's color from the Swatch
    *
    * @param type
@@ -104,11 +74,6 @@ public abstract class TEPattern extends DmxPattern {
    */
   public int getSwatchColor(TEColorType type) {
     return lx.engine.palette.getSwatchColor(type.swatchIndex()).getColor();
-  }
-
-  /** Refresh gradients from the global palette */
-  protected void updateGradients() {
-    this.gradientSource.updateGradients(this.lx.engine.palette.swatch);
   }
 
   // During construction, make gap points show up in red

--- a/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -433,7 +433,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
     speedRotor.updateAngle(iTime.getTime(), value);
 
     // Gradients always need to be up to date for TEColorParameter
-    updateGradients();
     expireColors();
 
     super.run(deltaMs);

--- a/src/main/java/titanicsend/pattern/jeff/ArtStandards.java
+++ b/src/main/java/titanicsend/pattern/jeff/ArtStandards.java
@@ -8,8 +8,11 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.utils.LXUtils;
+import titanicsend.color.TEGradientSource;
+import titanicsend.lx.LXGradientUtils;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.pattern.TEAudioPattern;
+import titanicsend.util.TEMath;
 
 /**
  * This edge pattern aims to apply all our art standards as documented:
@@ -40,6 +43,24 @@ public class ArtStandards extends TEAudioPattern {
     addParameter("energy", energy);
   }
 
+  /**
+   * Given a value in 0..1 (and wrapped back outside that range) Return a color within the
+   * primaryGradient
+   *
+   * @param lerp as a frac
+   * @return LXColor
+   */
+  @Deprecated
+  public int getPrimaryGradientColor(float lerp) {
+    /* HSV2 mode wraps returned colors around the color wheel via the shortest
+     * hue distance. In other words, we usually want a gradient to go from yellow
+     * to red via orange, not via lime, green, cyan, blue, purple, red.
+     */
+    return TEGradientSource.get().darkGradient.getColor(
+      TEMath.trianglef(lerp / 2), // Allow wrapping
+      LXGradientUtils.BlendMode.HSVM.function);
+  }
+
   public void runTEAudioPattern(double deltaMs) {
     /* Inside run(), and before iterating over the LED points, we want to do
      * anything that should be done only once per frame. We're targeting about
@@ -53,9 +74,7 @@ public class ArtStandards extends TEAudioPattern {
      */
 
     // Art standard: Respect the palette
-    // We'll use the `primaryGradient` that TEPattern provides. In case the
-    // palette has changed or is transitioning, this gets the new values.
-    updateGradients();
+    // We'll use the `primaryGradient` that TEPattern provides.
 
     /* Art standard: Use the tempo
      * `measure` is a 0..1 normalized ramp (fraction) into the current

--- a/src/main/java/titanicsend/pattern/jon/FrameBrights.java
+++ b/src/main/java/titanicsend/pattern/jon/FrameBrights.java
@@ -102,8 +102,6 @@ public class FrameBrights extends TEAudioPattern {
   }
 
   public void runTEAudioPattern(double deltaMs) {
-    updateGradients();
-
     // sync lit segment selection changes to measures, and
     // light pulses to the beat.
     float currentCycle = (float) measure();

--- a/src/main/java/titanicsend/pattern/mike/EdgeRunner.java
+++ b/src/main/java/titanicsend/pattern/mike/EdgeRunner.java
@@ -71,7 +71,7 @@ public class EdgeRunner extends TEPattern implements TEListener {
 
   public final LinkedColorParameter fillColor =
       registerColor(
-          "Fill", "fillColor", TEColorType.SECONDARY_BACKGROUND, "Color to fill the panels with");
+          "Fill", "fillColor", TEColorType.TERTIARY, "Color to fill the panels with");
 
   public EdgeRunner(LX lx) {
     super(lx);

--- a/src/main/java/titanicsend/ui/UITEPerformancePattern.java
+++ b/src/main/java/titanicsend/ui/UITEPerformancePattern.java
@@ -88,8 +88,8 @@ public class UITEPerformancePattern
     // the Chromatik window.
     params.add(null);
     params.add(null);
-    params.add(device.getControls().color.offset);
-    params.add(device.getControls().color.gradient);
+    params.add(null);
+    params.add(null);
 
     // slight hack to add source select and gain controls for NDI patterns without
     // replicating all this UI code...


### PR DESCRIPTION
Pulls our `TEColorParameter` off the bench and revamps it to be a color offset [within a gradient of the current global palette/swatch].  Also tuned up related color things while we were under the knife:

- Moved gradient calculations to happen ONCE at a global level instead of EVERY PATTERN.  This might be a measurable performance improvement.
- Removed swatch colors from indexes [0,1,4] that were black.  We can construct dark gradients without those now.
- Simplified our gradient options to "Normal" and "Dark".  The previous options were too advanced / not intuitive enough to get any use.
- `TEColorParameter`: removed some clutter including `Offset2`
- `TEColorParameter`: combined "Static Color" and "Gradient" into a single "Color Source"
- Moved the color parameter back onto the MidiFighterTwister.  I picked a random spot of bottom right.
- Added a badass new preview icon for the color parameter.  It shows the gradient and moves a triangle above and below the gradient to indicate the Offset value.  Now you can see if it's at the beginning or middle of the gradient:
<img width="56" alt="image" src="https://github.com/user-attachments/assets/d6531395-56f9-4a44-9799-fbd6e55351c1">
