### PR TITLE
Mothership - Startup looks + new shaders

### DIFF
--- a/Models/Mothership_car.lxm
+++ b/Models/Mothership_car.lxm
@@ -1,6 +1,6 @@
 {
-  "version": "1.0.1.TE.1-SNAPSHOT",
-  "timestamp": 1723319742744,
+  "version": "1.0.1.TE.2-SNAPSHOT",
+  "timestamp": 1723666671027,
   "fixtures": [
     {
       "jsonFixtureType": "Mothership/window/Ramp",
@@ -107,7 +107,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice01P"
@@ -226,7 +226,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice02P"
@@ -342,7 +342,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice03P"
@@ -461,7 +461,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice04P"
@@ -581,7 +581,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice05P"
@@ -703,7 +703,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice06P"
@@ -825,7 +825,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice07P"
@@ -947,7 +947,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice08P"
@@ -1069,7 +1069,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice09P"
@@ -1191,7 +1191,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice10P"
@@ -1313,7 +1313,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice11P"
@@ -1435,7 +1435,7 @@
         "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": false,
+        "mute": true,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice12P"
@@ -1554,7 +1554,7 @@
         "scale": 1.0,
         "selected": false,
         "deactivate": false,
-        "enabled": false,
+        "enabled": true,
         "brightness": 1.0,
         "identify": false,
         "mute": true,
@@ -1615,10 +1615,10 @@
         "scale": 1.0,
         "selected": false,
         "deactivate": false,
-        "enabled": false,
+        "enabled": true,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice13S"
@@ -1676,7 +1676,7 @@
         "scale": 1.0,
         "selected": false,
         "deactivate": false,
-        "enabled": false,
+        "enabled": true,
         "brightness": 1.0,
         "identify": false,
         "mute": true,
@@ -1740,7 +1740,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice14S"
@@ -1862,7 +1862,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice15S"
@@ -1980,7 +1980,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice16S"
@@ -2102,7 +2102,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice17S"
@@ -2224,7 +2224,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice18S"
@@ -2346,7 +2346,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice19S"
@@ -2468,7 +2468,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice20S"
@@ -2586,7 +2586,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice21S"
@@ -2708,7 +2708,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice22S"
@@ -2830,7 +2830,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice23S"
@@ -2952,7 +2952,7 @@
         "enabled": false,
         "brightness": 1.0,
         "identify": false,
-        "mute": true,
+        "mute": false,
         "solo": false,
         "tags": "",
         "fixtureType": "Mothership/window/Slice24S"

--- a/Projects/MShipStartupLooks.lxp
+++ b/Projects/MShipStartupLooks.lxp
@@ -1,0 +1,10566 @@
+{
+  "version": "1.0.1.TE.2-SNAPSHOT",
+  "timestamp": 1723666528594,
+  "model": {
+    "id": 2,
+    "class": "heronarts.lx.structure.LXStructure",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true,
+      "showNormalizationBounds": false
+    },
+    "parameters": {
+      "label": "LX",
+      "syncModelFile": true,
+      "allWhite": false,
+      "mute": false,
+      "normalizationMode": 0,
+      "normalizationX": 0.0,
+      "normalizationY": 0.0,
+      "normalizationZ": 0.0,
+      "normalizationWidth": 1000.0,
+      "normalizationHeight": 1000.0,
+      "normalizationDepth": 1000.0
+    },
+    "children": {
+      "views": {
+        "id": 3,
+        "class": "heronarts.lx.structure.view.LXViewEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX"
+        },
+        "children": {},
+        "views": [
+          {
+            "id": 264053,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Window",
+              "enabled": true,
+              "selector": "window*",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          }
+        ]
+      }
+    },
+    "output": {
+      "id": 4,
+      "class": "heronarts.lx.structure.LXStructureOutput",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Output",
+        "enabled": true,
+        "brightness": 1.0,
+        "fps": 0.0,
+        "gamma": 1.0,
+        "gammaMode": 1,
+        "whitePointRed": 255,
+        "whitePointGreen": 255,
+        "whitePointBlue": 255,
+        "whitePointWhite": 255
+      },
+      "children": {}
+    },
+    "fixtures": [
+      {
+        "jsonFixtureType": "Mothership/window/Ramp",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "angle": 0.0,
+          "onCar": true,
+          "outputP1W9": 6,
+          "outputS2W9": 7,
+          "outputP2W9": 8,
+          "outputS3W9": 3,
+          "outputP3W9": 2,
+          "outputS4W9": 4,
+          "artnetSequence": false,
+          "p1w9extraLEDs": 0,
+          "p1w9ledOffset": 0,
+          "s2w9extraLEDs": 0,
+          "s2w9ledOffset": 0,
+          "p2w9extraLEDs": 0,
+          "p2w9ledOffset": 0,
+          "s3w9extraLEDs": 0,
+          "s3w9ledOffset": 0,
+          "p3w9extraLEDs": 0,
+          "p3w9ledOffset": 0,
+          "s4w9extraLEDs": 0,
+          "s4w9ledOffset": 0
+        },
+        "id": 131283,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Ramp",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": true,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Ramp"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice01P",
+        "jsonParameters": {
+          "host": "10.128.42.46",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 1
+        },
+        "id": 131338,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 01P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice01P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice01S",
+        "jsonParameters": {
+          "host": "10.128.42.28",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 1
+        },
+        "id": 131415,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 01S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice01S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice02P",
+        "jsonParameters": {
+          "host": "10.128.42.10",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 2
+        },
+        "id": 131492,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 02P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice02P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice02S",
+        "jsonParameters": {
+          "host": "10.128.42.50",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 2
+        },
+        "id": 131569,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 02S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice02S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice03P",
+        "jsonParameters": {
+          "host": "10.128.42.44",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 3
+        },
+        "id": 131646,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 03P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice03P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice03S",
+        "jsonParameters": {
+          "host": "10.128.42.43",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 3
+        },
+        "id": 131723,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 03S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice03S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice04P",
+        "jsonParameters": {
+          "host": "10.128.42.42",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 4
+        },
+        "id": 131800,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 04P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice04P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice04S",
+        "jsonParameters": {
+          "host": "10.128.42.45",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "radial": 4
+        },
+        "id": 131877,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 04S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice04S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice05P",
+        "jsonParameters": {
+          "host": "10.128.42.35",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 5
+        },
+        "id": 131954,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 05P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice05P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice05S",
+        "jsonParameters": {
+          "host": "10.128.42.13",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 5
+        },
+        "id": 132031,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 05S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice05S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice06P",
+        "jsonParameters": {
+          "host": "10.128.42.15",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 6
+        },
+        "id": 132108,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 06P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice06P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice06S",
+        "jsonParameters": {
+          "host": "10.128.42.17",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 6
+        },
+        "id": 132185,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 06S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice06S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice07P",
+        "jsonParameters": {
+          "host": "10.128.42.18",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 7
+        },
+        "id": 132262,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 07P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice07P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice07S",
+        "jsonParameters": {
+          "host": "10.128.42.34",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 7
+        },
+        "id": 132339,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 07S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice07S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice08P",
+        "jsonParameters": {
+          "host": "10.128.42.9",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 8
+        },
+        "id": 132416,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 08P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice08P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice08S",
+        "jsonParameters": {
+          "host": "10.128.42.36",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 8
+        },
+        "id": 132493,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 08S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice08S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice09P",
+        "jsonParameters": {
+          "host": "10.128.42.30",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 9
+        },
+        "id": 132570,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 09P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice09P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice09S",
+        "jsonParameters": {
+          "host": "10.128.42.40",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 1,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 9
+        },
+        "id": 132647,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 09S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice09S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice10P",
+        "jsonParameters": {
+          "host": "10.128.42.31",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 10
+        },
+        "id": 132724,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 10P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice10P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice10S",
+        "jsonParameters": {
+          "host": "10.128.42.32",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 10
+        },
+        "id": 132801,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 10S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice10S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice11P",
+        "jsonParameters": {
+          "host": "10.128.42.26",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 11
+        },
+        "id": 132878,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 11P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice11P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice11S",
+        "jsonParameters": {
+          "host": "10.128.42.47",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 11
+        },
+        "id": 132955,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 11S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice11S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice12P",
+        "jsonParameters": {
+          "host": "10.128.42.41",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 12
+        },
+        "id": 133032,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 12P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice12P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice12S",
+        "jsonParameters": {
+          "host": "10.128.42.14",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 12
+        },
+        "id": 133109,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 12S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice12S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice13P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 13
+        },
+        "id": 133186,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 13P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice13P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice13S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 13
+        },
+        "id": 133263,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 13S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice13S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice14P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 14
+        },
+        "id": 133340,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 14P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice14P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice14S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 14
+        },
+        "id": 133417,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 14S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice14S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice15P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 15
+        },
+        "id": 133494,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 15P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice15P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice15S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 15
+        },
+        "id": 133571,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 15S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice15S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice16P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW5": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 16
+        },
+        "id": 133648,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 16P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice16P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice16S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW6": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 16
+        },
+        "id": 133725,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 16S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice16S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice17P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 17
+        },
+        "id": 133802,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 17P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice17P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice17S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 17
+        },
+        "id": 133879,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 17S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice17S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice18P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 18
+        },
+        "id": 133956,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 18P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice18P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice18S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 18
+        },
+        "id": 134033,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 18S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice18S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice19P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 19
+        },
+        "id": 134110,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 19P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice19P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice19S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 19
+        },
+        "id": 134187,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 19S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice19S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice20P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 20
+        },
+        "id": 134264,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 20P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice20P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice20S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 20
+        },
+        "id": 134341,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 20S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice20S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice21P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW6": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 21
+        },
+        "id": 134418,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 21P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice21P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice21S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW5": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 21
+        },
+        "id": 134495,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 21S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice21S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice22P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 22
+        },
+        "id": 134572,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 22P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice22P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice22S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 22
+        },
+        "id": 134649,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 22S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice22S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice23P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 23
+        },
+        "id": 134726,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 23P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice23P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice23S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 23
+        },
+        "id": 134803,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 23S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice23S"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice24P",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 24
+        },
+        "id": 134880,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 24P",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": true,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice24P"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "Mothership/window/Slice24S",
+        "jsonParameters": {
+          "host": "10.128.42.",
+          "outputW1": 5,
+          "outputW2": 6,
+          "outputW3": 7,
+          "outputW8a": 3,
+          "outputW8b": 2,
+          "outputW9": 4,
+          "artnetSequence": false,
+          "w1extraLEDs": 0,
+          "w1ledOffset": 0,
+          "w2extraLEDs": 0,
+          "w2ledOffset": 0,
+          "w3extraLEDs": 0,
+          "w3ledOffset": 0,
+          "w4extraLEDs": 0,
+          "w4ledOffset": 0,
+          "w5extraLEDs": 0,
+          "w5ledOffset": 0,
+          "w6extraLEDs": 0,
+          "w6ledOffset": 0,
+          "w7extraLEDs": 0,
+          "w7ledOffset": 0,
+          "w8AextraLEDs": 0,
+          "w8AledOffset": 0,
+          "w8BextraLEDs": 0,
+          "w8BledOffset": 0,
+          "w9extraLEDs": 0,
+          "w9ledOffset": 0,
+          "radial": 24
+        },
+        "id": 134957,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Slice 24S",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": false,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "Mothership/window/Slice24S"
+        },
+        "children": {}
+      }
+    ],
+    "file": "Mothership_car.lxm"
+  },
+  "engine": {
+    "id": 1,
+    "class": "heronarts.lx.LXEngine",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true
+    },
+    "parameters": {
+      "label": "Engine",
+      "multithreaded": true,
+      "channelMultithreaded": false,
+      "networkMultithreaded": false,
+      "framesPerSecond": 60.0,
+      "speed": 1.0,
+      "performanceMode": false
+    },
+    "children": {
+      "palette": {
+        "id": 6,
+        "class": "heronarts.lx.color.LXPalette",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette",
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "transitionMode": 0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 10.0,
+          "autoCycleCursor": 7,
+          "triggerSwatchCycle": false,
+          "expandedPerformance": true,
+          "label1": "1",
+          "label2": "2",
+          "label3": "3",
+          "label4": "4",
+          "label5": "5"
+        },
+        "children": {
+          "swatch": {
+            "id": 7,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWvDyn",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 8,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 38.33333206176758,
+                  "secondary/hue": 330.0
+                },
+                "children": {}
+              },
+              {
+                "id": 26019,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 78.91667175292969,
+                  "primary/hue": 249.0,
+                  "secondary/brightness": 44.9999885559082,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        },
+        "swatches": [
+          {
+            "id": 25799,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SWATCH A",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 25800,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 311.2940979003906,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 25802,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 101.17647552490234,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 25804,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 161.1764678955078,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 75.83333587646484,
+                  "secondary/hue": 51.0
+                },
+                "children": {}
+              },
+              {
+                "id": 25806,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 192.47059631347656,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 25808,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 0.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 222.1176300048828,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298744,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "PlumIce",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298745,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 40.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 294.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 298747,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298749,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "IceGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298750,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 61.00000087171793,
+                  "primary/hue": 192.58998466096818,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298752,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 47.0,
+                  "primary/hue": 258.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 28.333335876464844,
+                  "secondary/hue": 273.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298754,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "IceYelGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298755,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 298757,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 20.833328247070312,
+                  "primary/hue": 225.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 288.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298759,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "GreenRod",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298760,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 95.49999237060547,
+                  "primary/saturation": 80.83333587646484,
+                  "primary/hue": 78.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 82.5,
+                  "secondary/hue": 96.00000762939453
+                },
+                "children": {}
+              },
+              {
+                "id": 298762,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 99.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 98.33333587646484,
+                  "secondary/hue": 72.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298764,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SunWave",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298765,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.83333206176758,
+                  "primary/hue": 204.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 85.0,
+                  "secondary/hue": 210.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298767,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 273.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 300.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298769,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWv",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298770,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 9.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298772,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 77.25000762939453,
+                  "primary/hue": 256.0,
+                  "secondary/brightness": 76.66666412353516,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298774,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWvDyn",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298775,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 38.33333206176758,
+                  "secondary/hue": 330.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298777,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 78.91667175292969,
+                  "primary/hue": 249.0,
+                  "secondary/brightness": 44.9999885559082,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298779,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Sunset",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298780,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 69.33331298828125,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298782,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 63.33330154418945,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298784,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-13",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298785,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 71.66666412353516,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 59.99995040893555,
+                  "secondary/saturation": 58.333335876464844,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298787,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 98.33333587646484,
+                  "primary/hue": 219.0,
+                  "secondary/brightness": 38.3332633972168,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298789,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-14",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298790,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 56.66666793823242,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298792,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 62.5,
+                  "primary/hue": 174.0,
+                  "secondary/brightness": 64.16655731201172,
+                  "secondary/saturation": 70.0,
+                  "secondary/hue": 186.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298794,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-15",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298795,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 30.0,
+                  "primary/hue": 300.0,
+                  "secondary/brightness": 61.6666145324707,
+                  "secondary/saturation": 59.16666793823242,
+                  "secondary/hue": 303.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298797,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 68.333251953125,
+                  "primary/saturation": 73.33332824707031,
+                  "primary/hue": 318.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 40.833335876464844,
+                  "secondary/hue": 312.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298799,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-16",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298800,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 89.01960754394531,
+                  "primary/saturation": 97.5,
+                  "primary/hue": 159.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 68.08334350585938,
+                  "secondary/hue": 90.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298802,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 62.30385208129883,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 165.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298804,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-17",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298805,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 58.333335876464844,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 49.99996566772461,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 180.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298807,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 84.99995422363281,
+                  "secondary/saturation": 61.66666793823242,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298809,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-18",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298810,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 198.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298812,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 77.5,
+                  "primary/hue": 216.00001525878906,
+                  "secondary/brightness": 66.66657257080078,
+                  "secondary/saturation": 69.16666412353516,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298814,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-19",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298815,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 192.00001525878906,
+                  "secondary/brightness": 62.49994659423828,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 195.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298817,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 212.99998474121094,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 48.333335876464844,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 298819,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-20",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 298820,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 342.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 298822,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 51.66666793823242,
+                  "primary/hue": 333.0,
+                  "secondary/brightness": 66.66656494140625,
+                  "secondary/saturation": 55.83333206176758,
+                  "secondary/hue": 324.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        ]
+      },
+      "tempo": {
+        "id": 10,
+        "class": "heronarts.lx.Tempo",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Tempo",
+          "clockSource": 0,
+          "period": 500.0,
+          "bpm": 120.0,
+          "tap": false,
+          "nudgeUp": false,
+          "nudgeDown": false,
+          "beatsPerBar": 4,
+          "trigger": false,
+          "enabled": true
+        },
+        "children": {
+          "nudge": {
+            "id": 11,
+            "class": "heronarts.lx.modulator.LinearEnvelope",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LENV",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "loop": false,
+              "tempoSync": false,
+              "tempoMultiplier": 5,
+              "tempoLock": true
+            },
+            "children": {},
+            "basis": 0.0
+          }
+        }
+      },
+      "clips": {
+        "id": 12,
+        "class": "heronarts.lx.clip.LXClipEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "focusedClip": 0.0,
+          "numScenes": 8,
+          "snapshotTransitionEnabled": false,
+          "snapshotTransitionTimeSecs": 5.0,
+          "stopClips": false,
+          "triggerPatternCycle": false,
+          "gridMode": 0,
+          "gridViewOffset": 0,
+          "gridPatternOffset": 0,
+          "gridViewExpanded": false,
+          "clipInspectorExpanded": false,
+          "scene-1": false,
+          "pattern-1": false,
+          "scene-2": false,
+          "pattern-2": false,
+          "scene-3": false,
+          "pattern-3": false,
+          "scene-4": false,
+          "pattern-4": false,
+          "scene-5": false,
+          "pattern-5": false,
+          "scene-6": false,
+          "pattern-6": false,
+          "scene-7": false,
+          "pattern-7": false,
+          "scene-8": false,
+          "pattern-8": false,
+          "scene-9": false,
+          "pattern-9": false,
+          "scene-10": false,
+          "pattern-10": false,
+          "scene-11": false,
+          "pattern-11": false,
+          "scene-12": false,
+          "pattern-12": false,
+          "scene-13": false,
+          "pattern-13": false,
+          "scene-14": false,
+          "pattern-14": false,
+          "scene-15": false,
+          "pattern-15": false,
+          "scene-16": false,
+          "pattern-16": false,
+          "scene-17": false,
+          "pattern-17": false,
+          "scene-18": false,
+          "pattern-18": false,
+          "scene-19": false,
+          "pattern-19": false,
+          "scene-20": false,
+          "pattern-20": false,
+          "scene-21": false,
+          "pattern-21": false,
+          "scene-22": false,
+          "pattern-22": false,
+          "scene-23": false,
+          "pattern-23": false,
+          "scene-24": false,
+          "pattern-24": false,
+          "scene-25": false,
+          "pattern-25": false,
+          "scene-26": false,
+          "pattern-26": false,
+          "scene-27": false,
+          "pattern-27": false,
+          "scene-28": false,
+          "pattern-28": false,
+          "scene-29": false,
+          "pattern-29": false,
+          "scene-30": false,
+          "pattern-30": false,
+          "scene-31": false,
+          "pattern-31": false,
+          "scene-32": false,
+          "pattern-32": false,
+          "scene-33": false,
+          "pattern-33": false,
+          "scene-34": false,
+          "pattern-34": false,
+          "scene-35": false,
+          "pattern-35": false,
+          "scene-36": false,
+          "pattern-36": false,
+          "scene-37": false,
+          "pattern-37": false,
+          "scene-38": false,
+          "pattern-38": false,
+          "scene-39": false,
+          "pattern-39": false,
+          "scene-40": false,
+          "pattern-40": false,
+          "scene-41": false,
+          "pattern-41": false,
+          "scene-42": false,
+          "pattern-42": false,
+          "scene-43": false,
+          "pattern-43": false,
+          "scene-44": false,
+          "pattern-44": false,
+          "scene-45": false,
+          "pattern-45": false,
+          "scene-46": false,
+          "pattern-46": false,
+          "scene-47": false,
+          "pattern-47": false,
+          "scene-48": false,
+          "pattern-48": false,
+          "scene-49": false,
+          "pattern-49": false,
+          "scene-50": false,
+          "pattern-50": false,
+          "scene-51": false,
+          "pattern-51": false,
+          "scene-52": false,
+          "pattern-52": false,
+          "scene-53": false,
+          "pattern-53": false,
+          "scene-54": false,
+          "pattern-54": false,
+          "scene-55": false,
+          "pattern-55": false,
+          "scene-56": false,
+          "pattern-56": false,
+          "scene-57": false,
+          "pattern-57": false,
+          "scene-58": false,
+          "pattern-58": false,
+          "scene-59": false,
+          "pattern-59": false,
+          "scene-60": false,
+          "pattern-60": false,
+          "scene-61": false,
+          "pattern-61": false,
+          "scene-62": false,
+          "pattern-62": false,
+          "scene-63": false,
+          "pattern-63": false,
+          "scene-64": false,
+          "pattern-64": false,
+          "scene-65": false,
+          "pattern-65": false,
+          "scene-66": false,
+          "pattern-66": false,
+          "scene-67": false,
+          "pattern-67": false,
+          "scene-68": false,
+          "pattern-68": false,
+          "scene-69": false,
+          "pattern-69": false,
+          "scene-70": false,
+          "pattern-70": false,
+          "scene-71": false,
+          "pattern-71": false,
+          "scene-72": false,
+          "pattern-72": false,
+          "scene-73": false,
+          "pattern-73": false,
+          "scene-74": false,
+          "pattern-74": false,
+          "scene-75": false,
+          "pattern-75": false,
+          "scene-76": false,
+          "pattern-76": false,
+          "scene-77": false,
+          "pattern-77": false,
+          "scene-78": false,
+          "pattern-78": false,
+          "scene-79": false,
+          "pattern-79": false,
+          "scene-80": false,
+          "pattern-80": false,
+          "scene-81": false,
+          "pattern-81": false,
+          "scene-82": false,
+          "pattern-82": false,
+          "scene-83": false,
+          "pattern-83": false,
+          "scene-84": false,
+          "pattern-84": false,
+          "scene-85": false,
+          "pattern-85": false,
+          "scene-86": false,
+          "pattern-86": false,
+          "scene-87": false,
+          "pattern-87": false,
+          "scene-88": false,
+          "pattern-88": false,
+          "scene-89": false,
+          "pattern-89": false,
+          "scene-90": false,
+          "pattern-90": false,
+          "scene-91": false,
+          "pattern-91": false,
+          "scene-92": false,
+          "pattern-92": false,
+          "scene-93": false,
+          "pattern-93": false,
+          "scene-94": false,
+          "pattern-94": false,
+          "scene-95": false,
+          "pattern-95": false,
+          "scene-96": false,
+          "pattern-96": false,
+          "scene-97": false,
+          "pattern-97": false,
+          "scene-98": false,
+          "pattern-98": false,
+          "scene-99": false,
+          "pattern-99": false,
+          "scene-100": false,
+          "pattern-100": false,
+          "scene-101": false,
+          "pattern-101": false,
+          "scene-102": false,
+          "pattern-102": false,
+          "scene-103": false,
+          "pattern-103": false,
+          "scene-104": false,
+          "pattern-104": false,
+          "scene-105": false,
+          "pattern-105": false,
+          "scene-106": false,
+          "pattern-106": false,
+          "scene-107": false,
+          "pattern-107": false,
+          "scene-108": false,
+          "pattern-108": false,
+          "scene-109": false,
+          "pattern-109": false,
+          "scene-110": false,
+          "pattern-110": false,
+          "scene-111": false,
+          "pattern-111": false,
+          "scene-112": false,
+          "pattern-112": false,
+          "scene-113": false,
+          "pattern-113": false,
+          "scene-114": false,
+          "pattern-114": false,
+          "scene-115": false,
+          "pattern-115": false,
+          "scene-116": false,
+          "pattern-116": false,
+          "scene-117": false,
+          "pattern-117": false,
+          "scene-118": false,
+          "pattern-118": false,
+          "scene-119": false,
+          "pattern-119": false,
+          "scene-120": false,
+          "pattern-120": false,
+          "scene-121": false,
+          "pattern-121": false,
+          "scene-122": false,
+          "pattern-122": false,
+          "scene-123": false,
+          "pattern-123": false,
+          "scene-124": false,
+          "pattern-124": false,
+          "scene-125": false,
+          "pattern-125": false,
+          "scene-126": false,
+          "pattern-126": false,
+          "scene-127": false,
+          "pattern-127": false,
+          "scene-128": false,
+          "pattern-128": false
+        },
+        "children": {}
+      },
+      "audio": {
+        "id": 13,
+        "class": "heronarts.lx.audio.LXAudioEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true,
+          "ioExpanded": false,
+          "numSoundObjects": 0.0
+        },
+        "parameters": {
+          "label": "Audio",
+          "enabled": true,
+          "mode": 0,
+          "expandedPerformance": true
+        },
+        "children": {
+          "input": {
+            "id": 14,
+            "class": "heronarts.lx.audio.LXAudioInput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Input",
+              "device": 2
+            },
+            "children": {}
+          },
+          "output": {
+            "id": 15,
+            "class": "heronarts.lx.audio.LXAudioOutput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Output",
+              "file": "",
+              "trigger": false,
+              "looping": false,
+              "play": false
+            },
+            "children": {}
+          },
+          "soundStage": {
+            "id": 16,
+            "class": "heronarts.lx.audio.SoundStage",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SoundStage",
+              "mode": 0,
+              "xAbsolute": 0.0,
+              "yAbsolute": 0.0,
+              "zAbsolute": 0.0,
+              "widthAbsolute": 100.0,
+              "heightAbsolute": 100.0,
+              "depthAbsolute": 100.0,
+              "azimuthAbsolute": 0.0,
+              "elevationAbsolute": 0.0,
+              "xRelative": 0.0,
+              "yRelative": 0.0,
+              "zRelative": 0.0,
+              "widthRelative": 1.0,
+              "heightRelative": 1.0,
+              "depthRelative": 1.0,
+              "azimuthRelative": 0.0,
+              "elevationRelative": 0.0,
+              "showSoundStage": false,
+              "showSoundObjects": true,
+              "soundObjectMeterMode": 0,
+              "soundObjectSize": 10.0
+            },
+            "children": {}
+          },
+          "adm": {
+            "id": 17,
+            "class": "heronarts.lx.audio.ADM",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "ADM"
+            },
+            "children": {}
+          },
+          "envelop": {
+            "id": 82,
+            "class": "heronarts.lx.audio.Envelop",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Envelop",
+              "running": false,
+              "trigger": false
+            },
+            "children": {
+              "source": {
+                "id": 83,
+                "class": "heronarts.lx.audio.Envelop$Source",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Source",
+                  "running": true,
+                  "trigger": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "source-1": 0.0,
+                  "source-2": 0.0,
+                  "source-3": 0.0,
+                  "source-4": 0.0,
+                  "source-5": 0.0,
+                  "source-6": 0.0,
+                  "source-7": 0.0,
+                  "source-8": 0.0,
+                  "source-9": 0.0,
+                  "source-10": 0.0,
+                  "source-11": 0.0,
+                  "source-12": 0.0,
+                  "source-13": 0.0,
+                  "source-14": 0.0,
+                  "source-15": 0.0,
+                  "source-16": 0.0,
+                  "source-17": 0.0,
+                  "source-18": 0.0,
+                  "source-19": 0.0,
+                  "source-20": 0.0,
+                  "source-21": 0.0,
+                  "source-22": 0.0,
+                  "source-23": 0.0,
+                  "source-24": 0.0,
+                  "source-25": 0.0,
+                  "source-26": 0.0,
+                  "source-27": 0.0,
+                  "source-28": 0.0,
+                  "source-29": 0.0,
+                  "source-30": 0.0,
+                  "source-31": 0.0,
+                  "source-32": 0.0
+                },
+                "children": {}
+              },
+              "decode": {
+                "id": 84,
+                "class": "heronarts.lx.audio.Envelop$Decode",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Decode",
+                  "running": true,
+                  "trigger": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "decode-1": 0.0,
+                  "decode-2": 0.0,
+                  "decode-3": 0.0,
+                  "decode-4": 0.0,
+                  "decode-5": 0.0,
+                  "decode-6": 0.0,
+                  "decode-7": 0.0,
+                  "decode-8": 0.0
+                },
+                "children": {}
+              }
+            }
+          },
+          "reaper": {
+            "id": 85,
+            "class": "heronarts.lx.audio.Reaper",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Reaper",
+              "running": false,
+              "trigger": false,
+              "meterAttack": 0.0,
+              "meterRelease": 0.0,
+              "foldMode": 1,
+              "master": 0.0,
+              "master-active": false,
+              "meter-1": 0.0,
+              "meter-1-active": false,
+              "meter-2": 0.0,
+              "meter-2-active": false,
+              "meter-3": 0.0,
+              "meter-3-active": false,
+              "meter-4": 0.0,
+              "meter-4-active": false,
+              "meter-5": 0.0,
+              "meter-5-active": false,
+              "meter-6": 0.0,
+              "meter-6-active": false,
+              "meter-7": 0.0,
+              "meter-7-active": false,
+              "meter-8": 0.0,
+              "meter-8-active": false,
+              "meter-9": 0.0,
+              "meter-9-active": false,
+              "meter-10": 0.0,
+              "meter-10-active": false,
+              "meter-11": 0.0,
+              "meter-11-active": false,
+              "meter-12": 0.0,
+              "meter-12-active": false,
+              "meter-13": 0.0,
+              "meter-13-active": false,
+              "meter-14": 0.0,
+              "meter-14-active": false,
+              "meter-15": 0.0,
+              "meter-15-active": false,
+              "meter-16": 0.0,
+              "meter-16-active": false,
+              "meter-17": 0.0,
+              "meter-17-active": false,
+              "meter-18": 0.0,
+              "meter-18-active": false,
+              "meter-19": 0.0,
+              "meter-19-active": false,
+              "meter-20": 0.0,
+              "meter-20-active": false,
+              "meter-21": 0.0,
+              "meter-21-active": false,
+              "meter-22": 0.0,
+              "meter-22-active": false,
+              "meter-23": 0.0,
+              "meter-23-active": false,
+              "meter-24": 0.0,
+              "meter-24-active": false,
+              "meter-25": 0.0,
+              "meter-25-active": false,
+              "meter-26": 0.0,
+              "meter-26-active": false,
+              "meter-27": 0.0,
+              "meter-27-active": false,
+              "meter-28": 0.0,
+              "meter-28-active": false,
+              "meter-29": 0.0,
+              "meter-29-active": false,
+              "meter-30": 0.0,
+              "meter-30-active": false,
+              "meter-31": 0.0,
+              "meter-31-active": false,
+              "meter-32": 0.0,
+              "meter-32-active": false
+            },
+            "children": {}
+          },
+          "meter": {
+            "id": 86,
+            "class": "heronarts.lx.audio.LXAudioEngine$Meter",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Meter",
+              "running": true,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "gain": 0.0,
+              "range": 48.0,
+              "attack": 10.0,
+              "release": 100.0,
+              "slope": 4.5,
+              "band-1": 0.0,
+              "band-2": 0.0,
+              "band-3": 0.0,
+              "band-4": 0.0,
+              "band-5": 0.0,
+              "band-6": 0.0,
+              "band-7": 0.0,
+              "band-8": 0.0,
+              "band-9": 0.0,
+              "band-10": 0.0,
+              "band-11": 0.0,
+              "band-12": 0.0,
+              "band-13": 0.0,
+              "band-14": 0.0,
+              "band-15": 0.0,
+              "band-16": 0.0
+            },
+            "children": {}
+          }
+        }
+      },
+      "mixer": {
+        "id": 87,
+        "class": "heronarts.lx.mixer.LXMixerEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Mixer",
+          "crossfader": 0.5,
+          "crossfaderBlendMode": 1,
+          "focusedChannel": 1,
+          "focusedChannelAux": 1,
+          "cueA": false,
+          "cueB": false,
+          "auxA": false,
+          "auxB": false,
+          "viewCondensed": false,
+          "viewStacked": false,
+          "viewDeviceBin": true
+        },
+        "children": {
+          "master": {
+            "id": 95,
+            "class": "heronarts.lx.mixer.LXMasterBus",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false
+            },
+            "parameters": {
+              "label": "Master",
+              "fader": 1.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "previewMode": 1
+            },
+            "children": {
+              "modulation": {
+                "id": 96,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": []
+          }
+        },
+        "channels": [
+          {
+            "id": 320012,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Composite",
+              "fader": 1.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "blendMode": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 0,
+              "compositeMode": 1,
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 9,
+              "triggerPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 320013,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 320050,
+                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$DarkRadiance",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "DarkRadiance",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.72,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.27428572438657284,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 90.00003814697266,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 113.1427001953125,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320051,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320063,
+                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$DarkRadiance",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "DarkRadiance",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 0.6020408268086612,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.3742856898903847,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.020627414067143857,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": -0.6103666158995065,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 90.9524154663086,
+                  "te_color/saturation": 98.92852783203125,
+                  "te_color/hue": 265.7142333984375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320064,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320091,
+                "class": "titanicsend.pattern.glengine.StarField2",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "StarField2",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": -0.08,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.015899999886751177,
+                  "te_quantity": 0.657142847031355,
+                  "te_spin": -0.006687396419513547,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.1,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 99.40475463867188,
+                  "te_color/hue": 281.1427001953125,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320092,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320118,
+                "class": "titanicsend.pattern.jon.SimplexPosterized",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "SimplexPosterized",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 0.765306131914258,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.43623078963684403,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 4.719999875873327,
+                  "te_quantity": 1.5714286472648382,
+                  "te_spin": 0.006400000905990577,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.011428572237491608,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 279.428466796875,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320119,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320144,
+                "class": "titanicsend.pattern.jon.RadialSimplex",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "RadialSimplex",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": -0.25,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 9.0,
+                  "te_quantity": 1.2388571633026007,
+                  "te_spin": 0.03774694411900592,
+                  "te_brightness": 1.0,
+                  "te_wow1": 2,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 246.85693359375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320145,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320158,
+                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$RingOfFire",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "RingOfFire",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.25,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.9900000056624413,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.02207347251249825,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 37.7142333984375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320159,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320171,
+                "class": "titanicsend.pattern.glengine.StarField2",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "StarField2",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": -0.09517469720211968,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.015699999872595072,
+                  "te_quantity": 0.8,
+                  "te_spin": -0.0024992778858901055,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.1,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 25.7142333984375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320172,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320263,
+                "class": "titanicsend.pattern.yoffa.config.OrganicPatternConfig$MatrixScroller",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "MatrixScroller",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.02,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.015804081996606323,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.005714286118745804,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 77.5,
+                  "te_color/hue": 138.85693359375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320264,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320277,
+                "class": "titanicsend.pattern.glengine.StarField1",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "StarField1",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.015519100511401263,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 0.03814285770058632,
+                  "te_quantity": 0.15,
+                  "te_spin": -5.22449394148139E-4,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.7,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 74.16667175292969,
+                  "te_color/hue": 150.85693359375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320278,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 320356,
+                "class": "titanicsend.pattern.sinas.LightBeamsAudioReactivePattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "LightBeamsAudioReactive",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 0.8061224552802742,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.02,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 4.743371410407126,
+                  "te_quantity": 0.5,
+                  "te_spin": -0.014220650596018847,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 1.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 1.2,
+                  "te_freq": 0.01,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.16000000946223736
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320357,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              }
+            ]
+          },
+          {
+            "id": 320031,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "Effects",
+              "fader": 1.0,
+              "arm": false,
+              "selected": true,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "blendMode": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 0,
+              "compositeMode": 0,
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 320032,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 320077,
+                "class": "titanicsend.pattern.jon.SpaceExplosionFX",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "SpaceExplosionFX",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.17880818542704358,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.6914285961538553,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 181.7142333984375,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 320078,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              }
+            ]
+          }
+        ]
+      },
+      "modulation": {
+        "id": 97,
+        "class": "heronarts.lx.modulation.LXModulationEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Modulation"
+        },
+        "children": {},
+        "modulators": [],
+        "modulations": [],
+        "triggers": []
+      },
+      "output": {
+        "id": 98,
+        "class": "heronarts.lx.LXEngine$Output",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Output",
+          "enabled": false,
+          "brightness": 1.0,
+          "fps": 0.0,
+          "gamma": 1.0,
+          "gammaMode": 1,
+          "whitePointRed": 255,
+          "whitePointGreen": 255,
+          "whitePointBlue": 255,
+          "whitePointWhite": 255
+        },
+        "children": {}
+      },
+      "snapshots": {
+        "id": 100,
+        "class": "heronarts.lx.snapshot.LXSnapshotEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Snapshots",
+          "recallMixer": true,
+          "recallModulation": true,
+          "recallPattern": true,
+          "recallEffect": true,
+          "recallMaster": true,
+          "recallOutput": false,
+          "channelMode": 1,
+          "missingChannelMode": 0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "autoCycleCursor": 6,
+          "triggerSnapshotCycle": false
+        },
+        "children": {},
+        "snapshots": [
+          {
+            "id": 320090,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Green/Purple Sparks",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.6523767067755595
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_size",
+                "value": 0.72,
+                "normalizedValue": 0.6266666666666666
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_spin",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_wow1",
+                "value": 0.27428572438657284,
+                "normalizedValue": 0.27428572438657284
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/compositeLevel",
+                "value": 0.4438775684684515,
+                "normalizedValue": 0.4438775684684515
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.6523767067755595
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_size",
+                "value": 0.3742856898903847,
+                "normalizedValue": 0.16571425318717958
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_spin",
+                "value": -0.06,
+                "normalizedValue": 0.377525512860841
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wow1",
+                "value": 0.18285709246993065,
+                "normalizedValue": 0.18285709246993065
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_angle",
+                "value": -0.6103666158995065,
+                "normalizedValue": 0.4028571359813213
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320104,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Purple Sparks+Stars",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/compositeLevel",
+                "value": 0.6020408268086612,
+                "normalizedValue": 0.6020408268086612
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.6523767067755595
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_size",
+                "value": 0.3742856898903847,
+                "normalizedValue": 0.16571425318717958
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_spin",
+                "value": 0.020627414067143857,
+                "normalizedValue": 0.571811235310263
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_angle",
+                "value": -0.6103666158995065,
+                "normalizedValue": 0.4028571359813213
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_speed",
+                "value": -0.08,
+                "normalizedValue": 0.4465275599973303
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_size",
+                "value": 0.015899999886751177,
+                "normalizedValue": 0.3114285681928907
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_quantity",
+                "value": 0.657142847031355,
+                "normalizedValue": 0.657142847031355
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_spin",
+                "value": -0.006687396419513547,
+                "normalizedValue": 0.4591117485715226
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_wow2",
+                "value": 0.1,
+                "normalizedValue": 0.33333333333333337
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320157,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Calm Purple/Blue",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/compositeLevel",
+                "value": 0.765306131914258,
+                "normalizedValue": 0.765306131914258
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_speed",
+                "value": 0.43623078963684403,
+                "normalizedValue": 0.6409481345380679
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_size",
+                "value": 4.719999875873327,
+                "normalizedValue": 0.3885714108390467
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_quantity",
+                "value": 1.5714286472648382,
+                "normalizedValue": 0.5714285410940647
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_spin",
+                "value": 0.006400000905990577,
+                "normalizedValue": 0.5400000028312204
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_wow1",
+                "value": 0.011428572237491608,
+                "normalizedValue": 0.011428572237491608
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_speed",
+                "value": -0.25,
+                "normalizedValue": 0.39745808049904524
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_size",
+                "value": 9.0,
+                "normalizedValue": -0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_quantity",
+                "value": 1.2388571633026007,
+                "normalizedValue": 0.6637593877354734
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_spin",
+                "value": 0.03774694411900592,
+                "normalizedValue": 0.5971428640186786
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_wow1",
+                "value": 2,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320184,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Golden Sun",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_speed",
+                "value": 0.25,
+                "normalizedValue": 0.6025419195009547
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_size",
+                "value": 0.9900000056624413,
+                "normalizedValue": 0.4571428409644534
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_spin",
+                "value": 0.02207347251249825,
+                "normalizedValue": 0.5742857195436953
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_wow2",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_speed",
+                "value": -0.09517469720211968,
+                "normalizedValue": 0.44094812038196485
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_size",
+                "value": 0.015699999872595072,
+                "normalizedValue": 0.30571428207414486
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_quantity",
+                "value": 0.8,
+                "normalizedValue": 0.8
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_spin",
+                "value": -0.0024992778858901055,
+                "normalizedValue": 0.47500361083131154
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_wow2",
+                "value": 0.1,
+                "normalizedValue": 0.33333333333333337
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320276,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Strange Symbols",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.6523767067755595
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_size",
+                "value": 0.02,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_spin",
+                "value": 0.015804081996606323,
+                "normalizedValue": 0.5628571435809135
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_wow2",
+                "value": 0.005714286118745804,
+                "normalizedValue": 0.005714286118745804
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320290,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Emerald Ice",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_speed",
+                "value": 0.015519100511401263,
+                "normalizedValue": 0.520948126044406
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_size",
+                "value": 0.03814285770058632,
+                "normalizedValue": 0.1314285770058632
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_quantity",
+                "value": 0.15,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_spin",
+                "value": -5.22449394148139E-4,
+                "normalizedValue": 0.4885714240372199
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_wow2",
+                "value": 0.7,
+                "normalizedValue": 0.7
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          },
+          {
+            "id": 320369,
+            "class": "heronarts.lx.snapshot.LXGlobalSnapshot",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "At Rest (uses TE palette)",
+              "transitionTimeSecs": 1.0,
+              "recall": false,
+              "autoCycleEligible": true,
+              "hasCustomCycleTime": false,
+              "cycleTimeSecs": 60.0,
+              "hasCustomTransitionTime": false
+            },
+            "children": {},
+            "views": [
+              {
+                "scope": "OUTPUT",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/output/brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/crossfader",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/1",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/compositeMode",
+                "value": 1,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/1/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/2/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/3/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/4/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/5/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/6/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/7/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/8/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/9/enabled",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/enabled",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/compositeLevel",
+                "value": 0.8061224552802742,
+                "normalizedValue": 0.8061224552802742
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_speed",
+                "value": 0.02,
+                "normalizedValue": 0.5359842836500577
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_size",
+                "value": 4.743371410407126,
+                "normalizedValue": 0.9485714249312878
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_spin",
+                "value": -0.014220650596018847,
+                "normalizedValue": 0.44037481531261546
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_wow2",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_level",
+                "value": 1.2,
+                "normalizedValue": 0.6
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_freq",
+                "value": 0.01,
+                "normalizedValue": 0.01
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/1/pattern/10/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "CHANNEL_FADER",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "channelEnabled": true,
+                "channelFader": 1.0
+              },
+              {
+                "scope": "MIXER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/crossfadeGroup",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "ACTIVE_PATTERN",
+                "enabled": true,
+                "channelPath": "/lx/mixer/channel/2",
+                "activePatternIndex": 0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/view",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeMode",
+                "value": 0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/compositeLevel",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/setDefaults",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_speed",
+                "value": 0.5,
+                "normalizedValue": 0.75
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_xpos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_ypos",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_size",
+                "value": 1.0,
+                "normalizedValue": 0.19839679358717432
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_quantity",
+                "value": 0.5,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_spin",
+                "value": 0.17880818542704358,
+                "normalizedValue": 0.7114285845309496
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_brightness",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow1",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wow2",
+                "value": 0.6914285961538553,
+                "normalizedValue": 0.6914285961538553
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_wowtrigger",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_angle",
+                "value": 0.0,
+                "normalizedValue": 0.5
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_level",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_freq",
+                "value": 0.1,
+                "normalizedValue": 0.1
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/te_twist",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "PATTERNS",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/channel/2/pattern/1/panic",
+                "value": 0.0,
+                "normalizedValue": 0.0
+              },
+              {
+                "scope": "MASTER",
+                "type": "PARAMETER",
+                "enabled": true,
+                "parameterPath": "/lx/mixer/master/fader",
+                "value": 1.0,
+                "normalizedValue": 1.0
+              }
+            ]
+          }
+        ]
+      },
+      "dmx": {
+        "id": 101,
+        "class": "heronarts.lx.dmx.LXDmxEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "artNetReceivePort": 6454,
+          "artNetReceiveActive": true
+        },
+        "children": {}
+      },
+      "midi": {
+        "id": 102,
+        "class": "heronarts.lx.midi.LXMidiEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "computerKeyboardEnabled": false,
+          "computerKeyboardOctave": 5,
+          "computerKeyboardVelocity": 5
+        },
+        "children": {},
+        "inputs": [
+          {
+            "name": "APC40 mkII",
+            "channel": false,
+            "control": true,
+            "sync": false
+          }
+        ],
+        "surfaces": [
+          {
+            "class": "heronarts.lx.midi.surface.APC40Mk2",
+            "name": "APC40 mkII",
+            "settings": {
+              "masterFaderEnabled": true,
+              "crossfaderEnabled": true,
+              "faderMode": 2,
+              "deviceControl": true,
+              "performanceLock": true
+            }
+          }
+        ],
+        "mapping": []
+      },
+      "osc": {
+        "id": 103,
+        "class": "heronarts.lx.osc.LXOscEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "OSC",
+          "receiveHost": "0.0.0.0",
+          "receivePort": 3030,
+          "receiveActive": true,
+          "transmitHost": "10.1.3.1",
+          "transmitPort": 7890,
+          "transmitActive": false,
+          "logInput": false,
+          "logOutput": false
+        },
+        "children": {}
+      },
+      "virtualOverlays": {
+        "id": 104,
+        "class": "titanicsend.app.TEVirtualOverlays",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "TEVirtualOverlays",
+          "vertexSpheresVisible": false,
+          "vertexLabelsVisible": false,
+          "panelLabelsVisible": false,
+          "unknownPanelsVisible": true,
+          "opaqueBackPanelsVisible": true,
+          "backingOpacity": 1.0,
+          "powerBoxesVisible": false,
+          "lasersVisible": false
+        },
+        "children": {}
+      },
+      "globalPatternControls": {
+        "id": 105,
+        "class": "titanicsend.app.TEGlobalPatternControls",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "TEGlobalPatternControls"
+        },
+        "children": {}
+      },
+      "NDIEngine": {
+        "id": 108,
+        "class": "titanicsend.ndi.NDIEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "NDIEngine"
+        },
+        "children": {}
+      },
+      "GLEngine": {
+        "id": 109,
+        "class": "titanicsend.pattern.glengine.GLEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "GLEngine"
+        },
+        "children": {}
+      },
+      "audioStems": {
+        "id": 110,
+        "class": "titanicsend.audio.AudioStems",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "audioStems",
+          "gain": 0.0
+        },
+        "children": {}
+      },
+      "paletteManagerA": {
+        "id": 111,
+        "class": "titanicsend.color.ColorPaletteManager",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette Manager",
+          "hue": 311.2499998882413,
+          "saturation": 100.0,
+          "brightness": 100.0,
+          "paletteStrategy": 3,
+          "color1/brightness": 100.0,
+          "color1/saturation": 100.0,
+          "color1/hue": 311.2940979003906,
+          "color2/brightness": 100.0,
+          "color2/saturation": 100.0,
+          "color2/hue": 101.17647552490234,
+          "color3/brightness": 100.0,
+          "color3/saturation": 100.0,
+          "color3/hue": 161.1764678955078,
+          "pushSwatch": false,
+          "pinSwatch": true
+        },
+        "children": {}
+      },
+      "focus": {
+        "id": 126,
+        "class": "titanicsend.osc.CrutchOSC",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "CrutchOSC"
+        },
+        "children": {}
+      },
+      "director": {
+        "id": 127,
+        "class": "titanicsend.app.director.Director",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "director",
+          "te": 1.0,
+          "panels": 1.0,
+          "edges": 1.0,
+          "foh": 1.0,
+          "lasers": 1.0,
+          "beacons": 1.0,
+          "master": 1.0
+        },
+        "children": {}
+      }
+    }
+  },
+  "externals": {
+    "ui": {
+      "leftPaneActiveSection": 2,
+      "audioExpanded": true,
+      "envelopExpanded": true,
+      "reaperExpanded": true,
+      "paletteExpanded": true,
+      "cameraExpanded": true,
+      "mixerCentered": false,
+      "fixtureInspectorExpanded": false,
+      "viewsExpanded": true,
+      "soundStageExpanded": false,
+      "preview": {
+        "animation": false,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 2.0,
+        "camera": {
+          "active": false,
+          "radius": 407.30484248422493,
+          "theta": 179.3213032457279,
+          "phi": -1.0484236592892557,
+          "x": 0.0,
+          "y": 144.99998474121094,
+          "z": 3.814697265625E-6
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 407.30484248422493,
+            "theta": 179.3213032457279,
+            "phi": -1.0484236592892557,
+            "x": 0.0,
+            "y": 144.99998474121094,
+            "z": 3.814697265625E-6
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 3,
+          "pointSize": 1.5,
+          "alphaRef": 8,
+          "feather": 0.5,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 45.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": false
+        }
+      },
+      "previewAux": {
+        "animation": false,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 2.0,
+        "camera": {
+          "active": false,
+          "radius": 120.0,
+          "theta": 0.0,
+          "phi": 0.0,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 3.814697265625E-6
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 0,
+          "pointSize": 3.0,
+          "alphaRef": 8,
+          "feather": 0.5,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 45.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": true
+        }
+      }
+    }
+  }
+}

--- a/resources/shaders/darkradiance.fs
+++ b/resources/shaders/darkradiance.fs
@@ -1,0 +1,84 @@
+precision mediump float;
+const float pi = 3.14159265359;
+const float two_pi = (pi * 2.0);
+
+const float numRays = 3.0;    // actually sqrt of the number of rays
+float exposure;     // higher is brighter
+float falloff;      // higher is faster falloff
+float diff;         // amount of fake "diffraction" color
+float speed = 2.0;  // base movement speed.
+float radius = 0.25; // radius of ring of stars
+
+float rand(int seed, float ray) {
+    return mod(sin(float(seed)*363.5346+ray*674.2454)*6743.4365, 1.0);
+}
+
+vec2 rotate(vec2 point, float angle) {
+    mat2 rotationMatrix = mat2(cos(angle), -sin(angle), sin(angle), cos(angle));
+    return rotationMatrix * point;
+}
+
+vec4 light(vec2 position, float pulse) {
+    vec4 ret = vec4(iColorRGB,1.0);
+
+    // small brightly lit sphere in center
+    float dist = length(position);
+    ret.rgb *= (.5/dist) * (0.08 * pulse);
+
+    // create several rays at interesting offsets(golden ratio 1.618 is
+    // used here because... it looks about right), and slightly perturb color
+    // for a diffraction grating-like look
+    float ang = atan(position.y, position.x);
+    float offset = clamp(abs(position.x/position.y),1.,two_pi);
+
+    float s = iTime * (speed * beat);
+
+    for (float n = 1.0; n <= numRays; n += 1.0) {
+        float rayang = 1.618 * n + (s) + offset;
+        rayang = mod(rayang, two_pi);
+
+        // extend rays to both sides of circle
+        if (rayang < ang - pi) {rayang += two_pi;}
+        if (rayang > ang + pi) {rayang -= two_pi;}
+
+        float bri = exposure - abs(ang - rayang);
+        bri -=(falloff * dist);
+
+        if (bri > 0.0) {
+            vec2 uv = floor(vec2(10000.,1.) * position);
+            ret.rgb += vec3(1.+diff*rand(8644, n),
+            1.+diff*rand(4567, n),
+            1.+diff*rand(7354, n)) * bri;
+        }
+    }
+    ret *= smoothstep(0.5, 0.0, dist);
+    return ret * ret;
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord )  {
+    // normalize and center coordinates
+    vec2 position = ( gl_FragCoord.xy / iResolution.xy ) - 0.5;
+    //position.y *= iResolution.y/iResolution.x;
+    position *= iScale;
+    position = rotate(position,iRotationAngle);
+
+    // roughly circular "bounce" with beat
+    float b = two_pi * fract(iTime);
+    vec2 offset = 0.05 * vec2(sin(iTime+b),cos(-b));
+
+    // change average star size and level of diffraction effect
+    // with Wow1
+    falloff = 0.955;
+    exposure = 0.55;
+    diff = 0.5 + (0.5 * iWow1);
+
+    // display stars!
+
+    fragColor =
+    light(position - offset + vec2(radius, 0.),1.-sinPhaseBeat) +
+    light(position + offset + vec2(-radius, 0.),1.-sinPhaseBeat) +
+    light(position + offset + vec2(0., -radius),sinPhaseBeat) +
+    light(position - offset + vec2(0., radius),sinPhaseBeat);
+
+    fragColor = clamp(fragColor,0.,1.);
+}

--- a/resources/shaders/ringofire.fs
+++ b/resources/shaders/ringofire.fs
@@ -1,12 +1,5 @@
 // Experimental fire for Mothership
-#pragma name "RingOfFire"
-#pragma TEControl.SIZE.Range(0.91,1.15,0.8)
-#pragma TECONTROL.SPEED.Value(0.64)
 
-#pragma TEControl.QUANTITY.Disable
-#pragma TEControl.WOWTRIGGER.Disable
-#pragma TEControl.WOW2.Disable
-#pragma TEControl.WOW1.Disable
 
 #include <include/constants.fs>
 #include <include/colorspace.fs>

--- a/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -285,10 +285,8 @@ public class ShaderPanelsPatternConfig {
 
     private final GaussianFilter rmsFilter = new GaussianFilter(5);
 
-
     public NeonCells(LX lx) {
       super(lx, TEShaderView.SPLIT_PANEL_SECTIONS);
-
     }
 
     @Override
@@ -398,8 +396,8 @@ public class ShaderPanelsPatternConfig {
       controls.setRange(TEControlTag.WOW2, 0, 0, 1); // contrast
       controls.setRange(TEControlTag.QUANTITY, 1, 1, 16); // number of kaleidoscope slices
       controls.setValue(TEControlTag.SPIN, 0);
-      controls.setRange(TEControlTag.LEVELREACTIVITY,0.33,0,1);
-      controls.setRange(TEControlTag.FREQREACTIVITY,0.33,0,1);
+      controls.setRange(TEControlTag.LEVELREACTIVITY, 0.33, 0, 1);
+      controls.setRange(TEControlTag.FREQREACTIVITY, 0.33, 0, 1);
 
       addShader("metallic_wave.fs");
     }
@@ -446,6 +444,42 @@ public class ShaderPanelsPatternConfig {
       controls.setRange(TEControlTag.WOW2, 1.0, 0.25, 2.0);
 
       addShader("smoke_shader.fs");
+    }
+  }
+
+  @LXCategory("Mothership")
+  public static class RingOfFire extends ConstructedShaderPattern {
+    public RingOfFire(LX lx) {
+      super(lx, TEShaderView.DOUBLE_LARGE);
+    }
+
+    @Override
+    protected void createShader() {
+      // set up common controls
+
+      controls.setRange(TEControlTag.SIZE, 0.91, 1.15, 0.8);
+      controls.setValue(TEControlTag.SPEED, 0.64);
+
+      controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+      controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+      controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+      controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+
+      addShader("ringofire.fs");
+    }
+  }
+
+  @LXCategory("Mothership")
+  public static class DarkRadiance extends ConstructedShaderPattern {
+    public DarkRadiance(LX lx) {
+      super(lx, TEShaderView.DOUBLE_LARGE);
+    }
+
+    @Override
+    protected void createShader() {
+      controls.setRange(TEControlTag.SIZE, 0.64, 0.25, 1); // overall scale
+
+      addShader("darkradiance.fs");
     }
   }
 }


### PR DESCRIPTION
A set of "looks" that we can use for Mothership startup, and a couple of new/modified patterns especially for Mothership.

The startup looks are in the project file MShipStartupLooks.lxp.
They're stored as named snapshots (below the palette in the **Global** panel)

This project has only the view-facing side of the Mothership lit, which I think will give a more accurate view of how patterns will look in the field.   Also, for best viewing in Chromatik, go to the **Camera** section at the bottom of the **Model** panel and change the **Point Size** from 3.00 to 1.5.   Again, I think this will give a more realistic picture of how the LEDs on Mothership will look.   (No warranty here though -- can't be certain 'till we see it light up!) 

There are has two channels:
- A composite channel containing all the patterns needed to create the looks
- An effects channel, which is set up with SpaceExplosionFX to make the cyan laser pew (you can do it at any point by pressing **WowTrigger** on that channel).

(Video will be available on TE Slack shortly)