### PR TITLE
Mothership driving pattern

### DIFF
--- a/Fixtures/Mothership/window/Slice02P.lxf
+++ b/Fixtures/Mothership/window/Slice02P.lxf
@@ -46,13 +46,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "run" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "run" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "run" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "run" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "run" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "run" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "run" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" }
   ],

--- a/Fixtures/Mothership/window/Slice02S.lxf
+++ b/Fixtures/Mothership/window/Slice02S.lxf
@@ -46,13 +46,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "run" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "run" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "run" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "run" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "run" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "run" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "run" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" }
   ],

--- a/Fixtures/Mothership/window/Slice03P.lxf
+++ b/Fixtures/Mothership/window/Slice03P.lxf
@@ -46,13 +46,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "run" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "run" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "run" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "run" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "run" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "run" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "run" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" }
   ],

--- a/Fixtures/Mothership/window/Slice03S.lxf
+++ b/Fixtures/Mothership/window/Slice03S.lxf
@@ -46,13 +46,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "run" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "run" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "run" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "run" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "run" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "run" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "run" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" }
   ],

--- a/Fixtures/Mothership/window/Slice05P.lxf
+++ b/Fixtures/Mothership/window/Slice05P.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 05P",
-  tags: [ "slice", "port", "slice05", "slice05p" ],
+  tags: [ "slice", "port", "slice05", "slice05p", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.35", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice05S.lxf
+++ b/Fixtures/Mothership/window/Slice05S.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 05S",
-  tags: [ "slice", "starboard", "star", "slice05", "slice05s" ],
+  tags: [ "slice", "starboard", "star", "slice05", "slice05s", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.13", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice06P.lxf
+++ b/Fixtures/Mothership/window/Slice06P.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 06P",
-  tags: [ "slice", "port", "slice06", "slice06p" ],
+  tags: [ "slice", "port", "slice06", "slice06p", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.15", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice06S.lxf
+++ b/Fixtures/Mothership/window/Slice06S.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 06S",
-  tags: [ "slice", "starboard", "star", "slice06", "slice06s" ],
+  tags: [ "slice", "starboard", "star", "slice06", "slice06s", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.17", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice07P.lxf
+++ b/Fixtures/Mothership/window/Slice07P.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 07P",
-  tags: [ "slice", "port", "slice07", "slice07p" ],
+  tags: [ "slice", "port", "slice07", "slice07p", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.18", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice07S.lxf
+++ b/Fixtures/Mothership/window/Slice07S.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 07S",
-  tags: [ "slice", "starboard", "star", "slice07", "slice07s" ],
+  tags: [ "slice", "starboard", "star", "slice07", "slice07s", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.34", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice08P.lxf
+++ b/Fixtures/Mothership/window/Slice08P.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 08P",
-  tags: [ "slice", "port", "slice08", "slice08p" ],
+  tags: [ "slice", "port", "slice08", "slice08p", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.9", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice08S.lxf
+++ b/Fixtures/Mothership/window/Slice08S.lxf
@@ -2,7 +2,7 @@
   /* Mothership by Titanic's End */
 
   label: "Slice 08S",
-  tags: [ "slice", "starboard", "star", "slice08", "slice08s" ],
+  tags: [ "slice", "starboard", "star", "slice08", "slice08s", "drive" ],
 
   "parameters": {
     "host": { type: "string", default: "10.128.42.36", label: "Host", description: "Controller IP address or hostname" },

--- a/Fixtures/Mothership/window/Slice11P.lxf
+++ b/Fixtures/Mothership/window/Slice11P.lxf
@@ -49,13 +49,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "drive" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "drive" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "drive" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "drive" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "drive" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "drive" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "drive" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" },
     { type: "Window9", id: "w9", extraLEDs: "$w9extraLEDs", ledOffset: "$w9ledOffset" }

--- a/Fixtures/Mothership/window/Slice11S.lxf
+++ b/Fixtures/Mothership/window/Slice11S.lxf
@@ -49,13 +49,13 @@
   ],
 
   "components": [
-    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset" },
-    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset" },
-    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset" },
-    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset" },
-    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset" },
-    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset" },
-    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset" },
+    { type: "Window1", id: "w1", extraLEDs: "$w1extraLEDs", ledOffset: "$w1ledOffset", tag: "drive" },
+    { type: "Window2", id: "w2", extraLEDs: "$w2extraLEDs", ledOffset: "$w2ledOffset", tag: "drive" },
+    { type: "Window3", id: "w3", extraLEDs: "$w3extraLEDs", ledOffset: "$w3ledOffset", tag: "drive" },
+    { type: "Window4", id: "w4", extraLEDs: "$w4extraLEDs", ledOffset: "$w4ledOffset", tag: "drive" },
+    { type: "Window5", id: "w5", extraLEDs: "$w5extraLEDs", ledOffset: "$w5ledOffset", tag: "drive" },
+    { type: "Window6", id: "w6", extraLEDs: "$w6extraLEDs", ledOffset: "$w6ledOffset", tag: "drive" },
+    { type: "Window7", id: "w7", extraLEDs: "$w7extraLEDs", ledOffset: "$w7ledOffset", tag: "drive" },
     { type: "Window8A", id: "w8a", extraLEDs: "$w8AextraLEDs", ledOffset: "$w8AledOffset" },
     { type: "Window8B", id: "w8b", extraLEDs: "$w8BextraLEDs", ledOffset: "$w8BledOffset" },
     { type: "Window9", id: "w9", extraLEDs: "$w9extraLEDs", ledOffset: "$w9ledOffset" }

--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -359,6 +359,8 @@ public class TEApp extends LXStudio {
       lx.registry.addPattern(HandTracker.class);
       lx.registry.addPattern(TargetPixelStamper.class);
       //lx.registry.addPattern(ModelFileWriter.class);
+      lx.registry.addPattern(TwoColorPattern.class);
+      lx.registry.addPattern(MothershipDrivingPattern.class);
 
       // Midi surface names for use with BomeBox
       lx.engine.midi.registerSurface(

--- a/src/main/java/titanicsend/pattern/cesar/HandTracker.java
+++ b/src/main/java/titanicsend/pattern/cesar/HandTracker.java
@@ -12,8 +12,9 @@ import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.StringParameter;
 import titanicsend.color.TEColorType;
 import titanicsend.pattern.TEPattern;
+import titanicsend.util.TECategory;
 
-@LXCategory("Panel FG")
+@LXCategory(TECategory.UTILITY)
 public class HandTracker extends TEPattern {
   public final BooleanParameter circle =
       new BooleanParameter("Circle", false).setDescription("Square or circle");

--- a/src/main/java/titanicsend/pattern/jon/ModelFileWriter.java
+++ b/src/main/java/titanicsend/pattern/jon/ModelFileWriter.java
@@ -24,11 +24,12 @@ import titanicsend.model.TEPanelModel;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 import titanicsend.util.TE;
+import titanicsend.util.TECategory;
 
 import javax.imageio.ImageIO;
 
 /** Write model points, and other data to one or more CSV files. */
-@LXCategory("Utility")
+@LXCategory(TECategory.UTILITY)
 public class ModelFileWriter extends TEPerformancePattern {
   boolean doneWriting = false;
   public static final int IMAGE_WIDTH = 640;

--- a/src/main/java/titanicsend/pattern/justin/MothershipDrivingPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/MothershipDrivingPattern.java
@@ -1,0 +1,25 @@
+package titanicsend.pattern.justin;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.LXComponentName;
+import heronarts.lx.color.LXColor;
+import titanicsend.util.TECategory;
+
+/**
+ * Driving lights and running lights for Mothership.
+ * Tags are set in the fixture files.
+ */
+@LXCategory(TECategory.UTILITY)
+@LXComponentName("Mothership Driving")
+public class MothershipDrivingPattern extends TwoColorPattern {
+
+  public MothershipDrivingPattern(LX lx) {
+    super(lx);
+
+    this.color1.setColor(LXColor.WHITE);
+    this.color2.setColor(LXColor.RED);
+    this.tag1.reset("drive");
+    this.tag2.reset("run");
+  }
+}

--- a/src/main/java/titanicsend/pattern/justin/TwoColorPattern.java
+++ b/src/main/java/titanicsend/pattern/justin/TwoColorPattern.java
@@ -1,0 +1,117 @@
+package titanicsend.pattern.justin;
+
+import heronarts.glx.ui.UI2dContainer;
+import heronarts.glx.ui.component.UIKnob;
+import heronarts.glx.ui.component.UITextBox;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.LXComponentName;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LinkedColorParameter;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.parameter.StringParameter;
+import heronarts.lx.pattern.LXPattern;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.device.UIDevice;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+import heronarts.lx.utils.LXUtils;
+import titanicsend.util.TECategory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@LXCategory(TECategory.UTILITY)
+@LXComponentName("Two Color")
+public class TwoColorPattern extends LXPattern implements UIDeviceControls<TwoColorPattern> {
+
+  public LinkedColorParameter color1 = new LinkedColorParameter("Color1", LXColor.WHITE);
+  public LinkedColorParameter color2 = new LinkedColorParameter("Color2", LXColor.RED);
+
+  public StringParameter tag1 = new StringParameter("Tag1", "tag1");
+  public StringParameter tag2 = new StringParameter("Tag2", "tag2");
+
+  private final List<LXPoint> points1 = new ArrayList<LXPoint>();
+  private final List<LXPoint> points2 = new ArrayList<LXPoint>();
+
+  public TwoColorPattern(LX lx) {
+    super(lx);
+
+    addParameter("color1", this.color1);
+    addParameter("color2", this.color2);
+    addParameter("tag1", this.tag1);
+    addParameter("tag2", this.tag2);
+
+    refresh1();
+    refresh2();
+  }
+
+  @Override
+  protected void onModelChanged(LXModel model) {
+    refresh1();
+    refresh2();
+  }
+
+  @Override
+  public void onParameterChanged(LXParameter p) {
+    if (p == this.tag1) {
+      refresh1();
+    } else if (p == this.tag2) {
+      refresh2();
+    }
+  }
+
+  protected void refresh1() {
+    refresh(this.points1, this.tag1.getString());
+  }
+
+  protected void refresh2() {
+    refresh(this.points2, this.tag2.getString());
+  }
+
+  private void refresh(List<LXPoint> points, String tag) {
+    points.clear();
+    if (LXUtils.isEmpty(tag)) {
+      return;
+    }
+
+    for (LXModel tagModel : this.model.sub(tag)) {
+      points.addAll(tagModel.getPoints());
+    }
+  }
+
+  @Override
+  protected void run(double deltaMs) {
+    int color1 = this.color1.getColor();
+    int color2 = this.color2.getColor();
+
+    for (LXPoint point : this.points1) {
+      this.colors[point.index] = color1;
+    }
+
+    for (LXPoint point : this.points2) {
+      this.colors[point.index] = color2;
+    }
+  }
+
+  protected UITextBox textTag1;
+  protected UITextBox textTag2;
+
+  @Override
+  public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, TwoColorPattern device) {
+    uiDevice.setLayout(UI2dContainer.Layout.VERTICAL, 8);
+    uiDevice.setContentWidth(155);
+
+    uiDevice.addChildren(
+      UIDevice.newHorizontalContainer(UIKnob.HEIGHT, 4).addChildren(
+        newColorControl(this.color1),
+        newTextBox(this.tag1, 100).setY(10)
+      ),
+      UIDevice.newHorizontalContainer(UIKnob.HEIGHT, 4).addChildren(
+        newColorControl(this.color2),
+        newTextBox(this.tag2, 100).setY(10)
+      )
+    );
+  }
+}

--- a/src/main/java/titanicsend/pattern/util/TargetPixelStamper.java
+++ b/src/main/java/titanicsend/pattern/util/TargetPixelStamper.java
@@ -13,8 +13,9 @@ import heronarts.lx.parameter.LXParameter;
 import java.util.*;
 import titanicsend.model.TEPanelSection;
 import titanicsend.pattern.TEPattern;
+import titanicsend.util.TECategory;
 
-@LXCategory("Utility")
+@LXCategory(TECategory.UTILITY)
 public class TargetPixelStamper extends TEPattern {
   public static final int MSEC_PER_COLOR = 1000;
 

--- a/src/main/java/titanicsend/util/TECategory.java
+++ b/src/main/java/titanicsend/util/TECategory.java
@@ -1,0 +1,5 @@
+package titanicsend.util;
+
+public class TECategory {
+  public static final String UTILITY = "Utility";
+}


### PR DESCRIPTION
Dedicated driving pattern.  Uses two colors: The first color is intended for headlights.  The second color is to be visible while keeping reflectivity low behind the driver.

Add the tag "drive" to fixture files for color1, and the tag "run" as in "running lights" to fixture files for color2.

We'll choose the windows on playa.

I also added a TECategory class and adjusted the patterns tagged "Utility".  Sorry this should have been in a different PR, just got carried away.