### PR TITLE
Director APCminiMk2: improve name for local device

### DIFF
--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -363,6 +363,8 @@ public class TEApp extends LXStudio {
         MidiNames.BOMEBOX_APC40MK2, APC40Mk2.class);
       // The Director midi surface must be registered *after* the Director and ColorPaletteManager
       lx.engine.midi.registerSurface(
+        MidiNames.APCMINIMK2_DIRECTOR, DirectorAPCminiMk2.class);
+      lx.engine.midi.registerSurface(
         MidiNames.BOMEBOX_VIRTUAL_APCMINIMK2_DIRECTOR, DirectorAPCminiMk2.class);
       lx.engine.midi.registerSurface(
         MidiNames.BOMEBOX_MIDIFIGHTERTWISTER1, MidiFighterTwister.class);

--- a/src/main/java/titanicsend/lx/DirectorAPCminiMk2.java
+++ b/src/main/java/titanicsend/lx/DirectorAPCminiMk2.java
@@ -48,7 +48,9 @@ import titanicsend.util.TE;
  */
 public class DirectorAPCminiMk2 extends LXMidiSurface implements LXMidiSurface.Bidirectional {
 
-  public static final String DEVICE_NAME = "APC mini mk2 (Director) Control";
+  // To use locally, rename system device to match LOCAL_DEVICE_NAME
+  public static final String LOCAL_DEVICE_NAME = "Director";
+  public static final String DEVICE_NAME = LOCAL_DEVICE_NAME + " Control";
 
   public static final boolean EXPORT_GRID_TO_CSV = false;
 


### PR DESCRIPTION
It will now work to rename the local device to "Director" in MIDI Studio.

In the end this presents to Chromatik differently than the Bomebox virtual midi port.  The virtual port comes across as "Director" while the local one appears as "Director Control".