### PR TITLE
Don't reset camera if it is already correct for dynamic model

### DIFF
--- a/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/src/main/java/heronarts/lx/studio/TEApp.java
@@ -634,7 +634,8 @@ public class TEApp extends LXStudio {
     public void applyTECameraPosition() {
       if (this.lx instanceof LXStudio) {
         LXStudio.UI ui = ((LXStudio) this.lx).ui;
-        if (staticModel) {
+        double pointSize = ui.preview.pointCloud.pointSize.getValue();
+        if (staticModel && pointSize < 500) {
           // Camera position and point size for static model (2022-23)
           ui.preview.pointCloud.pointSize.setValue(80000);
           ui.preview.camera.theta.setValue(270);
@@ -643,7 +644,7 @@ public class TEApp extends LXStudio {
           ui.previewAux.camera.theta.setValue(270);
           ui.previewAux.camera.phi.setValue(-6);
           ui.previewAux.camera.radius.setValue(17000000);
-        } else {
+        } else if (!staticModel && pointSize > 500) {
           // Camera position and point size for dynamic model (2024+)
           ui.preview.pointCloud.pointSize.reset();
           ui.preview.camera.radius.reset();


### PR DESCRIPTION
Camera was resetting on every file open, unnecessary.