### PR TITLE
Beacons for dynamic model + Gamepad engine

### DIFF
--- a/Fixtures/Beacons/Beacon1.lxf
+++ b/Fixtures/Beacons/Beacon1.lxf
@@ -1,6 +1,6 @@
 {
   label: "Beacon1",
-  tags: [ "dmx", "beam", "dmxFixture" ],
+  tags: [ "dmx", "beacon", "dmxFixture" ],
 
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",

--- a/Fixtures/Beacons/Beacon1.lxf
+++ b/Fixtures/Beacons/Beacon1.lxf
@@ -4,7 +4,8 @@
 
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",
-    "dmx_host": "10.6.1.101"
+    "dmx_host": "10.6.1.101",
+    "tiltLimit": "90"
   },
 
   "components": [

--- a/Fixtures/Beacons/Beacon1.lxf
+++ b/Fixtures/Beacons/Beacon1.lxf
@@ -1,0 +1,15 @@
+{
+  label: "Beacon1",
+  tags: [ "dmx", "beam", "dmxFixture" ],
+
+  "meta": {
+    "dmx": "titanicsend.dmx.model.BeaconModel",
+    "dmx_host": "10.6.1.101"
+  },
+
+  "components": [
+    {
+      type: "point"
+    }
+  ]
+}

--- a/Fixtures/Beacons/Beacon2.lxf
+++ b/Fixtures/Beacons/Beacon2.lxf
@@ -1,6 +1,6 @@
 {
   label: "Beacon1",
-  tags: [ "dmx", "beam", "dmxFixture" ],
+  tags: [ "dmx", "beacon", "dmxFixture" ],
 
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",

--- a/Fixtures/Beacons/Beacon2.lxf
+++ b/Fixtures/Beacons/Beacon2.lxf
@@ -4,7 +4,8 @@
 
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",
-    "dmx_host": "10.6.1.102"
+    "dmx_host": "10.6.1.102",
+    "tiltLimit": "90"
   },
 
   "components": [

--- a/Fixtures/Beacons/Beacon2.lxf
+++ b/Fixtures/Beacons/Beacon2.lxf
@@ -1,0 +1,15 @@
+{
+  label: "Beacon1",
+  tags: [ "dmx", "beam", "dmxFixture" ],
+
+  "meta": {
+    "dmx": "titanicsend.dmx.model.BeaconModel",
+    "dmx_host": "10.6.1.102"
+  },
+
+  "components": [
+    {
+      type: "point"
+    }
+  ]
+}

--- a/Fixtures/Beacons/ChauvetIntimidator.lxf
+++ b/Fixtures/Beacons/ChauvetIntimidator.lxf
@@ -1,0 +1,15 @@
+{
+  label: "BeamQ60",
+  tags: [ "dmx", "beam", "dmxFixture" ],
+
+  "meta": {
+    "dmx": "titanicsend.dmx.model.ChauvetBeamQ60Model",
+    "dmx_host": "10.0.0.69"
+  },
+
+  "components": [
+    {
+      type: "point"
+    }
+  ]
+}

--- a/Fixtures/Beacons/ChauvetIntimidator.lxf
+++ b/Fixtures/Beacons/ChauvetIntimidator.lxf
@@ -1,6 +1,6 @@
 {
   label: "BeamQ60",
-  tags: [ "dmx", "beam", "dmxFixture" ],
+  tags: [ "dmx", "beacon", "dmxFixture" ],
 
   "meta": {
     "dmx": "titanicsend.dmx.model.ChauvetBeamQ60Model",

--- a/src/main/java/titanicsend/app/director/Director.java
+++ b/src/main/java/titanicsend/app/director/Director.java
@@ -26,6 +26,8 @@ public class Director extends LXComponent implements LX.Listener, LXOscComponent
       .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
       .setDescription("Top fader, dims all components");
 
+  private final CompoundParameter beaconsFader;
+
   public Director(LX lx) {
     super(lx, "director");
     current = this;
@@ -37,7 +39,10 @@ public class Director extends LXComponent implements LX.Listener, LXOscComponent
     addFilter(new TagFilter("edges", "Edges", "edge"));
     addFilter(new TagFilter("foh", "FOH", "mothership"));
     addFilter(new Filter("lasers", "Lasers"));
-    addFilter(new DmxFilter("beacons", "Beacons", "beacon"));
+
+    Filter beaconsFilter = new DmxFilter("beacons", "Beacons", "beacon");
+    addFilter(beaconsFilter);
+    this.beaconsFader = beaconsFilter.fader;
 
     addParameter("master", this.master);
 
@@ -59,6 +64,10 @@ public class Director extends LXComponent implements LX.Listener, LXOscComponent
     for (Filter filter : this.filters) {
       filter.modelChanged(model);
     }
+  }
+
+  public double getBeaconsLevel() {
+    return this.beaconsFader.getNormalized() * this.master.getNormalized();
   }
 
   @Override

--- a/src/main/java/titanicsend/app/director/DmxFilter.java
+++ b/src/main/java/titanicsend/app/director/DmxFilter.java
@@ -1,6 +1,8 @@
 package titanicsend.app.director;
 
 import heronarts.lx.model.LXModel;
+import heronarts.lx.studio.TEApp;
+import titanicsend.dmx.DmxEngine;
 
 public class DmxFilter extends Filter {
 

--- a/src/main/java/titanicsend/app/director/DmxFilter.java
+++ b/src/main/java/titanicsend/app/director/DmxFilter.java
@@ -1,8 +1,6 @@
 package titanicsend.app.director;
 
 import heronarts.lx.model.LXModel;
-import heronarts.lx.studio.TEApp;
-import titanicsend.dmx.DmxEngine;
 
 public class DmxFilter extends Filter {
 

--- a/src/main/java/titanicsend/dmx/DmxBuffer.java
+++ b/src/main/java/titanicsend/dmx/DmxBuffer.java
@@ -21,7 +21,7 @@ import titanicsend.dmx.parameter.DmxParameter;
 /**
  * Similar to ModelBuffer. Eventually might be merged with LXBuffer/ModelBuffer.
  *
- * <p>DmxBuffer is one fixture, DmxModelBuffer is all the fixtures
+ * DmxBuffer is one fixture, DmxModelBuffer is all the fixtures
  */
 public class DmxBuffer {
 

--- a/src/main/java/titanicsend/dmx/DmxModelBuffer.java
+++ b/src/main/java/titanicsend/dmx/DmxModelBuffer.java
@@ -17,31 +17,24 @@ package titanicsend.dmx;
 
 import heronarts.lx.LX;
 import heronarts.lx.model.LXModel;
+import titanicsend.dmx.model.DmxModel;
 import titanicsend.dmx.model.DmxWholeModel;
+
+import java.util.List;
 
 /**
  * The DMX equivalent to ModelBuffer uses two classes, DmxBuffer and DmxModelBuffer, due to
  * effectively being a 2D array.
  *
- * <p>DmxBuffer is one fixture, DmxModelBuffer is all the fixtures
+ * DmxBuffer is one fixture, DmxModelBuffer is all the fixtures
  */
-public class DmxModelBuffer extends DmxFullBuffer {
+public class DmxModelBuffer extends DmxFullBuffer implements DmxWholeModel.DmxWholeModelListener {
 
   private final LX lx;
+  private final DmxWholeModel dmxWholeModel;
   private DmxBuffer[] array;
 
   public boolean modified = false;
-
-  private final LX.Listener modelListener =
-      new LX.Listener() {
-        @Override
-        public void modelChanged(LX lx, LXModel model) {
-          // TE is a static model so this isn't necessary
-          // if (array.length != model.size) {
-          //   initArray(getWholeModel(model));
-          // }
-        }
-      };
 
   public static DmxWholeModel getWholeModel(LXModel model) {
     if (model instanceof DmxWholeModel) {
@@ -57,8 +50,13 @@ public class DmxModelBuffer extends DmxFullBuffer {
 
   public DmxModelBuffer(LX lx, DmxWholeModel model) {
     this.lx = lx;
+    this.dmxWholeModel = model;
     initArray(model);
-    lx.addListener(this.modelListener);
+    this.dmxWholeModel.addDmxListener(this);
+  }
+  @Override
+  public void dmxModelsChanged(List<DmxModel> dmxModels) {
+    initArray(this.dmxWholeModel);
   }
 
   private void initArray(DmxWholeModel dmxWholeModel) {
@@ -84,7 +82,8 @@ public class DmxModelBuffer extends DmxFullBuffer {
   }
 
   public void dispose() {
-    this.lx.removeListener(this.modelListener);
+    this.dmxWholeModel.removeDmxListener(this);
     this.array = null;
   }
+
 }

--- a/src/main/java/titanicsend/dmx/model/BeaconModel.java
+++ b/src/main/java/titanicsend/dmx/model/BeaconModel.java
@@ -1,5 +1,7 @@
 package titanicsend.dmx.model;
 
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
 import titanicsend.dmx.DmxBuffer;
 import titanicsend.dmx.parameter.DmxCompoundParameter;
 import titanicsend.dmx.parameter.DmxDiscreteParameter;
@@ -48,9 +50,40 @@ public class BeaconModel extends DmxModel {
 
   public static final int CONTROL_NORMAL = 0;
 
+  public static class BeaconConfig extends DmxCommonConfig {
+    public float tiltLimit;
+
+    public BeaconConfig setTiltLimit(float tiltLimit) {
+      this.tiltLimit = tiltLimit;
+      return this;
+    }
+  }
+
+  static BeaconConfig createConfig(LXModel model) {
+    LXPoint point = model.points[0];
+    BeaconConfig c = new BeaconConfig();
+    c.host = model.meta("dmx_host");
+    c.tiltLimit = Float.parseFloat(model.meta("tiltLimit"));
+    c.x = point.x;
+    c.y = point.y;
+    c.z = point.z;
+
+    return c;
+  }
+
+  /** Dynamic model constructor */
+  public BeaconModel(LXModel model) {
+    super(model, createConfig(model));
+    initialize(((BeaconConfig)this.config).tiltLimit);
+  }
+
+  /** Static model constructor */
   public BeaconModel(DmxCommonConfig config, float tiltLimit, String... tags) {
     super(MODEL_TYPE, config, tags);
+    initialize(tiltLimit);
+  }
 
+  private void initialize(float tiltLimit){
     DmxCompoundParameter pan = new DmxCompoundParameter("Pan").setNumBytes(2);
     DmxCompoundParameter tilt =
         new DmxCompoundParameter("Tilt", TILT_MIN, TILT_MIN, TILT_MAX).setNumBytes(2);
@@ -96,7 +129,7 @@ public class BeaconModel extends DmxModel {
               new DmxDiscreteParameterOption("Open", 0),
               new DmxDiscreteParameterOption("Spot Open", 11),
               new DmxDiscreteParameterOption("Gobo 1", 22),
-              new DmxDiscreteParameterOption("Gobo 2", 32),
+              new DmxDiscreteParameterOption("Gobo 12", 32),
               new DmxDiscreteParameterOption("Gobo 3", 42),
               new DmxDiscreteParameterOption("Gobo 4", 52),
               new DmxDiscreteParameterOption("Gobo 5", 62),

--- a/src/main/java/titanicsend/dmx/model/ChauvetBeamQ60Model.java
+++ b/src/main/java/titanicsend/dmx/model/ChauvetBeamQ60Model.java
@@ -1,5 +1,7 @@
 package titanicsend.dmx.model;
 
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
 import titanicsend.dmx.parameter.DmxCompoundParameter;
 import titanicsend.dmx.parameter.DmxDiscreteParameter;
 import titanicsend.dmx.parameter.DmxDiscreteParameterOption;
@@ -22,16 +24,37 @@ public class ChauvetBeamQ60Model extends DmxModel {
   public static final int INDEX_SHUTTER = 5;
   public static final int INDEX_DIMMER = 6;
   public static final int INDEX_VIRTUAL_COLOR_WHEEL_CONTROL = 7;
-  public static final int INDEX_VIRTCAL_COLOR_WHEEL = 8;
+  public static final int INDEX_VIRTUAL_COLOR_WHEEL = 8;
   public static final int INDEX_RED = 9;
   public static final int INDEX_GREEN = 10;
   public static final int INDEX_BLUE = 11;
   public static final int INDEX_WHITE = 12;
   public static final int INDEX_CONTROL = 13;
 
+  static DmxCommonConfig createConfig(LXModel model) {
+    LXPoint point = model.points[0];
+    DmxCommonConfig c = new DmxCommonConfig();
+    c.host = model.meta("dmx_host");
+    c.x = point.x;
+    c.y = point.y;
+    c.z = point.z;
+
+    return c;
+  }
+
+  /** Dynamic model constructor */
+  public ChauvetBeamQ60Model(LXModel model) {
+    super(model, createConfig(model));
+    initialize();
+  }
+
+  /** Static model constructor */
   public ChauvetBeamQ60Model(DmxCommonConfig config, String... tags) {
     super(MODEL_TYPE, config, tags);
+    initialize();
+  }
 
+  private void initialize() {
     DmxCompoundParameter pan = new DmxCompoundParameter("Pan").setNumBytes(2);
     DmxCompoundParameter tilt = new DmxCompoundParameter("Tilt", -180, 180, 0).setNumBytes(2);
     DmxDiscreteParameter panContinuous =

--- a/src/main/java/titanicsend/dmx/model/DmxModel.java
+++ b/src/main/java/titanicsend/dmx/model/DmxModel.java
@@ -17,6 +17,7 @@
  */
 package titanicsend.dmx.model;
 
+import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.output.ArtNetDatagram;
 import heronarts.lx.output.LXBufferOutput;
@@ -138,8 +139,44 @@ public abstract class DmxModel extends TEModel implements LXParameterListener {
 
   public int numBytes = 0;
 
+  public final DmxCommonConfig config;
+
+  /** Dynamic model constructor */
+  public DmxModel(LXModel model, DmxCommonConfig config) {
+    super("DmxModel", model);
+
+    this.config = config;
+
+    this.id = config.id;
+    this.x.setValue(config.x);
+    this.y.setValue(config.y);
+    this.z.setValue(config.z);
+    this.yaw.setValue(config.yaw);
+    this.pitch.setValue(config.pitch);
+    this.roll.setValue(config.roll);
+    this.host.setValue(config.host);
+    this.artNetSequenceEnabled.setValue(config.sequenceEnabled);
+    this.fps.setValue(config.fps);
+    this.artNetUniverse.setValue(config.universe);
+    this.dmxChannel.setValue(config.channel);
+
+    // It's a baby version of LXStructure classes.
+    // If user changes an output parameter, let's notice and rebuild the output.
+    // Allows runtime adjustments such as from a UI element
+    addOutputParameter("byteOrder", this.byteOrder);
+    addOutputParameter("host", this.host);
+    addOutputParameter("port", this.port);
+    addOutputParameter("fps", this.fps);
+    addOutputParameter("dmxChannel", this.dmxChannel);
+    addOutputParameter("artNetUniverse", this.artNetUniverse);
+    addOutputParameter("artNetSequenceEnabled", this.artNetSequenceEnabled);
+  }
+
+  /** Static model constructor */
   public DmxModel(String teModelType, DmxCommonConfig config, String... tags) {
     super(teModelType, new ArrayList<LXPoint>(), tags);
+
+    this.config = config;
 
     this.id = config.id;
     this.x.setValue(config.x);

--- a/src/main/java/titanicsend/dmx/model/DmxWholeModel.java
+++ b/src/main/java/titanicsend/dmx/model/DmxWholeModel.java
@@ -24,4 +24,25 @@ public interface DmxWholeModel {
   public int sizeDmx();
 
   public List<DmxModel> getDmxModels();
+
+  default void clearBeacons() { }
+
+  default void addBeacon(DmxModel dmxModel) { }
+
+  public interface DmxWholeModelListener {
+    public void dmxModelsChanged(List<DmxModel> dmxModels);
+  }
+
+  default public void addDmxListener(DmxWholeModelListener listener) { }
+
+  default public void removeDmxListener(DmxWholeModelListener listener) { }
+
+  /**
+   * Sequence of events:
+   * LX.modelChanged
+   * TEWholeModel.modelTEChanged
+   * DmxWholeModel.dmxModelsChanged
+   *   --model buffers monitor this one and update
+   */
+  default void notifyDmxWholeModelListeners() { }
 }

--- a/src/main/java/titanicsend/dmx/parameter/DmxCompoundParameter.java
+++ b/src/main/java/titanicsend/dmx/parameter/DmxCompoundParameter.java
@@ -17,6 +17,7 @@ package titanicsend.dmx.parameter;
 
 import heronarts.lx.LX;
 import heronarts.lx.parameter.CompoundParameter;
+import titanicsend.app.director.Director;
 
 public class DmxCompoundParameter extends CompoundParameter implements DmxParameter {
 
@@ -117,7 +118,8 @@ public class DmxCompoundParameter extends CompoundParameter implements DmxParame
    */
   @Override
   public double getDmxValue(double alpha) {
-    return super.getValue() * (this.scaleToAlpha ? alpha : 1);
+    // Quick solution, the director beacons fader will combine with channel fader here
+    return super.getValue() * (this.scaleToAlpha ? (alpha * Director.get().getBeaconsLevel()) : 1);
   }
 
   public DmxParameter setDmxValue(double value) {

--- a/src/main/java/titanicsend/dmx/pattern/BeaconEasyPattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/BeaconEasyPattern.java
@@ -7,6 +7,7 @@ import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIDevice;
 import heronarts.lx.studio.ui.device.UIDeviceControls;
 import titanicsend.dmx.model.BeaconModel;
+import titanicsend.dmx.model.ChauvetBeamQ60Model;
 import titanicsend.dmx.model.DmxModel;
 import titanicsend.dmx.parameter.DmxDiscreteParameter;
 import titanicsend.dmx.parameter.DmxDiscreteParameterOption;
@@ -14,7 +15,7 @@ import titanicsend.ui.UIUtils;
 
 @LXCategory("DMX")
 public class BeaconEasyPattern extends BeaconPattern
-    implements UIDeviceControls<BeaconEasyPattern> {
+        implements UIDeviceControls<BeaconEasyPattern> {
 
   // Color Wheel (without the scroll options)
   DmxDiscreteParameter colorWheelFixed =
@@ -57,19 +58,26 @@ public class BeaconEasyPattern extends BeaconPattern
 
   @Override
   protected void run(double deltaMs) {
-
     double pan = this.pan.getNormalized();
     double tilt = this.tilt.getNormalized();
     int ptSpd = (int) this.ptSpdLinear.getValue();
     int colorWheel = this.colorWheelFixed.getDmxValue();
 
     for (DmxModel d : this.modelTE.getBeacons()) {
-      setDmxNormalized(d, BeaconModel.INDEX_PAN, pan);
-      setDmxNormalized(d, BeaconModel.INDEX_TILT, tilt);
-      setDmxValue(d, BeaconModel.INDEX_PT_SPEED, ptSpd);
-      setDmxValue(d, BeaconModel.INDEX_COLOR_WHEEL, colorWheel);
-      setDmxValue(d, BeaconModel.INDEX_SHUTTER, BeaconModel.SHUTTER_OPEN);
-      setDmxNormalized(d, BeaconModel.INDEX_DIMMER, BeaconModel.DIMMER_NORMALIZED_100);
+      if (d instanceof BeaconModel) {
+        setDmxNormalized(d, BeaconModel.INDEX_PAN, pan);
+        setDmxNormalized(d, BeaconModel.INDEX_TILT, tilt);
+        setDmxValue(d, BeaconModel.INDEX_PT_SPEED, ptSpd);
+        setDmxValue(d, BeaconModel.INDEX_COLOR_WHEEL, colorWheel);
+        setDmxValue(d, BeaconModel.INDEX_SHUTTER, BeaconModel.SHUTTER_OPEN);
+        setDmxNormalized(d, BeaconModel.INDEX_DIMMER, BeaconModel.DIMMER_NORMALIZED_100);
+      } else if (d instanceof ChauvetBeamQ60Model) {
+        setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_PAN, pan);
+        setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_TILT, tilt);
+        setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_SHUTTER, 32);
+        setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_DIMMER, 1);
+        setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_RED, 100);
+      }
     }
   }
 
@@ -77,4 +85,5 @@ public class BeaconEasyPattern extends BeaconPattern
   public void buildDeviceControls(UI ui, UIDevice uiDevice, BeaconEasyPattern device) {
     UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
   }
+
 }

--- a/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
@@ -2,6 +2,7 @@ package titanicsend.dmx.pattern;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BoundedParameter;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.LXNormalizedParameter;
@@ -10,6 +11,7 @@ import heronarts.lx.studio.LXStudio;
 import heronarts.lx.studio.TEApp;
 import heronarts.lx.studio.ui.device.UIDevice;
 import heronarts.lx.studio.ui.device.UIDeviceControls;
+import titanicsend.color.TEColorType;
 import titanicsend.dmx.model.BeaconModel;
 import titanicsend.dmx.model.ChauvetBeamQ60Model;
 import titanicsend.dmx.model.DmxModel;
@@ -149,10 +151,29 @@ public class BeaconGamePattern extends BeaconPattern
                 setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_TILT, tilt);
                 setDmxValue(d, ChauvetBeamQ60Model.INDEX_PT_SPEED, ptSpd);
                 setDmxValue(d, ChauvetBeamQ60Model.INDEX_SHUTTER, shutterValue);
-                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_DIMMER, 1);
-                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_RED, 100);
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_DIMMER, dimmer);
+                int color =  getColor(TEColorType.PRIMARY);
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_RED, redNormalized(color));
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_GREEN, greenNormalized(color));
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_BLUE, blueNormalized(color));
             }
         }
+    }
+
+    private int getColor(TEColorType colorType) {
+      return this.lx.engine.palette.getSwatchColor(colorType.swatchIndex()).getColor();
+    }
+
+    private float redNormalized(int color) {
+      return ((float)Byte.toUnsignedInt(LXColor.red(color))) / 255f;
+    }
+
+    private float greenNormalized(int color) {
+      return ((float)Byte.toUnsignedInt(LXColor.green(color))) / 255f;
+    }
+
+    private float blueNormalized(int color) {
+      return ((float)Byte.toUnsignedInt(LXColor.blue(color))) / 255f;
     }
 
     @Override

--- a/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
@@ -1,0 +1,169 @@
+package titanicsend.dmx.pattern;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.parameter.BoundedParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXNormalizedParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.TEApp;
+import heronarts.lx.studio.ui.device.UIDevice;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+import titanicsend.dmx.model.BeaconModel;
+import titanicsend.dmx.model.ChauvetBeamQ60Model;
+import titanicsend.dmx.model.DmxModel;
+import titanicsend.dmx.parameter.DmxCompoundParameter;
+import titanicsend.gamepad.GamepadEngine;
+import titanicsend.ui.UIUtils;
+
+@LXCategory("DMX")
+public class BeaconGamePattern extends BeaconPattern
+        implements UIDeviceControls<BeaconGamePattern>, GamepadEngine.Gamepad.GamepadListener {
+
+    public final DiscreteParameter input = new DiscreteParameter("Input", 16)
+            .setDescription("Gamepad input number 1-16");
+
+    private final GamepadEngine.Gamepad gamepad;
+
+    public BeaconGamePattern(LX lx) {
+        super(lx);
+
+        addParameter("Gamepad", this.input);
+
+        // TODO: remove visual controls from game pattern
+        addParameter("Pan", this.pan);
+        addParameter("Tilt", this.tilt);
+        addParameter("Cyan", this.cyan);
+        addParameter("Magenta", this.magenta);
+        addParameter("Yellow", this.yellow);
+        addParameter("ClrWheel", this.colorWheel);
+        addParameter("Gobo1", this.gobo1);
+        addParameter("Gobo1Rotate", this.gobo1rotation);
+        addParameter("Gobo2", this.gobo2);
+        addParameter("Prism1", this.prism1);
+        addParameter("Prism1Rotate", this.prism1rotation);
+        addParameter("Prism2Rotate", this.prism2rotation);
+        addParameter("Focus", this.focus);
+        addParameter("Shutter", this.shutter);
+        addParameter("Dimmer", this.dimmer);
+        addParameter("Frost1", this.frost1);
+        addParameter("Frost2", this.frost2);
+        addParameter("ptSpd", this.ptSpeed);
+        addParameter("Control", this.control); // Use caution!
+
+        this.gamepad = TEApp.gamepadEngine.createGamepad();
+        this.gamepad.addListener(this);
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter p) {
+      if (p == this.input) {
+        this.gamepad.input.setValue(this.input.getValue());
+      }
+    }
+
+    private static final int ptSpeedTick = 5;
+
+    @Override
+    public void onGamepadParameterChanged(LXParameter p) {
+      if (p == this.gamepad.axisLeftX) {
+        gamepadAxisToBeaconParameter(this.pan, this.gamepad.axisLeftX);
+      } else if (p == this.gamepad.axisRightX) {
+        gamepadAxisToBeaconParameter(this.tilt, this.gamepad.axisRightY);
+      } else if (p == this.gamepad.dpUp) {
+        if (this.ptSpeed.getDmxValue() < (225-ptSpeedTick)) {
+          this.ptSpeed.increment(ptSpeedTick);
+        }
+//        this.ptSpeed.setNormalized(this.ptSpeed.getNormalized() + .05);
+      } else if (p == this.gamepad.dpDown) {
+          if (this.ptSpeed.getDmxValue() > ptSpeedTick) {
+              this.ptSpeed.decrement(ptSpeedTick);
+          }
+//        this.ptSpeed.setNormalized(this.ptSpeed.getNormalized() - .05);
+      }
+      // TODO: map other buttons to beacon parameters on playa!
+    }
+
+    private void gamepadAxisToBeaconParameter(DmxCompoundParameter target, LXNormalizedParameter source) {
+      target.setValue(target.range.normalizedToValue(source.getNormalized(), 3, BoundedParameter.NormalizationCurve.BIAS_CENTER));
+    }
+
+    private int shutterValue = 32;
+
+    @Override
+    public void run(double deltaMs) {
+        float rightTrigger = this.gamepad.axisRightTrigger.getNormalizedf();
+        if (rightTrigger < .1) {
+            shutterValue = 32;
+        } else {
+            shutterValue = (int) ((rightTrigger - .1) * (95-75) / (1 - .1) + 75);
+        }
+
+        // Reminder: Don't use Normalized for DmxDiscreteParameters,
+        // they likely do not scale linearly to 0-255.
+        double pan = this.pan.getNormalized();
+        double tilt = this.tilt.getNormalized();
+        double cyan = this.cyan.getNormalized();
+        double magenta = this.magenta.getNormalized();
+        double yellow = this.yellow.getNormalized();
+        int colorWheel = this.colorWheel.getDmxValue();
+        int gobo1 = this.gobo1.getDmxValue();
+        double gobo1rotate = this.gobo1rotation.getNormalized();
+        int gobo2 = this.gobo2.getDmxValue();
+        int prism1 = this.prism1.getDmxValue();
+        double prism1rotate = this.prism1rotation.getNormalized();
+        double prism2rotate = this.prism2rotation.getNormalized();
+        double focus = this.focus.getNormalized();
+        int shutter = this.shutter.getDmxValue();
+        double dimmer = this.dimmer.getNormalized();
+        double frost1 = this.frost1.getNormalized();
+        double frost2 = this.frost2.getNormalized();
+        int ptSpd = this.ptSpeed.getDmxValue();
+        int control = this.control.getDmxValue();
+
+        for (DmxModel d : this.modelTE.getBeacons()) {
+            if (d instanceof BeaconModel) {
+                setDmxNormalized(d, BeaconModel.INDEX_PAN, pan);
+                setDmxNormalized(d, BeaconModel.INDEX_TILT, tilt);
+                setDmxNormalized(d, BeaconModel.INDEX_CYAN, cyan);
+                setDmxNormalized(d, BeaconModel.INDEX_MAGENTA, magenta);
+                setDmxNormalized(d, BeaconModel.INDEX_YELLOW, yellow);
+                setDmxValue(d, BeaconModel.INDEX_COLOR_WHEEL, colorWheel);
+                setDmxValue(d, BeaconModel.INDEX_GOBO1, gobo1);
+                setDmxNormalized(d, BeaconModel.INDEX_GOBO1_ROTATION, gobo1rotate);
+                setDmxValue(d, BeaconModel.INDEX_GOBO2, gobo2);
+                setDmxValue(d, BeaconModel.INDEX_PRISM1, prism1);
+                setDmxNormalized(d, BeaconModel.INDEX_PRISM1_ROTATION, prism1rotate);
+                setDmxNormalized(d, BeaconModel.INDEX_PRISM2_ROTATION, prism2rotate);
+                setDmxNormalized(d, BeaconModel.INDEX_FOCUS, focus);
+                setDmxValue(d, BeaconModel.INDEX_SHUTTER, shutter);
+                setDmxNormalized(d, BeaconModel.INDEX_DIMMER, dimmer);
+                setDmxNormalized(d, BeaconModel.INDEX_FROST1, frost1);
+                setDmxNormalized(d, BeaconModel.INDEX_FROST2, frost2);
+                setDmxValue(d, BeaconModel.INDEX_PT_SPEED, ptSpd);
+                // CONTROL_NORMAL is a default value so isn't required to be set by pattern
+                setDmxValue(d, BeaconModel.INDEX_CONTROL, control);
+            } else if (d instanceof ChauvetBeamQ60Model) {
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_PAN, pan);
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_TILT, tilt);
+                setDmxValue(d, ChauvetBeamQ60Model.INDEX_PT_SPEED, ptSpd);
+                setDmxValue(d, ChauvetBeamQ60Model.INDEX_SHUTTER, shutterValue);
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_DIMMER, 1);
+                setDmxNormalized(d, ChauvetBeamQ60Model.INDEX_RED, 100);
+            }
+        }
+    }
+
+    @Override
+    public void dispose() {
+        this.gamepad.removeListener(this);
+        this.gamepad.dispose();
+        super.dispose();
+    }
+
+    @Override
+    public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, BeaconGamePattern device) {
+        UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    }
+}

--- a/src/main/java/titanicsend/dmx/pattern/BeaconPattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/BeaconPattern.java
@@ -187,7 +187,7 @@ public abstract class BeaconPattern extends DmxPattern {
           });
   // It would be fine for a pattern to set dimmer to max and let the faders do the rest
   DmxCompoundParameter dimmer =
-      new DmxCompoundParameter("Dimmer", 0, 0, 100)
+      new DmxCompoundParameter("Dimmer", 100, 0, 100)
           .setNumBytes(2)
           .setScaleToAlpha(true); // Faders applied to this parameter
   DmxCompoundParameter frost1 = new DmxCompoundParameter("Frost1", 0, 0, 100);

--- a/src/main/java/titanicsend/gamepad/GamepadEngine.java
+++ b/src/main/java/titanicsend/gamepad/GamepadEngine.java
@@ -1,0 +1,398 @@
+package titanicsend.gamepad;
+
+import heronarts.glx.event.GamepadEvent;
+import heronarts.lx.LX;
+import heronarts.lx.LXComponent;
+import heronarts.lx.parameter.*;
+import heronarts.lx.utils.LXUtils;
+import org.lwjgl.system.MemoryUtil;
+
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Scanner;
+
+import static org.lwjgl.glfw.GLFW.GLFW_JOYSTICK_LAST;
+import static org.lwjgl.glfw.GLFW.glfwUpdateGamepadMappings;
+
+/**
+ * A relay between Chromatik system gamepad events and consumers such as patterns.
+ * Two mechanisms are available for classes wishing to use gamepad data:
+ * 1. Listen to GamepadEngine to be notified of raw gamepad events.
+ * 2. Create a new Gamepad object which has axis+button parameters and an adjustable Input
+ *    parameter to choose from one of the 16 system gamepad slots.
+ */
+public class GamepadEngine extends LXComponent {
+
+  static public final String MAPPINGS_FILE = "resources/gamecontrollers/gamecontrollerdb.txt";
+  // Fixed number of gamepad slots as defined by GLFW
+  static public final int NUM_GAMEPADS = GLFW_JOYSTICK_LAST + 1;
+
+  public static interface Listener {
+    default public void onGamepadButtonPressed(GamepadEvent gamepadEvent, int button) { }
+
+    default public void onGamepadButtonReleased(GamepadEvent gamepadEvent, int button) { }
+
+    default public void onGamepadAxisChanged(GamepadEvent gamepadEvent, int axis, float value) { }
+  }
+
+  private final List<Listener> listeners = new ArrayList<Listener>();
+
+  private final SystemGamepad[] systemGamePads = new SystemGamepad[NUM_GAMEPADS];
+
+  public GamepadEngine(LX lx) {
+    super(lx, "GamepadEngine");
+
+    for (int i = 0; i < NUM_GAMEPADS; i++) {
+      this.systemGamePads[i] = new SystemGamepad(lx, i);
+    }
+  }
+
+  /**
+   * Update gamepad mappings for this runtime.
+   */
+  public void updateGamepadMappings() {
+    // To get the latest mappings, download a new copy of
+    // https://github.com/mdqinc/SDL_GameControllerDB/blob/master/gamecontrollerdb.txt
+
+    // Load gamepad mappings from a file
+    String mappings = loadGamepadMappingsFromFile();
+
+    if (!LXUtils.isEmpty(mappings)) {
+      ByteBuffer mappingBuffer = MemoryUtil.memUTF8(mappings);
+
+      if (glfwUpdateGamepadMappings(mappingBuffer)) {
+        LX.log("Gamepad mappings updated successfully.");
+      } else {
+        LX.error("Failed to update gamepad mappings.");
+      }
+    }
+  }
+
+  /**
+   * Load gamepad mappings from a text file. Only needed for mappings that did not exist
+   * in the lwjgl db, but it's fine to load the full latest db too.
+   */
+  private String loadGamepadMappingsFromFile() {
+    StringBuilder mappings = new StringBuilder();
+    try (Scanner s = new Scanner(new File(MAPPINGS_FILE))) {
+      while (s.hasNextLine()) {
+        String line = s.nextLine();
+        mappings.append(line).append("\n");
+      }
+    } catch (Throwable e) {
+      LX.error(e, "Error reading gamepad mappings file: " + e.getMessage());
+      return null;
+    }
+
+    return mappings.toString().trim();
+  }
+
+  /* Listeners */
+
+  public GamepadEngine addListener(Listener listener) {
+    Objects.requireNonNull(listener);
+    if (this.listeners.contains(listener)) {
+      throw new IllegalStateException(("Cannot add duplicate GamepadEngine.Listener: " + listener));
+    }
+    this.listeners.add(listener);
+    return this;
+  }
+
+  public GamepadEngine removeListener(Listener listener) {
+    if (!this.listeners.contains(listener)) {
+      throw new IllegalStateException(
+        "May not remove non-registered GamepadEngine.Listener: " + listener);
+    }
+    this.listeners.remove(listener);
+    return this;
+  }
+
+  /* Input: system event notifications from TEApp */
+
+  public void lxGamepadButtonPressed(GamepadEvent gamepadEvent, int button) {
+    for (Listener listener : this.listeners) {
+      listener.onGamepadButtonPressed(gamepadEvent, button);
+    }
+    lxGamepadButton(gamepadEvent, button, true);
+  }
+
+  public void lxGamepadButtonReleased(GamepadEvent gamepadEvent, int button) {
+    for (Listener listener : this.listeners) {
+      listener.onGamepadButtonReleased(gamepadEvent, button);
+    }
+    lxGamepadButton(gamepadEvent, button, false);
+  }
+
+  private void lxGamepadButton(GamepadEvent gamepadEvent, int button, boolean on) {
+    SystemGamepad gamepad = this.systemGamePads[gamepadEvent.gamepadId];
+    switch (button) {
+      case GamepadEvent.BUTTON_A:
+        gamepad.a.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_B:
+        gamepad.b.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_X:
+        gamepad.x.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_Y:
+        gamepad.y.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_DPAD_UP:
+        gamepad.dpUp.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_DPAD_DOWN:
+        gamepad.dpDown.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_DPAD_LEFT:
+        gamepad.dpLeft.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_DPAD_RIGHT:
+        gamepad.dpRight.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_LEFT_BUMPER:
+        gamepad.leftShoulder.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_RIGHT_BUMPER:
+        gamepad.rightShoulder.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_LEFT_THUMB:
+        gamepad.leftStick.setValue(on);
+        break;
+      case GamepadEvent.BUTTON_RIGHT_THUMB:
+        gamepad.rightStick.setValue(on);
+        break;
+    }
+  }
+
+  public void lxGamepadAxisChanged(GamepadEvent gamepadEvent, int axis, float value) {
+    for (Listener listener : this.listeners) {
+      listener.onGamepadAxisChanged(gamepadEvent, axis, value);
+    }
+    SystemGamepad gamepad = this.systemGamePads[gamepadEvent.gamepadId];
+    switch (axis) {
+      case 0:
+        gamepad.axisLeftX.setValue(value);
+        break;
+      case 1:
+        gamepad.axisLeftY.setValue(value);
+        break;
+      case 2:
+        gamepad.axisRightX.setValue(value);
+        break;
+      case 3:
+        gamepad.axisRightY.setValue(value);
+        break;
+      case 4:
+        gamepad.axisLeftTrigger.setValue(value);
+        break;
+      case 5:
+        gamepad.axisRightTrigger.setValue(value);
+        break;
+    }
+  }
+
+  public Gamepad createGamepad() {
+    return new Gamepad(this.lx);
+  }
+
+  public Gamepad createGamepad(int input) {
+    return new Gamepad(this.lx, input);
+  }
+
+  public void dispose() {
+    this.listeners.clear();
+  }
+
+  /**
+   * Common base class for system and user gamepads. Represents a physical gamepad
+   * with parameters for button and axis states.
+   */
+  public abstract class GamepadBase extends LXComponent {
+    public interface GamepadListener {
+      public void onGamepadParameterChanged(LXParameter parameter);
+    }
+
+    public final BoundedParameter axisLeftX = new BoundedParameter("Axis L-X", 0, -1, 1);
+    public final BoundedParameter axisLeftY = new BoundedParameter("Axis L-Y", 0, -1, 1);
+    public final BoundedParameter axisRightX = new BoundedParameter("Axis R-X", 0, -1, 1);
+    public final BoundedParameter axisRightY = new BoundedParameter("Axis R-Y", 0, -1, 1);
+
+    public final BoundedParameter axisLeftTrigger = new BoundedParameter("Axis R-Y", 0, -1, 1);
+    public final BoundedParameter axisRightTrigger = new BoundedParameter("Axis R-Y", 0, -1, 1);
+
+    public final BooleanParameter a = new BooleanParameter("A");
+    public final BooleanParameter b = new BooleanParameter("B");
+    public final BooleanParameter x = new BooleanParameter("X");
+    public final BooleanParameter y = new BooleanParameter("Y");
+    public final BooleanParameter back = new BooleanParameter("Back");
+    public final BooleanParameter start = new BooleanParameter("Start");
+    public final BooleanParameter guide = new BooleanParameter("Guide");
+    public final BooleanParameter dpUp = new BooleanParameter("DP up");
+    public final BooleanParameter dpRight = new BooleanParameter("DP right");
+    public final BooleanParameter dpDown = new BooleanParameter("DP down");
+    public final BooleanParameter dpLeft = new BooleanParameter("DP left");
+    public final BooleanParameter leftShoulder = new BooleanParameter("L Shoulder");
+    public final BooleanParameter rightShoulder = new BooleanParameter("R Shoulder");
+    public final BooleanParameter leftStick = new BooleanParameter("L Stick");
+    public final BooleanParameter rightStick = new BooleanParameter("R Stick");
+
+    public GamepadBase(LX lx) {
+      super(lx);
+      addParameter("axisLeftX", this.axisLeftX);
+      addParameter("axisLeftY", this.axisLeftY);
+      addParameter("axisRightX", this.axisRightX);
+      addParameter("axisRightY", this.axisRightY);
+      addParameter("axisLeftTrigger", this.axisLeftTrigger);
+      addParameter("axisRightTrigger", this.axisRightTrigger);
+      addParameter("a", this.a);
+      addParameter("b", this.b);
+      addParameter("x", this.x);
+      addParameter("y", this.y);
+      addParameter("back", this.back);
+      addParameter("start", this.start);
+      addParameter("guide", this.guide);
+      addParameter("dpUp", this.dpUp);
+      addParameter("dpRight", this.dpRight);
+      addParameter("dpDown", this.dpDown);
+      addParameter("dpLeft", this.dpLeft);
+      addParameter("leftShoulder", this.leftShoulder);
+      addParameter("rightShoulder", this.rightShoulder);
+      addParameter("leftStick", this.leftStick);
+      addParameter("rightStick", this.rightStick);
+    }
+
+    private List<GamepadListener> listeners = new ArrayList<GamepadListener>();
+
+    public GamepadBase addListener(GamepadListener listener) {
+      Objects.requireNonNull(listener);
+      if (this.listeners.contains(listener)) {
+        throw new IllegalStateException(("Cannot add duplicate GamepadListener: " + listener));
+      }
+      this.listeners.add(listener);
+      return this;
+    }
+
+    public GamepadBase removeListener(GamepadListener listener) {
+      if (!this.listeners.contains(listener)) {
+        throw new IllegalStateException(
+            "May not remove non-registered GamepadListener: " + listener);
+      }
+      this.listeners.remove(listener);
+      return this;
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter parameter) {
+      for (GamepadListener listener : this.listeners) {
+        listener.onGamepadParameterChanged(parameter);
+      }
+    }
+  }
+
+  /**
+   * Gamepad representing a fixed input number 1-16
+   */
+  public class SystemGamepad extends GamepadBase {
+    public final int input;
+
+    public SystemGamepad(LX lx, int input) {
+      super(lx);
+      this.input = input;
+    }
+  }
+
+  /**
+   * Gamepad with an adjustable input number allowing selection from the system gamepad slots.
+   */
+  public class Gamepad extends GamepadBase {
+    public final DiscreteParameter input = new DiscreteParameter("Input", NUM_GAMEPADS)
+      .setDescription("Gamepad input number 1-16");
+
+    // Event source
+    private SystemGamepad source;
+
+    private GamepadListener sourceListener = (p) -> {
+      // Follow source parameters
+      getParameter(p.getPath()).setValue(p.getValue());
+    };
+
+    private Gamepad(LX lx) {
+      this(lx,0);
+    }
+
+    private Gamepad(LX lx, int input) {
+      super(lx);
+      addParameter("input", this.input);
+
+      // Set input number, which will immediately sync this to the corresponding system gamepad
+      this.input.setValue(input);
+      if (input == 0) {
+        onInputChanged(input);
+      }
+    }
+
+    @Override
+    public void onParameterChanged(LXParameter parameter) {
+      super.onParameterChanged(parameter);
+      if (parameter == this.input) {
+        onInputChanged(this.input.getValuei());
+      }
+    }
+
+    private void onInputChanged(int input) {
+      if (this.source != null) {
+        unregister();
+      }
+      this.source = systemGamePads[input];
+      register();
+      refreshFromSource();
+    }
+
+    private void register() {
+      this.source.addListener(this.sourceListener);
+    }
+
+    private void unregister() {
+      this.source.removeListener(this.sourceListener);
+    }
+
+    /**
+     * Copy parameter values from source gamepad
+     */
+    private void refreshFromSource() {
+      this.axisLeftX.setValue(this.source.axisLeftX.getValue());
+      this.axisLeftY.setValue(this.source.axisLeftY.getValue());
+      this.axisRightX.setValue(this.source.axisRightX.getValue());
+      this.axisRightY.setValue(this.source.axisRightY.getValue());
+      this.axisLeftTrigger.setValue(this.source.axisLeftTrigger.getValue());
+      this.axisRightTrigger.setValue(this.source.axisRightTrigger.getValue());
+      this.a.setValue(this.source.a.getValue());
+      this.b.setValue(this.source.b.getValue());
+      this.x.setValue(this.source.x.getValue());
+      this.y.setValue(this.source.y.getValue());
+      this.back.setValue(this.source.back.getValue());
+      this.start.setValue(this.source.start.getValue());
+      this.guide.setValue(this.source.guide.getValue());
+      this.dpUp.setValue(this.source.dpUp.getValue());
+      this.dpRight.setValue(this.source.dpRight.getValue());
+      this.dpDown.setValue(this.source.dpDown.getValue());
+      this.dpLeft.setValue(this.source.dpLeft.getValue());
+      this.leftShoulder.setValue(this.source.leftShoulder.getValue());
+      this.rightShoulder.setValue(this.source.rightShoulder.getValue());
+      this.leftStick.setValue(this.source.leftStick.getValue());
+      this.rightStick.setValue(this.source.rightStick.getValue());
+    }
+
+    @Override
+    public void dispose() {
+      if (this.source != null) {
+        unregister();
+      }
+      super.dispose();
+    }
+  }
+}

--- a/src/main/java/titanicsend/model/TEModel.java
+++ b/src/main/java/titanicsend/model/TEModel.java
@@ -3,6 +3,7 @@ package titanicsend.model;
 import java.util.List;
 import java.util.stream.Stream;
 
+import heronarts.lx.LXComponent;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
 

--- a/src/main/java/titanicsend/model/TEWholeModel.java
+++ b/src/main/java/titanicsend/model/TEWholeModel.java
@@ -18,7 +18,7 @@ import titanicsend.dmx.model.DmxWholeModel;
  */
 public interface TEWholeModel extends DmxWholeModel {
 
-  public static interface TEListener {
+  public static interface TEModelListener {
     /**
      * TEWholeModel collections have been rebuilt following a change to the
      * LXModel hierarchy. All users of these collections and objects should
@@ -26,8 +26,8 @@ public interface TEWholeModel extends DmxWholeModel {
      */
     public void modelTEChanged(TEWholeModel model);
   }
-  public TEWholeModel addListener(TEListener listener);
-  public TEWholeModel removeListener(TEListener listener);
+  public TEWholeModel addListener(TEModelListener listener);
+  public TEWholeModel removeListener(TEModelListener listener);
 
   public abstract boolean isGapPoint(LXPoint p);
   public abstract int[] getGapPointIndices();

--- a/src/main/java/titanicsend/model/TEWholeModelStatic.java
+++ b/src/main/java/titanicsend/model/TEWholeModelStatic.java
@@ -1081,9 +1081,9 @@ public class TEWholeModelStatic extends LXModel implements TEWholeModel {
     view.normalization.setValue(viewDefinition.viewNormalization);
   }
 
-  private final List<TEListener> listeners = new ArrayList<TEListener>();
+  private final List<TEModelListener> listeners = new ArrayList<TEModelListener>();
 
-  public TEWholeModel addListener(TEListener listener) {
+  public TEWholeModel addListener(TEModelListener listener) {
     Objects.requireNonNull(listener);
     if (this.listeners.contains(listener)) {
       throw new IllegalStateException("Cannot add duplicate TEListener: " + listener);
@@ -1092,7 +1092,7 @@ public class TEWholeModelStatic extends LXModel implements TEWholeModel {
     return this;
   }
 
-  public TEWholeModel removeListener(TEListener listener) {
+  public TEWholeModel removeListener(TEModelListener listener) {
     if (!this.listeners.contains(listener)) {
       throw new IllegalStateException("Cannot remove non-registered TEListener: " + listener);
     }

--- a/src/main/java/titanicsend/pattern/mike/EdgeRunner.java
+++ b/src/main/java/titanicsend/pattern/mike/EdgeRunner.java
@@ -15,12 +15,12 @@ import java.util.*;
 import titanicsend.app.TEVirtualColor;
 import titanicsend.color.TEColorType;
 import titanicsend.model.*;
-import titanicsend.model.TEWholeModel.TEListener;
+import titanicsend.model.TEWholeModel.TEModelListener;
 import titanicsend.pattern.TEPattern;
 import titanicsend.util.TEColor;
 
 @LXCategory("Combo FG")
-public class EdgeRunner extends TEPattern implements TEListener {
+public class EdgeRunner extends TEPattern implements TEModelListener {
   public final DiscreteParameter numRunners =
       new DiscreteParameter("Runners", 10, 0, 50).setDescription("Number of concurrent runners");
 


### PR DESCRIPTION
DmxEngine (ie Beacons) modified to work with dynamic model.  DmxModel class can be specified in an LXF, therefore beacons can be added and removed like other fixtures.  There's an intricate tracking of LX buffers that creates DMX buffers and makes them available to patterns, so in theory beacon patterns can be run on multiple channels and blended.  The blending has not been extensively tested and I expect for this year we'll run a single dedicated Beacons channel.

Added an example pattern where beacon color is synced to the global palette.  Demo video shows color following our Director midi controller.

Implemented the Director fader for beacons into beacon models.  This happens behind the scenes of the pattern where the channel fader is applied to the DMX fixture's Dimmer parameter.

Added a Gamepad engine to flush out on the gamepad support we added to Chromatik this summer.  The BeaconGame pattern demonstrates gamepad control and color sync.

Of note the DmxEngine is still a very early version.  It should work for this year but still needs refinement and polish.

[https://www.youtube.com/watch?v=MFjWLs3A_zY](https://www.youtube.com/watch?v=MFjWLs3A_zY)
