### PR TITLE
Set shader rendering resolution from TEApp command line

### DIFF
--- a/resources/shaders/ringofire.fs
+++ b/resources/shaders/ringofire.fs
@@ -1,0 +1,74 @@
+// Experimental fire for Mothership
+#pragma name "RingOfFire"
+#pragma TEControl.SIZE.Range(0.91,1.15,0.8)
+#pragma TECONTROL.SPEED.Value(0.64)
+
+#pragma TEControl.QUANTITY.Disable
+#pragma TEControl.WOWTRIGGER.Disable
+#pragma TEControl.WOW2.Disable
+#pragma TEControl.WOW1.Disable
+
+#include <include/constants.fs>
+#include <include/colorspace.fs>
+
+// generate 2D rotation matrix
+mat2 r2d(float a) {
+    float c=cos(a),s=sin(a);
+    return mat2(c, s, -s, c);
+}
+
+// cheap 3D simplex noise from Shadertoy
+// TODO - use texture-based noise fn instead.
+float snoise(vec3 uv, float res) {
+    const vec3 s = vec3(1.0, 10.0, 100.0);
+    uv *= res;
+
+    vec3 uv0 = floor(mod(uv, res))*s;
+    vec3 uv1 = floor(mod(uv+vec3(1.), res))*s;
+
+    vec3 f = fract(uv); f = f*f*(3.0-2.0*f);
+
+    vec4 v = vec4(uv0.x+uv0.y+uv0.z, uv1.x+uv0.y+uv0.z,
+    uv0.x+uv1.y+uv0.z, uv1.x+uv1.y+uv0.z);
+
+    vec4 r = fract(sin(v*1e-1)*1e3);
+    float r0 = mix(mix(r.x, r.y, f.x), mix(r.z, r.w, f.x), f.y);
+
+    r = fract(sin((v + uv1.z - uv0.z)*1e-1)*1e3);
+    float r1 = mix(mix(r.x, r.y, f.x), mix(r.z, r.w, f.x), f.y);
+
+    return mix(r0, r1, f.z)*2.-1.;
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    vec2 p = -.5 + fragCoord.xy / iResolution.xy;
+    //p.x *= iResolution.x/iResolution.y;
+
+    p *= r2d(iRotationAngle);
+    p *= iScale;
+
+    // convert to polar coordinates, scaled to fit the
+    // Mothership's ring.
+    vec3 coord = vec3(atan(p.x,p.y)/TAU+.5, length(p)*.4, .5);
+
+    // Generate a few octaves of animated noise for the fire
+    // Lower waves have more weight, higher have more detail
+    float color = 3.0 - (3.*length(2.*p));
+    for(int i = 1; i <= 7; i++) {
+        float p2 = pow(2.0, float(i));
+        color += (.5 / p2) * snoise(coord + vec3(0.,-iTime*.05, -iTime*.01), p2*16.);
+    }
+    color = clamp(color, 0., 1.);
+
+    // adjust color for more variation
+    vec3 hsb = iColorHSB;
+
+    // just a tiny shift in hue gives the fire more life
+    hsb.x += 0.08 * color;
+    // saturation -- hotter (brighter) is whiter
+    hsb.y = 1.5 - color * color;
+    // n.b.- we leave value where it was in the palette color
+    // let alpha handle brightness
+
+    fragColor = vec4(hsv2rgb(hsb), color);
+}

--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -123,6 +123,12 @@ public class TEApp extends LXStudio {
   private static int WINDOW_HEIGHT = 800;
   private static String resourceSubdir;
 
+  // Default shader system rendering canvas
+  // resolution.  May be changed via the startup
+  // command line argument --resolution=WIDTHxHEIGHT
+  public static int glRenderWidth = 640;
+  public static int glRenderHeight = 480;
+
   @LXPlugin.Name("Titanic's End")
   public static class Plugin implements LXStudio.Plugin, LX.Listener, LX.ProjectListener {
 
@@ -172,7 +178,7 @@ public class TEApp extends LXStudio {
 
       this.dmxEngine = new DmxEngine(lx);
       this.ndiEngine = new NDIEngine(lx);
-      this.glEngine = new GLEngine(lx,staticModel);
+      this.glEngine = new GLEngine(lx,glRenderWidth,glRenderHeight,staticModel);
 
       lx.engine.registerComponent("audioStems", this.audioStems = new AudioStems(lx));
       lx.engine.registerComponent("paletteManagerA", this.paletteManagerA = new ColorPaletteManager(lx));
@@ -776,6 +782,25 @@ public class TEApp extends LXStudio {
         loadVehicle = true;
       } else if (arg.equals("dynamic")) {
         staticModel = false;
+      } else if (arg.equals("--resolution")) {
+        // Parse shader rendering resolution from command line. Resolution is specified as a string
+        // in the format "WIDTHxHEIGHT" where WIDTH and HEIGHT are integers. (e.g. "640x480")
+        if (i + 1 < args.length) {
+          String[] resolution = args[i + 1].split("x");
+          if (resolution.length == 2) {
+            try {
+              glRenderWidth = Integer.parseInt(resolution[0]);
+              glRenderHeight = Integer.parseInt(resolution[1]);
+              i++; // let the rest of the parser skip the resolution argument
+            } catch (NumberFormatException nfx) {
+              error("Invalid render resolution: " + args[i + 1]);
+            }
+          } else {
+            error("Invalid render resolution: " + args[i + 1]);
+          }
+        } else {
+          error("Missing render resolution");
+        }
       } else {
         error("Unrecognized CLI argument, ignoring: " + arg);
       }

--- a/src/main/java/titanicsend/pattern/glengine/GLEngine.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEngine.java
@@ -10,6 +10,7 @@ import heronarts.lx.LXComponent;
 import heronarts.lx.LXLoopTask;
 import heronarts.lx.audio.GraphicMeter;
 import titanicsend.pattern.yoffa.shader_engine.ShaderUtils;
+import titanicsend.util.TE;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,9 +23,10 @@ import static com.jogamp.opengl.GL.*;
 public class GLEngine extends LXComponent implements LXLoopTask {
   public static final String PATH = "GLEngine";
 
-  // default canvas size
-  private static final int xSize = 640;
-  private static final int ySize = 480;
+  // rendering canvas size.  May be changed
+  // via the startup command line.
+  private static int xSize;
+  private static int ySize;
 
   // audio texture size and buffer
   private static final int audioTextureWidth = 512;
@@ -62,7 +64,10 @@ public class GLEngine extends LXComponent implements LXLoopTask {
   // and need to swap the x and z axes.
   // TODO - remove when we move to dynamic model
   private final boolean isStatic;
-  public boolean isStaticModel() { return isStatic; }
+
+  public boolean isStaticModel() {
+    return isStatic;
+  }
 
   public GLAutoDrawable getCanvas() {
     return canvas;
@@ -220,7 +225,11 @@ public class GLEngine extends LXComponent implements LXLoopTask {
         audioTextureData);
   }
 
-  public GLEngine(LX lx,boolean isStaticModel) {
+  public GLEngine(LX lx, int width, int height,  boolean isStaticModel) {
+    // save rendering canvas dimensions
+    this.xSize = width;
+    this.ySize = height;
+    TE.log("GLEngine: Rendering canvas size: " + xSize + "x" + ySize);
 
     // register glEngine so we can access it from patterns.
     // and add it as an engine task for audio analysis and buffer management


### PR DESCRIPTION
You can now use the command line option `--resolution WIDTHxHEIGHT` to specify a rendering resolution for the shader system.  

This helps tremendously in cases where we're dealing with a larger multi-car model, or where the aspect ratio of the model is significantly different from the original Titanic's End car (which is roughly 4:3).  For example, the Mothership has a 1:1 aspect ratio, and will look better with `--resolution 512x512` or some other square resolution.   

For now there are no limits on how low or how high you can go.  But be aware, higher resolutions can have a large impact on performance.  