### PR TITLE
Added bootup channel template project file

### DIFF
--- a/Projects/BootupTemplate.lxp
+++ b/Projects/BootupTemplate.lxp
@@ -1,0 +1,14846 @@
+{
+  "version": "1.0.1.TE.2-SNAPSHOT",
+  "timestamp": 1724638879345,
+  "model": {
+    "id": 2,
+    "class": "heronarts.lx.structure.LXStructure",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true,
+      "showNormalizationBounds": false
+    },
+    "parameters": {
+      "label": "LX",
+      "syncModelFile": false,
+      "allWhite": false,
+      "mute": false,
+      "normalizationMode": 0,
+      "normalizationX": 0.0,
+      "normalizationY": 0.0,
+      "normalizationZ": 0.0,
+      "normalizationWidth": 1000.0,
+      "normalizationHeight": 1000.0,
+      "normalizationDepth": 1000.0
+    },
+    "children": {
+      "views": {
+        "id": 3,
+        "class": "heronarts.lx.structure.view.LXViewEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX"
+        },
+        "children": {},
+        "views": [
+          {
+            "id": 596,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Fixtures;",
+              "enabled": true,
+              "selector": "912;983;9114;9116;1011;10100;10115;10117;1198;11100;1283;1285;2527;2583;2584;2588;25110;25114;2628;2699;26100;26102;26111;26115;27109;27110;27112;27114;28109;28111;28113;28115;3031;3033;3038;3042;30118;3133;3139;31118;31119;31121;3337;3338;3339;3637;3638;3643;3656;3657;36123;3739;3744;3750;37123;3842;3843;3944;39101;39121;4243;42118;42119;42120;4357;4386;43120;4447;4450;44101;4546;4547;4550;45122;45123;4656;4658;46122;46123;4750;4751;4754;4790;47122;50123;5154;5169;5182;5190;5255;5258;5275;5292;5296;5482;54122;5558;5592;55122;5657;5658;56123;5758;5786;5896;58122;6065;6093;60125;60127;6567;6593;6790;6793;6970;6982;6990;6993;69127;7081;7082;7089;70127;7375;7381;7391;7392;73128;7592;7596;7597;75128;7879;7897;78128;78129;7980;7997;8096;8097;8182;8189;8191;8192;8292;82122;8384;8385;83114;8485;8486;8488;8688;86120;88110;88119;88120;8991;89125;89126;89127;9093;91126;91128;91129;92122;93127;9697;97128;9899;98100;99100;99101;99102;100115;101102;101121;102111;102119;102121;109110;109111;109112;109113;110111;110119;111119;112113;112114;112116;112124;113115;113117;113124;114116;115117;116124;117124;118119;119120;119121;125126;125127;126129;128129;FA;FB;FSA;FSB;FSC;FPA;FPB;FPC;AA;AB;ASA;ASB;ASC;APA;APB;APC;SFA;SFB;SEA;SFC;SFD;SEB;SEC;SED;SDA;SDB;SDC;SEE;SCA;SCB;SCC;SBA;SBB;SBC;SBD;SBE;SAA;SAB;SAC;SAD;SUF;SUA;PAA;PAB;PBA;PAC;PAD;PBB;PBC;PBD;PCA;PCB;PCC;PBE;PDA;PDB;PDC;PEA;PEB;PEC;PED;PEE;PFA;PFB;PFC;PFD;PUF;PUA",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 597,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 1,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Edges",
+              "enabled": true,
+              "selector": "Edge",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 598,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 2,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Edges;",
+              "enabled": true,
+              "selector": "912;983;9114;9116;1011;10100;10115;10117;1198;11100;1283;1285;2527;2583;2584;2588;25110;25114;2628;2699;26100;26102;26111;26115;27109;27110;27112;27114;28109;28111;28113;28115;3031;3033;3038;3042;30118;3133;3139;31118;31119;31121;3337;3338;3339;3637;3638;3643;3656;3657;36123;3739;3744;3750;37123;3842;3843;3944;39101;39121;4243;42118;42119;42120;4357;4386;43120;4447;4450;44101;4546;4547;4550;45122;45123;4656;4658;46122;46123;4750;4751;4754;4790;47122;50123;5154;5169;5182;5190;5255;5258;5275;5292;5296;5482;54122;5558;5592;55122;5657;5658;56123;5758;5786;5896;58122;6065;6093;60125;60127;6567;6593;6790;6793;6970;6982;6990;6993;69127;7081;7082;7089;70127;7375;7381;7391;7392;73128;7592;7596;7597;75128;7879;7897;78128;78129;7980;7997;8096;8097;8182;8189;8191;8192;8292;82122;8384;8385;83114;8485;8486;8488;8688;86120;88110;88119;88120;8991;89125;89126;89127;9093;91126;91128;91129;92122;93127;9697;97128;9899;98100;99100;99101;99102;100115;101102;101121;102111;102119;102121;109110;109111;109112;109113;110111;110119;111119;112113;112114;112116;112124;113115;113117;113124;114116;115117;116124;117124;118119;119120;119121;125126;125127;126129;128129",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 599,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 3,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Panels",
+              "enabled": true,
+              "selector": "Panel",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 600,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 4,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Panels;",
+              "enabled": true,
+              "selector": "FA;FB;FSA;FSB;FSC;FPA;FPB;FPC;AA;AB;ASA;ASB;ASC;APA;APB;APC;SFA;SFB;SEA;SFC;SFD;SEB;SEC;SED;SDA;SDB;SDC;SEE;SCA;SCB;SCC;SBA;SBB;SBC;SBD;SBE;SAA;SAB;SAC;SAD;SUF;SUA;PAA;PAB;PBA;PAC;PAD;PBB;PBC;PBD;PCA;PCB;PCC;PBE;PDA;PDB;PDC;PEA;PEB;PEC;PED;PEE;PFA;PFB;PFC;PFD;PUF;PUA",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 601,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 5,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Panel Sections",
+              "enabled": true,
+              "selector": "fore;aft;starboard-fore;starboard-fore-single;starboard-aft;starboard-aft-single;port-fore;port-fore-single;port-aft;port-aft-single",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 602,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 6,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Outline",
+              "enabled": true,
+              "selector": "113117,28113,28111,111119,118119,30118,3033,3337,37123,45123,45122,82122,7082,7089,89125",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 603,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 7,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Outline;",
+              "enabled": true,
+              "selector": "113117;28113;28111;111119;118119;30118;3033;3337;37123;45123;45122;82122;7082;7089;89125",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 604,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 8,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Outline DJ",
+              "enabled": true,
+              "selector": "11-98,98-99,99-101,44-101,44-47,47-90,67-90,65-67",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          },
+          {
+            "id": 605,
+            "class": "heronarts.lx.structure.view.LXViewDefinition",
+            "internal": {
+              "modulationColor": 9,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Outline DJ;",
+              "enabled": true,
+              "selector": "11-98;98-99;99-101;44-101;44-47;47-90;67-90;65-67",
+              "normalization": 0,
+              "priority": true
+            },
+            "children": {}
+          }
+        ]
+      }
+    },
+    "output": {
+      "id": 4,
+      "class": "heronarts.lx.structure.LXStructureOutput",
+      "internal": {
+        "modulationColor": 0,
+        "modulationControlsExpanded": true,
+        "modulationsExpanded": true
+      },
+      "parameters": {
+        "label": "Output",
+        "enabled": true,
+        "brightness": 1.0,
+        "fps": 0.0,
+        "gamma": 1.0,
+        "gammaMode": 1,
+        "whitePointRed": 255,
+        "whitePointGreen": 255,
+        "whitePointBlue": 255,
+        "whitePointWhite": 255
+      },
+      "children": {}
+    },
+    "fixtures": [
+      {
+        "jsonFixtureType": "TE/panel/FA",
+        "jsonParameters": {
+          "xOffset": 7.913386821746826,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.215",
+          "strand1output": 1,
+          "strand2host": "10.7.21.215",
+          "strand2output": 2,
+          "strand3host": "10.7.21.215",
+          "strand3output": 3,
+          "strand4host": "10.7.21.215",
+          "strand4output": 4,
+          "strand5host": "10.7.21.214",
+          "strand5output": 3,
+          "strand6host": "10.7.21.214",
+          "strand6output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 165877,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FB",
+        "jsonParameters": {
+          "xOffset": 8.897639274597168,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.213",
+          "strand1output": 1,
+          "strand2host": "10.7.21.213",
+          "strand2output": 2,
+          "strand3host": "10.7.21.213",
+          "strand3output": 3,
+          "strand4host": "10.7.21.213",
+          "strand4output": 4,
+          "strand5host": "10.7.21.214",
+          "strand5output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 165962,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FSA",
+        "jsonParameters": {
+          "xOffset": 6.09382963180542,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.14",
+          "strand1output": 1,
+          "strand2host": "10.7.10.14",
+          "strand2output": 2,
+          "strand3host": "10.7.10.14",
+          "strand3output": 3,
+          "strand4host": "10.7.10.14",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166043,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FSA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FSA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FSB",
+        "jsonParameters": {
+          "xOffset": 9.833954811096191,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.212",
+          "strand1output": 1,
+          "strand2host": "10.7.21.212",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166134,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FSB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FSB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FSC",
+        "jsonParameters": {
+          "xOffset": 8.568790435791016,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.221",
+          "strand1output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166179,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FSC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FSC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FPA",
+        "jsonParameters": {
+          "xOffset": 7.482972621917725,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.14",
+          "strand1output": 1,
+          "strand2host": "10.7.1.14",
+          "strand2output": 2,
+          "strand3host": "10.7.1.14",
+          "strand3output": 3,
+          "strand4host": "10.7.1.14",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166214,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FPA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FPA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FPB",
+        "jsonParameters": {
+          "xOffset": 9.833954811096191,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.212",
+          "strand1output": 4,
+          "strand2host": "10.7.21.212",
+          "strand2output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166283,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FPB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FPB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/FPC",
+        "jsonParameters": {
+          "xOffset": 8.568790435791016,
+          "yOffset": 6.0,
+          "strand1host": "10.7.21.221",
+          "strand1output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166328,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel FPC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/FPC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/AA",
+        "jsonParameters": {
+          "xOffset": 7.913386821746826,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.215",
+          "strand1output": 1,
+          "strand2host": "10.7.20.215",
+          "strand2output": 2,
+          "strand3host": "10.7.20.215",
+          "strand3output": 3,
+          "strand4host": "10.7.20.215",
+          "strand4output": 4,
+          "strand5host": "10.7.20.214",
+          "strand5output": 3,
+          "strand6host": "10.7.20.214",
+          "strand6output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166365,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel AA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/AA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/AB",
+        "jsonParameters": {
+          "xOffset": 8.897639274597168,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.213",
+          "strand1output": 1,
+          "strand2host": "10.7.20.213",
+          "strand2output": 2,
+          "strand3host": "10.7.20.213",
+          "strand3output": 3,
+          "strand4host": "10.7.20.213",
+          "strand4output": 4,
+          "strand5host": "10.7.20.214",
+          "strand5output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166450,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel AB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/AB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/ASA",
+        "jsonParameters": {
+          "xOffset": 6.09382963180542,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.114",
+          "strand1output": 1,
+          "strand2host": "10.7.11.114",
+          "strand2output": 2,
+          "strand3host": "10.7.11.114",
+          "strand3output": 3,
+          "strand4host": "10.7.11.114",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166529,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel ASA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/ASA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/ASB",
+        "jsonParameters": {
+          "xOffset": 9.833954811096191,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.212",
+          "strand1output": 3,
+          "strand2host": "10.7.20.212",
+          "strand2output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166620,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel ASB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/ASB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/ASC",
+        "jsonParameters": {
+          "xOffset": 7.584538459777832,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.221",
+          "strand1output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166665,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel ASC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/ASC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/APA",
+        "jsonParameters": {
+          "xOffset": 7.482972621917725,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.114",
+          "strand1output": 1,
+          "strand2host": "10.7.19.114",
+          "strand2output": 2,
+          "strand3host": "10.7.19.114",
+          "strand3output": 3,
+          "strand4host": "10.7.19.114",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166700,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel APA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/APA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/APB",
+        "jsonParameters": {
+          "xOffset": 9.833954811096191,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.212",
+          "strand1output": 1,
+          "strand2host": "10.7.20.212",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166769,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel APB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/APB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/APC",
+        "jsonParameters": {
+          "xOffset": 7.584538459777832,
+          "yOffset": 6.0,
+          "strand1host": "10.7.20.221",
+          "strand1output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166814,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel APC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/APC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SFA",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.13",
+          "strand1output": 1,
+          "strand2host": "10.7.10.13",
+          "strand2output": 2,
+          "strand3host": "10.7.10.13",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166849,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SFA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SFA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SFB",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.9.12",
+          "strand1output": 1,
+          "strand2host": "10.7.9.12",
+          "strand2output": 2,
+          "strand3host": "10.7.9.12",
+          "strand3output": 3,
+          "strand4host": "10.7.9.12",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166914,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SFB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SFB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SEA",
+        "jsonParameters": {
+          "xOffset": 9.530516624450684,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.12",
+          "strand1output": 1,
+          "strand2host": "10.7.10.12",
+          "strand2output": 2,
+          "strand3host": "10.7.10.12",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 166995,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SEA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SEA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SFC",
+        "jsonParameters": {
+          "xOffset": 7.6467742919921875,
+          "yOffset": 6.0,
+          "strand1host": "10.7.9.24",
+          "strand1output": 1,
+          "strand2host": "10.7.9.24",
+          "strand2output": 2,
+          "strand3host": "10.7.9.24",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167052,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SFC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SFC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SFD",
+        "jsonParameters": {
+          "xOffset": 11.461127281188965,
+          "yOffset": 6.0,
+          "strand1host": "10.7.8.11",
+          "strand1output": 1,
+          "strand2host": "10.7.8.11",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167115,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SFD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SFD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SEB",
+        "jsonParameters": {
+          "xOffset": 14.403048515319824,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.11",
+          "strand1output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167146,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SEB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SEB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SEC",
+        "jsonParameters": {
+          "xOffset": 9.903098106384277,
+          "yOffset": 6.0,
+          "strand1host": "10.7.9.23",
+          "strand1output": 1,
+          "strand2host": "10.7.9.23",
+          "strand2output": 2,
+          "strand3host": "10.7.9.23",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167167,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SEC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SEC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SED",
+        "jsonParameters": {
+          "xOffset": 9.05272388458252,
+          "yOffset": 6.0,
+          "strand1host": "10.7.9.22",
+          "strand1output": 1,
+          "strand2host": "10.7.9.22",
+          "strand2output": 2,
+          "strand3host": "10.7.9.22",
+          "strand3output": 3,
+          "strand4host": "10.7.9.22",
+          "strand4output": 4,
+          "strand5host": "10.7.9.21",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167218,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SED",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SED"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SDA",
+        "jsonParameters": {
+          "xOffset": 17.108060836791992,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.11",
+          "strand1output": 1,
+          "strand2host": "10.7.10.11",
+          "strand2output": 2,
+          "strand3host": "10.7.10.11",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167301,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SDA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SDA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SDB",
+        "jsonParameters": {
+          "xOffset": 15.139557838439941,
+          "yOffset": 6.0,
+          "strand1host": "10.7.10.10",
+          "strand1output": 1,
+          "strand2host": "10.7.10.10",
+          "strand2output": 2,
+          "strand3host": "10.7.10.10",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167334,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SDB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SDB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SDC",
+        "jsonParameters": {
+          "xOffset": 7.3696699142456055,
+          "yOffset": 6.0,
+          "strand1host": "10.7.9.20",
+          "strand1output": 1,
+          "strand2host": "10.7.9.20",
+          "strand2output": 2,
+          "strand3host": "10.7.9.20",
+          "strand3output": 3,
+          "strand4host": "10.7.9.20",
+          "strand4output": 4,
+          "strand5host": "10.7.9.21",
+          "strand5output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167373,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SDC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SDC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SEE",
+        "jsonParameters": {
+          "xOffset": 8.955739974975586,
+          "yOffset": 6.0,
+          "strand1host": "10.7.8.11",
+          "strand1output": 3,
+          "strand2host": "10.7.8.11",
+          "strand2output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167466,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SEE",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SEE"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SCA",
+        "jsonParameters": {
+          "xOffset": 18.10432243347168,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.111",
+          "strand1output": 1,
+          "strand2host": "10.7.11.111",
+          "strand2output": 2,
+          "strand3host": "10.7.11.111",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167509,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SCA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SCA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SCB",
+        "jsonParameters": {
+          "xOffset": 16.135818481445312,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.110",
+          "strand1output": 1,
+          "strand2host": "10.7.11.110",
+          "strand2output": 2,
+          "strand3host": "10.7.11.110",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167544,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SCB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SCB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SCC",
+        "jsonParameters": {
+          "xOffset": 6.938027858734131,
+          "yOffset": 6.0,
+          "strand1host": "10.7.2.21",
+          "strand1output": 1,
+          "strand2host": "10.7.2.21",
+          "strand2output": 2,
+          "strand3host": "10.7.2.21",
+          "strand3output": 3,
+          "strand4host": "10.7.2.21",
+          "strand4output": 4,
+          "strand5host": "10.7.2.20",
+          "strand5output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167581,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SCC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SCC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SBA",
+        "jsonParameters": {
+          "xOffset": 8.5462646484375,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.112",
+          "strand1output": 1,
+          "strand2host": "10.7.11.112",
+          "strand2output": 2,
+          "strand3host": "10.7.11.112",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167676,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SBA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SBA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SBB",
+        "jsonParameters": {
+          "xOffset": 15.387300491333008,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.111",
+          "strand1output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167733,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SBB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SBB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SBC",
+        "jsonParameters": {
+          "xOffset": 9.919804573059082,
+          "yOffset": 6.0,
+          "strand1host": "10.7.2.23",
+          "strand1output": 1,
+          "strand2host": "10.7.2.23",
+          "strand2output": 2,
+          "strand3host": "10.7.2.23",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167754,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SBC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SBC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SBD",
+        "jsonParameters": {
+          "xOffset": 8.61209774017334,
+          "yOffset": 6.0,
+          "strand1host": "10.7.2.22",
+          "strand1output": 1,
+          "strand2host": "10.7.2.22",
+          "strand2output": 2,
+          "strand3host": "10.7.2.22",
+          "strand3output": 3,
+          "strand4host": "10.7.2.22",
+          "strand4output": 4,
+          "strand5host": "10.7.2.23",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167805,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SBD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SBD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SBE",
+        "jsonParameters": {
+          "xOffset": 8.870606422424316,
+          "yOffset": 6.0,
+          "strand1host": "10.7.3.11",
+          "strand1output": 1,
+          "strand2host": "10.7.3.11",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167888,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SBE",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SBE"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SAA",
+        "jsonParameters": {
+          "xOffset": 8.680485725402832,
+          "yOffset": 6.0,
+          "strand1host": "10.7.11.113",
+          "strand1output": 1,
+          "strand2host": "10.7.11.113",
+          "strand2output": 2,
+          "strand3host": "10.7.11.113",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167933,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SAA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SAA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SAB",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.2.24",
+          "strand1output": 1,
+          "strand2host": "10.7.2.24",
+          "strand2output": 2,
+          "strand3host": "10.7.2.24",
+          "strand3output": 3,
+          "strand4host": "10.7.2.24",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 167998,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SAB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SAB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SAC",
+        "jsonParameters": {
+          "xOffset": 8.631026268005371,
+          "yOffset": 6.0,
+          "strand1host": "10.7.2.12",
+          "strand1output": 1,
+          "strand2host": "10.7.2.12",
+          "strand2output": 2,
+          "strand3host": "10.7.2.12",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168079,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SAC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SAC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SAD",
+        "jsonParameters": {
+          "xOffset": 12.445379257202148,
+          "yOffset": 6.0,
+          "strand1host": "10.7.3.11",
+          "strand1output": 3,
+          "strand2host": "10.7.3.11",
+          "strand2output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168142,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SAD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SAD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SUF",
+        "jsonParameters": {
+          "xOffset": 8.579174041748047,
+          "yOffset": 6.0,
+          "strand1host": "10.7.6.11",
+          "strand1output": 1,
+          "strand2host": "10.7.6.11",
+          "strand2output": 2,
+          "strand3host": "10.7.6.11",
+          "strand3output": 3,
+          "strand4host": "10.7.6.11",
+          "strand4output": 4,
+          "strand5host": "10.7.6.21",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168173,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SUF",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SUF"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/SUA",
+        "jsonParameters": {
+          "xOffset": 7.59993314743042,
+          "yOffset": 6.0,
+          "strand1host": "10.7.6.10",
+          "strand1output": 1,
+          "strand2host": "10.7.6.10",
+          "strand2output": 2,
+          "strand3host": "10.7.6.10",
+          "strand3output": 3,
+          "strand4host": "10.7.6.10",
+          "strand4output": 4,
+          "strand5host": "10.7.6.21",
+          "strand5output": 2,
+          "strand6host": "10.7.6.21",
+          "strand6output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168250,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel SUA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/SUA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PAA",
+        "jsonParameters": {
+          "xOffset": 8.680485725402832,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.13",
+          "strand1output": 1,
+          "strand2host": "10.7.1.13",
+          "strand2output": 2,
+          "strand3host": "10.7.1.13",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168351,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PAA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PAA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PAB",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.12.124",
+          "strand1output": 1,
+          "strand2host": "10.7.12.124",
+          "strand2output": 2,
+          "strand3host": "10.7.12.124",
+          "strand3output": 3,
+          "strand4host": "10.7.12.124",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168416,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PAB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PAB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PBA",
+        "jsonParameters": {
+          "xOffset": 9.530516624450684,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.12",
+          "strand1output": 1,
+          "strand2host": "10.7.1.12",
+          "strand2output": 2,
+          "strand3host": "10.7.1.12",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168497,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PBA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PBA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PAC",
+        "jsonParameters": {
+          "xOffset": 7.6467742919921875,
+          "yOffset": 6.0,
+          "strand1host": "10.7.12.112",
+          "strand1output": 1,
+          "strand2host": "10.7.12.112",
+          "strand2output": 2,
+          "strand3host": "10.7.12.112",
+          "strand3output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168554,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PAC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PAC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PAD",
+        "jsonParameters": {
+          "xOffset": 12.445379257202148,
+          "yOffset": 6.0,
+          "strand1host": "10.7.13.111",
+          "strand1output": 3,
+          "strand2host": "10.7.13.111",
+          "strand2output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168615,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PAD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PAD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PBB",
+        "jsonParameters": {
+          "xOffset": 15.387288093566895,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.11",
+          "strand1output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168646,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PBB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PBB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PBC",
+        "jsonParameters": {
+          "xOffset": 9.903098106384277,
+          "yOffset": 6.0,
+          "strand1host": "10.7.12.123",
+          "strand1output": 1,
+          "strand2host": "10.7.12.123",
+          "strand2output": 2,
+          "strand3host": "10.7.12.123",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168667,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PBC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PBC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PBD",
+        "jsonParameters": {
+          "xOffset": 10.036975860595703,
+          "yOffset": 6.0,
+          "strand1host": "10.7.12.122",
+          "strand1output": 1,
+          "strand2host": "10.7.12.122",
+          "strand2output": 2,
+          "strand3host": "10.7.12.122",
+          "strand3output": 3,
+          "strand4host": "10.7.12.122",
+          "strand4output": 4,
+          "strand5host": "10.7.12.121",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168720,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PBD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PBD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PCA",
+        "jsonParameters": {
+          "xOffset": 17.108060836791992,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.11",
+          "strand1output": 1,
+          "strand2host": "10.7.1.11",
+          "strand2output": 2,
+          "strand3host": "10.7.1.11",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168805,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PCA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PCA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PCB",
+        "jsonParameters": {
+          "xOffset": 16.123809814453125,
+          "yOffset": 6.0,
+          "strand1host": "10.7.1.10",
+          "strand1output": 1,
+          "strand2host": "10.7.1.10",
+          "strand2output": 2,
+          "strand3host": "10.7.1.10",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168838,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PCB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PCB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PCC",
+        "jsonParameters": {
+          "xOffset": 7.3696699142456055,
+          "yOffset": 6.0,
+          "strand1host": "10.7.12.120",
+          "strand1output": 1,
+          "strand2host": "10.7.12.120",
+          "strand2output": 2,
+          "strand3host": "10.7.12.120",
+          "strand3output": 3,
+          "strand4host": "10.7.12.120",
+          "strand4output": 4,
+          "strand5host": "10.7.12.121",
+          "strand5output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168877,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PCC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PCC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PBE",
+        "jsonParameters": {
+          "xOffset": 9.93999195098877,
+          "yOffset": 6.0,
+          "strand1host": "10.7.13.111",
+          "strand1output": 1,
+          "strand2host": "10.7.13.111",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 168972,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PBE",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PBE"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PDA",
+        "jsonParameters": {
+          "xOffset": 18.10432243347168,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.111",
+          "strand1output": 1,
+          "strand2host": "10.7.19.111",
+          "strand2output": 2,
+          "strand3host": "10.7.19.111",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169015,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PDA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PDA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PDB",
+        "jsonParameters": {
+          "xOffset": 15.151567459106445,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.110",
+          "strand1output": 1,
+          "strand2host": "10.7.19.110",
+          "strand2output": 2,
+          "strand3host": "10.7.19.110",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169048,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PDB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PDB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PDC",
+        "jsonParameters": {
+          "xOffset": 6.938027858734131,
+          "yOffset": 6.0,
+          "strand1host": "10.7.18.120",
+          "strand1output": 1,
+          "strand2host": "10.7.18.120",
+          "strand2output": 2,
+          "strand3host": "10.7.18.120",
+          "strand3output": 3,
+          "strand4host": "10.7.18.120",
+          "strand4output": 4,
+          "strand5host": "10.7.18.121",
+          "strand5output": 1,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169087,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PDC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PDC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PEA",
+        "jsonParameters": {
+          "xOffset": 9.530516624450684,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.112",
+          "strand1output": 1,
+          "strand2host": "10.7.19.112",
+          "strand2output": 2,
+          "strand3host": "10.7.19.112",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169180,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PEA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PEA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PEB",
+        "jsonParameters": {
+          "xOffset": 15.387300491333008,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.111",
+          "strand1output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169237,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PEB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PEB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PEC",
+        "jsonParameters": {
+          "xOffset": 9.919804573059082,
+          "yOffset": 6.0,
+          "strand1host": "10.7.18.123",
+          "strand1output": 1,
+          "strand2host": "10.7.18.123",
+          "strand2output": 2,
+          "strand3host": "10.7.18.123",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169258,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PEC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PEC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PED",
+        "jsonParameters": {
+          "xOffset": 8.61209774017334,
+          "yOffset": 6.0,
+          "strand1host": "10.7.18.122",
+          "strand1output": 1,
+          "strand2host": "10.7.18.122",
+          "strand2output": 2,
+          "strand3host": "10.7.18.122",
+          "strand3output": 3,
+          "strand4host": "10.7.18.122",
+          "strand4output": 4,
+          "strand5host": "10.7.18.121",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169309,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PED",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PED"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PEE",
+        "jsonParameters": {
+          "xOffset": 9.8548583984375,
+          "yOffset": 6.0,
+          "strand1host": "10.7.17.111",
+          "strand1output": 1,
+          "strand2host": "10.7.17.111",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169392,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PEE",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PEE"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PFA",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.19.113",
+          "strand1output": 1,
+          "strand2host": "10.7.19.113",
+          "strand2output": 2,
+          "strand3host": "10.7.19.113",
+          "strand3output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169437,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PFA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PFA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PFB",
+        "jsonParameters": {
+          "xOffset": 7.696234226226807,
+          "yOffset": 6.0,
+          "strand1host": "10.7.18.112",
+          "strand1output": 1,
+          "strand2host": "10.7.18.112",
+          "strand2output": 2,
+          "strand3host": "10.7.18.112",
+          "strand3output": 3,
+          "strand4host": "10.7.18.112",
+          "strand4output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169502,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PFB",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PFB"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PFC",
+        "jsonParameters": {
+          "xOffset": 6.188870429992676,
+          "yOffset": 6.0,
+          "strand1host": "10.7.18.124",
+          "strand1output": 1,
+          "strand2host": "10.7.18.124",
+          "strand2output": 2,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169583,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PFC",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PFC"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PFD",
+        "jsonParameters": {
+          "xOffset": 12.445379257202148,
+          "yOffset": 6.0,
+          "strand1host": "10.7.17.111",
+          "strand1output": 3,
+          "strand2host": "10.7.17.111",
+          "strand2output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169672,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PFD",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PFD"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PUF",
+        "jsonParameters": {
+          "xOffset": 8.579174041748047,
+          "yOffset": 6.0,
+          "strand1host": "10.7.6.111",
+          "strand1output": 1,
+          "strand2host": "10.7.6.111",
+          "strand2output": 2,
+          "strand3host": "10.7.6.111",
+          "strand3output": 3,
+          "strand4host": "10.7.6.111",
+          "strand4output": 4,
+          "strand5host": "10.7.6.121",
+          "strand5output": 4,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169703,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PUF",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PUF"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/panel/PUA",
+        "jsonParameters": {
+          "xOffset": 7.59993314743042,
+          "yOffset": 6.0,
+          "strand1host": "10.7.6.110",
+          "strand1output": 1,
+          "strand2host": "10.7.6.110",
+          "strand2output": 2,
+          "strand3host": "10.7.6.110",
+          "strand3output": 3,
+          "strand4host": "10.7.6.110",
+          "strand4output": 4,
+          "strand5host": "10.7.6.121",
+          "strand5output": 1,
+          "strand6host": "10.7.6.121",
+          "strand6output": 3,
+          "artnetSequence": false,
+          "onCar": true
+        },
+        "id": 169780,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Panel PUA",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/panel/PUA"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge9-12",
+        "jsonParameters": {
+          "points": 188,
+          "host": "10.7.19.120",
+          "output": 1,
+          "ledOffset": 233,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.5293354988098145,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169879,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 9-12",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge9-12"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge9-83",
+        "jsonParameters": {
+          "points": 48,
+          "host": "10.7.19.121",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.404312610626221,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169881,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 9-83",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge9-83"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge9-114",
+        "jsonParameters": {
+          "points": 119,
+          "host": "10.7.19.121",
+          "output": 1,
+          "ledOffset": 48,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 7.183310508728027,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169883,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 9-114",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge9-114"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge9-116",
+        "jsonParameters": {
+          "points": 158,
+          "host": "10.7.19.123",
+          "output": 2,
+          "ledOffset": 249,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.26291036605835,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169885,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 9-116",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge9-116"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge10-11",
+        "jsonParameters": {
+          "points": 188,
+          "host": "10.7.11.120",
+          "output": 1,
+          "ledOffset": 234,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.5293354988098145,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169887,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 10-11",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge10-11"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge10-100",
+        "jsonParameters": {
+          "points": 48,
+          "host": "10.7.11.121",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.404312610626221,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169889,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 10-100",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge10-100"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge10-115",
+        "jsonParameters": {
+          "points": 119,
+          "host": "10.7.11.121",
+          "output": 1,
+          "ledOffset": 48,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 7.183310508728027,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169891,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 10-115",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge10-115"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge10-117",
+        "jsonParameters": {
+          "points": 158,
+          "host": "10.7.11.123",
+          "output": 1,
+          "ledOffset": 249,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.26291036605835,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169893,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 10-117",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge10-117"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge11-98",
+        "jsonParameters": {
+          "points": 105,
+          "host": "10.7.11.120",
+          "output": 1,
+          "ledOffset": 129,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.923449993133545,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169895,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 11-98",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge11-98"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge11-100",
+        "jsonParameters": {
+          "points": 209,
+          "host": "10.7.11.122",
+          "output": 1,
+          "ledOffset": 208,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 9.898892402648926,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169897,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 11-100",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge11-100"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge12-83",
+        "jsonParameters": {
+          "points": 209,
+          "host": "10.7.19.122",
+          "output": 1,
+          "ledOffset": 208,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 9.898892402648926,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169899,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 12-83",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge12-83"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge12-85",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.19.120",
+          "output": 1,
+          "ledOffset": 133,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.563950061798096,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169901,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 12-85",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge12-85"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-27",
+        "jsonParameters": {
+          "points": 90,
+          "host": "10.7.17.112",
+          "output": 1,
+          "ledOffset": 181,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.531277179718018,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169903,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-27",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-27"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-83",
+        "jsonParameters": {
+          "points": 155,
+          "host": "10.7.18.111",
+          "output": 1,
+          "ledOffset": 116,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.652245998382568,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169905,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-83",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-83"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-84",
+        "jsonParameters": {
+          "points": 120,
+          "host": "10.7.17.110",
+          "output": 1,
+          "ledOffset": 242,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.344910144805908,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169907,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-84",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-84"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-88",
+        "jsonParameters": {
+          "points": 61,
+          "host": "10.7.17.110",
+          "output": 1,
+          "ledOffset": 181,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.7185704708099365,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169909,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-88",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-88"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-110",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.17.112",
+          "output": 1,
+          "ledOffset": 58,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.865997791290283,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169911,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-110",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-110"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge25-114",
+        "jsonParameters": {
+          "points": 116,
+          "host": "10.7.18.111",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 8.013010025024414,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169913,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 25-114",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge25-114"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-28",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.3.12",
+          "output": 2,
+          "ledOffset": 177,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 2.250277042388916,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169915,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-28",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-28"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-99",
+        "jsonParameters": {
+          "points": 120,
+          "host": "10.7.3.10",
+          "output": 2,
+          "ledOffset": 242,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.344910144805908,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169917,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-99",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-99"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-100",
+        "jsonParameters": {
+          "points": 151,
+          "host": "10.7.2.11",
+          "output": 2,
+          "ledOffset": 123,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.964645862579346,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169919,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-100",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-100"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-102",
+        "jsonParameters": {
+          "points": 61,
+          "host": "10.7.3.10",
+          "output": 2,
+          "ledOffset": 181,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.7185704708099365,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169921,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-102",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-102"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-111",
+        "jsonParameters": {
+          "points": 119,
+          "host": "10.7.3.12",
+          "output": 2,
+          "ledOffset": 58,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 8.178398132324219,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169923,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-111",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-111"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge26-115",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.2.11",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.716310024261475,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169925,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 26-115",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge26-115"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge27-109",
+        "jsonParameters": {
+          "points": 71,
+          "host": "10.7.20.210",
+          "output": 1,
+          "ledOffset": 138,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.203756332397461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169927,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 27-109",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge27-109"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge27-110",
+        "jsonParameters": {
+          "points": 58,
+          "host": "10.7.17.112",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.298299789428711,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169929,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 27-110",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge27-110"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge27-112",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.18.113",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359066963195801,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169931,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 27-112",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge27-112"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge27-114",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.18.113",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.691760063171387,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169933,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 27-114",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge27-114"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge28-109",
+        "jsonParameters": {
+          "points": 71,
+          "host": "10.7.20.211",
+          "output": 1,
+          "ledOffset": 323,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.203756332397461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169935,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 28-109",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge28-109"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge28-111",
+        "jsonParameters": {
+          "points": 58,
+          "host": "10.7.3.12",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.298299789428711,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169937,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 28-111",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge28-111"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge28-113",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.2.13",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359066963195801,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169939,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 28-113",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge28-113"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge28-115",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.2.13",
+          "output": 2,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.691760063171387,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169941,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 28-115",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge28-115"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge30-31",
+        "jsonParameters": {
+          "points": 168,
+          "host": "10.7.4.10",
+          "output": 1,
+          "ledOffset": 296,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.197672367095947,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169943,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 30-31",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge30-31"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge30-33",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.4.11",
+          "output": 1,
+          "ledOffset": 209,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.2379021644592285,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169945,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 30-33",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge30-33"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge30-38",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.4.110",
+          "output": 1,
+          "ledOffset": 289,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.2379021644592285,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169947,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 30-38",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge30-38"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge30-42",
+        "jsonParameters": {
+          "points": 168,
+          "host": "10.7.4.110",
+          "output": 1,
+          "ledOffset": 121,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.197672367095947,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169949,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 30-42",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge30-42"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge30-118",
+        "jsonParameters": {
+          "points": 86,
+          "host": "10.7.4.11",
+          "output": 1,
+          "ledOffset": 347,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.055959224700928,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169951,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 30-118",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge30-118"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge31-33",
+        "jsonParameters": {
+          "points": 109,
+          "host": "10.7.4.11",
+          "output": 1,
+          "ledOffset": 100,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.907185077667236,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169953,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 31-33",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge31-33"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge31-39",
+        "jsonParameters": {
+          "points": 109,
+          "host": "10.7.5.11",
+          "output": 3,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.1070051193237305,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169955,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 31-39",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge31-39"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge31-118",
+        "jsonParameters": {
+          "points": 121,
+          "host": "10.7.4.10",
+          "output": 1,
+          "ledOffset": 175,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.516032695770264,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169957,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 31-118",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge31-118"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge31-119",
+        "jsonParameters": {
+          "points": 189,
+          "host": "10.7.4.12",
+          "output": 1,
+          "ledOffset": 142,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.533348560333252,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169959,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 31-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge31-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge31-121",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.4.11",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.247873783111572,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169961,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 31-121",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge31-121"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge33-37",
+        "jsonParameters": {
+          "points": 237,
+          "host": "10.7.5.10",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.648992538452148,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169963,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 33-37",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge33-37"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge33-38",
+        "jsonParameters": {
+          "points": 45,
+          "host": "10.7.4.111",
+          "output": 1,
+          "ledOffset": 209,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.5636000633239746,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169965,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 33-38",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge33-38"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge33-39",
+        "jsonParameters": {
+          "points": 168,
+          "host": "10.7.5.11",
+          "output": 3,
+          "ledOffset": 109,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.63840389251709,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169967,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 33-39",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge33-39"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-37",
+        "jsonParameters": {
+          "points": 77,
+          "host": "10.7.6.122",
+          "output": 1,
+          "ledOffset": 429,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.0644001960754395,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169969,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-37",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-37"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-38",
+        "jsonParameters": {
+          "points": 237,
+          "host": "10.7.15.110",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.648992538452148,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169971,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-38",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-38"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-43",
+        "jsonParameters": {
+          "points": 131,
+          "host": "10.7.6.122",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.053445339202881,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169973,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-43",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-43"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-56",
+        "jsonParameters": {
+          "points": 60,
+          "host": "10.7.6.124",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.562351703643799,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169975,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-56",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-56"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-57",
+        "jsonParameters": {
+          "points": 121,
+          "host": "10.7.6.122",
+          "output": 1,
+          "ledOffset": 308,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.130076885223389,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169977,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-57",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-57"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge36-123",
+        "jsonParameters": {
+          "points": 51,
+          "host": "10.7.6.124",
+          "output": 1,
+          "ledOffset": 60,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.967548847198486,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169979,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 36-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge36-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge37-39",
+        "jsonParameters": {
+          "points": 131,
+          "host": "10.7.6.22",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.053445339202881,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169981,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 37-39",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge37-39"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge37-44",
+        "jsonParameters": {
+          "points": 121,
+          "host": "10.7.6.22",
+          "output": 2,
+          "ledOffset": 308,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.130076885223389,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169983,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 37-44",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge37-44"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge37-50",
+        "jsonParameters": {
+          "points": 60,
+          "host": "10.7.6.24",
+          "output": 4,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.562351703643799,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169985,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 37-50",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge37-50"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge37-123",
+        "jsonParameters": {
+          "points": 51,
+          "host": "10.7.6.24",
+          "output": 4,
+          "ledOffset": 60,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.967548847198486,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169987,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 37-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge37-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge38-42",
+        "jsonParameters": {
+          "points": 109,
+          "host": "10.7.4.111",
+          "output": 1,
+          "ledOffset": 100,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.907185077667236,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169989,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 38-42",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge38-42"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge38-43",
+        "jsonParameters": {
+          "points": 168,
+          "host": "10.7.15.111",
+          "output": 1,
+          "ledOffset": 109,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.63840389251709,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169991,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 38-43",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge38-43"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge39-44",
+        "jsonParameters": {
+          "points": 177,
+          "host": "10.7.6.22",
+          "output": 2,
+          "ledOffset": 131,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.002903938293457,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169993,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 39-44",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge39-44"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge39-101",
+        "jsonParameters": {
+          "points": 129,
+          "host": "10.7.6.20",
+          "output": 1,
+          "ledOffset": 93,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 9.970459938049316,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169995,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 39-101",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge39-101"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge39-121",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.6.20",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.723820686340332,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169997,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 39-121",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge39-121"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge42-43",
+        "jsonParameters": {
+          "points": 109,
+          "host": "10.7.15.111",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.1070051193237305,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 169999,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 42-43",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge42-43"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge42-118",
+        "jsonParameters": {
+          "points": 121,
+          "host": "10.7.4.110",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.516032695770264,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170001,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 42-118",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge42-118"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge42-119",
+        "jsonParameters": {
+          "points": 189,
+          "host": "10.7.4.120",
+          "output": 1,
+          "ledOffset": 142,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.533348560333252,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170003,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 42-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge42-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge42-120",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.4.111",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.247873783111572,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170005,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 42-120",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge42-120"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge43-57",
+        "jsonParameters": {
+          "points": 177,
+          "host": "10.7.6.122",
+          "output": 1,
+          "ledOffset": 131,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.002903938293457,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170007,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 43-57",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge43-57"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge43-86",
+        "jsonParameters": {
+          "points": 144,
+          "host": "10.7.6.120",
+          "output": 1,
+          "ledOffset": 93,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.048960208892822,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170009,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 43-86",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge43-86"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge43-120",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.6.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.723820686340332,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170011,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 43-120",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge43-120"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge44-47",
+        "jsonParameters": {
+          "points": 177,
+          "host": "10.7.6.23",
+          "output": 2,
+          "ledOffset": 207,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.967431545257568,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170013,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 44-47",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge44-47"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge44-50",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.6.23",
+          "output": 2,
+          "ledOffset": 84,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.008687973022461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170015,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 44-50",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge44-50"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge44-101",
+        "jsonParameters": {
+          "points": 185,
+          "host": "10.7.6.20",
+          "output": 1,
+          "ledOffset": 222,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 2.347642421722412,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170017,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 44-101",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge44-101"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge45-46",
+        "jsonParameters": {
+          "points": 45,
+          "host": "10.7.6.124",
+          "output": 1,
+          "ledOffset": 256,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.5636000633239746,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170019,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 45-46",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge45-46"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge45-47",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.6.12",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.499268054962158,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170021,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 45-47",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge45-47"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge45-50",
+        "jsonParameters": {
+          "points": 111,
+          "host": "10.7.6.12",
+          "output": 1,
+          "ledOffset": 93,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.538340091705322,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170023,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 45-50",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge45-50"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge45-122",
+        "jsonParameters": {
+          "points": 133,
+          "host": "10.7.6.14",
+          "output": 2,
+          "ledOffset": 218,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.035471439361572,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170025,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 45-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge45-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge45-123",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.6.24",
+          "output": 4,
+          "ledOffset": 111,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.742503643035889,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170027,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 45-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge45-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge46-56",
+        "jsonParameters": {
+          "points": 111,
+          "host": "10.7.6.112",
+          "output": 1,
+          "ledOffset": 100,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.538340091705322,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170029,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 46-56",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge46-56"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge46-58",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.6.112",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.202568054199219,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170031,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 46-58",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge46-58"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge46-122",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.6.114",
+          "output": 1,
+          "ledOffset": 218,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 9.316471099853516,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170033,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 46-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge46-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge46-123",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.6.124",
+          "output": 1,
+          "ledOffset": 111,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.742503643035889,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170035,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 46-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge46-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge47-50",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.6.12",
+          "output": 1,
+          "ledOffset": 204,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.058324813842773,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170037,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 47-50",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge47-50"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge47-51",
+        "jsonParameters": {
+          "points": 135,
+          "host": "10.7.8.10",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.212716102600098,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170039,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 47-51",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge47-51"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge47-54",
+        "jsonParameters": {
+          "points": 128,
+          "host": "10.7.6.25",
+          "output": 2,
+          "ledOffset": 327,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.639286518096924,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170041,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 47-54",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge47-54"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge47-90",
+        "jsonParameters": {
+          "points": 67,
+          "host": "10.7.8.10",
+          "output": 1,
+          "ledOffset": 248,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 3.9318206310272217,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170043,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 47-90",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge47-90"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge47-122",
+        "jsonParameters": {
+          "points": 214,
+          "host": "10.7.6.25",
+          "output": 2,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.8687663078308105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170045,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 47-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge47-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge50-123",
+        "jsonParameters": {
+          "points": 84,
+          "host": "10.7.6.23",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.2193522453308105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170047,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 50-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge50-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge51-54",
+        "jsonParameters": {
+          "points": 83,
+          "host": "10.7.6.13",
+          "output": 2,
+          "ledOffset": 151,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.872291088104248,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170049,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 51-54",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge51-54"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge51-69",
+        "jsonParameters": {
+          "points": 61,
+          "host": "10.7.8.20",
+          "output": 1,
+          "ledOffset": 117,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 3.719163179397583,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170051,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 51-69",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge51-69"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge51-82",
+        "jsonParameters": {
+          "points": 117,
+          "host": "10.7.8.20",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.0245280265808105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170053,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 51-82",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge51-82"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge51-90",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.8.10",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.571544170379639,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170055,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 51-90",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge51-90"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge52-55",
+        "jsonParameters": {
+          "points": 82,
+          "host": "10.7.6.113",
+          "output": 1,
+          "ledOffset": 144,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.2003912925720215,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170057,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 52-55",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge52-55"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge52-58",
+        "jsonParameters": {
+          "points": 135,
+          "host": "10.7.13.110",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.212716102600098,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170059,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 52-58",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge52-58"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge52-75",
+        "jsonParameters": {
+          "points": 61,
+          "host": "10.7.13.120",
+          "output": 1,
+          "ledOffset": 117,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 3.719163179397583,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170061,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 52-75",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge52-75"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge52-92",
+        "jsonParameters": {
+          "points": 117,
+          "host": "10.7.13.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.0245280265808105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170063,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 52-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge52-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge52-96",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.13.110",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.571544170379639,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170065,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 52-96",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge52-96"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge54-82",
+        "jsonParameters": {
+          "points": 151,
+          "host": "10.7.6.13",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.77465295791626,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170067,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 54-82",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge54-82"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge54-122",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.6.25",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.679020404815674,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170069,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 54-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge54-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge55-58",
+        "jsonParameters": {
+          "points": 128,
+          "host": "10.7.6.125",
+          "output": 1,
+          "ledOffset": 327,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.639286518096924,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170071,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 55-58",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge55-58"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge55-92",
+        "jsonParameters": {
+          "points": 144,
+          "host": "10.7.6.113",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 8.0713529586792,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170073,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 55-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge55-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge55-122",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.6.125",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.679020404815674,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170075,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 55-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge55-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge56-57",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.6.123",
+          "output": 1,
+          "ledOffset": 84,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.008687973022461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170077,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 56-57",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge56-57"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge56-58",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.6.112",
+          "output": 1,
+          "ledOffset": 211,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.058324813842773,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170079,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 56-58",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge56-58"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge56-123",
+        "jsonParameters": {
+          "points": 84,
+          "host": "10.7.6.123",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.2193522453308105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170081,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 56-123",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge56-123"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge57-58",
+        "jsonParameters": {
+          "points": 177,
+          "host": "10.7.6.123",
+          "output": 1,
+          "ledOffset": 207,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.967431545257568,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170083,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 57-58",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge57-58"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge57-86",
+        "jsonParameters": {
+          "points": 179,
+          "host": "10.7.6.120",
+          "output": 1,
+          "ledOffset": 237,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.316242218017578,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170085,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 57-86",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge57-86"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge58-96",
+        "jsonParameters": {
+          "points": 67,
+          "host": "10.7.13.110",
+          "output": 1,
+          "ledOffset": 248,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 3.9318206310272217,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170087,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 58-96",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge58-96"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge58-122",
+        "jsonParameters": {
+          "points": 214,
+          "host": "10.7.6.125",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.8687663078308105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170089,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 58-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge58-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge60-65",
+        "jsonParameters": {
+          "points": 188,
+          "host": "10.7.10.20",
+          "output": 1,
+          "ledOffset": 228,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.5293354988098145,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170091,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 60-65",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge60-65"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge60-93",
+        "jsonParameters": {
+          "points": 48,
+          "host": "10.7.10.21",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359201431274414,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170093,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 60-93",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge60-93"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge60-125",
+        "jsonParameters": {
+          "points": 158,
+          "host": "10.7.10.23",
+          "output": 2,
+          "ledOffset": 249,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.26291036605835,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170095,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 60-125",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge60-125"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge60-127",
+        "jsonParameters": {
+          "points": 119,
+          "host": "10.7.10.21",
+          "output": 1,
+          "ledOffset": 48,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 7.183310508728027,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170097,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 60-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge60-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge65-67",
+        "jsonParameters": {
+          "points": 105,
+          "host": "10.7.10.20",
+          "output": 1,
+          "ledOffset": 123,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.902515411376953,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170099,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 65-67",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge65-67"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge65-93",
+        "jsonParameters": {
+          "points": 209,
+          "host": "10.7.10.22",
+          "output": 4,
+          "ledOffset": 208,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 1.0,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170101,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 65-93",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge65-93"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge67-90",
+        "jsonParameters": {
+          "points": 160,
+          "host": "10.7.9.10",
+          "output": 1,
+          "ledOffset": 166,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.41436767578125,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170103,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 67-90",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge67-90"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge67-93",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.10.20",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.994309902191162,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170105,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 67-93",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge67-93"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge69-70",
+        "jsonParameters": {
+          "points": 90,
+          "host": "10.7.8.12",
+          "output": 2,
+          "ledOffset": 181,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.531277179718018,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170107,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 69-70",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge69-70"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge69-82",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.8.12",
+          "output": 2,
+          "ledOffset": 58,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.865997791290283,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170109,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 69-82",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge69-82"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge69-90",
+        "jsonParameters": {
+          "points": 120,
+          "host": "10.7.8.20",
+          "output": 1,
+          "ledOffset": 178,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.344910144805908,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170111,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 69-90",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge69-90"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge69-93",
+        "jsonParameters": {
+          "points": 155,
+          "host": "10.7.9.11",
+          "output": 1,
+          "ledOffset": 123,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.635539531707764,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170113,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 69-93",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge69-93"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge69-127",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.9.11",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.716310024261475,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170115,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 69-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge69-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge70-81",
+        "jsonParameters": {
+          "points": 71,
+          "host": "10.7.21.210",
+          "output": 1,
+          "ledOffset": 138,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.203756332397461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170117,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 70-81",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge70-81"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge70-82",
+        "jsonParameters": {
+          "points": 58,
+          "host": "10.7.8.12",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.298299789428711,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170119,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 70-82",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge70-82"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge70-89",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.9.13",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359066963195801,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170121,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 70-89",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge70-89"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge70-127",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.9.13",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.691760063171387,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170123,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 70-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge70-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge73-75",
+        "jsonParameters": {
+          "points": 90,
+          "host": "10.7.13.112",
+          "output": 1,
+          "ledOffset": 181,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.531277179718018,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170125,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 73-75",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge73-75"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge73-81",
+        "jsonParameters": {
+          "points": 71,
+          "host": "10.7.21.211",
+          "output": 1,
+          "ledOffset": 323,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.203756332397461,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170127,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 73-81",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge73-81"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge73-91",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.12.113",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359066963195801,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170129,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 73-91",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge73-91"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge73-92",
+        "jsonParameters": {
+          "points": 58,
+          "host": "10.7.13.112",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.298299789428711,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170131,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 73-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge73-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge73-128",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.12.113",
+          "output": 1,
+          "ledOffset": 113,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.691760063171387,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170133,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 73-128",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge73-128"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge75-92",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.13.112",
+          "output": 1,
+          "ledOffset": 58,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.865997791290283,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170135,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 75-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge75-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge75-96",
+        "jsonParameters": {
+          "points": 120,
+          "host": "10.7.13.120",
+          "output": 1,
+          "ledOffset": 178,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.344910144805908,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170137,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 75-96",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge75-96"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge75-97",
+        "jsonParameters": {
+          "points": 155,
+          "host": "10.7.12.111",
+          "output": 1,
+          "ledOffset": 123,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.635539531707764,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170139,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 75-97",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge75-97"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge75-128",
+        "jsonParameters": {
+          "points": 123,
+          "host": "10.7.12.111",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.716310024261475,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170141,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 75-128",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge75-128"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge78-79",
+        "jsonParameters": {
+          "points": 188,
+          "host": "10.7.1.20",
+          "output": 1,
+          "ledOffset": 234,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 7.5293354988098145,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170143,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 78-79",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge78-79"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge78-97",
+        "jsonParameters": {
+          "points": 48,
+          "host": "10.7.1.21",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.359182834625244,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170145,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 78-97",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge78-97"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge78-128",
+        "jsonParameters": {
+          "points": 119,
+          "host": "10.7.1.21",
+          "output": 1,
+          "ledOffset": 48,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 7.1832990646362305,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170147,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 78-128",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge78-128"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge78-129",
+        "jsonParameters": {
+          "points": 158,
+          "host": "10.7.1.23",
+          "output": 1,
+          "ledOffset": 249,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.26291036605835,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170149,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 78-129",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge78-129"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge79-80",
+        "jsonParameters": {
+          "points": 105,
+          "host": "10.7.1.20",
+          "output": 1,
+          "ledOffset": 129,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.902515411376953,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170151,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 79-80",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge79-80"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge79-97",
+        "jsonParameters": {
+          "points": 209,
+          "host": "10.7.1.22",
+          "output": 1,
+          "ledOffset": 208,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 9.886881828308105,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170153,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 79-97",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge79-97"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge80-96",
+        "jsonParameters": {
+          "points": 160,
+          "host": "10.7.12.110",
+          "output": 1,
+          "ledOffset": 166,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.41436767578125,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170155,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 80-96",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge80-96"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge80-97",
+        "jsonParameters": {
+          "points": 129,
+          "host": "10.7.1.20",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.025710105895996,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170157,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 80-97",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge80-97"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge81-82",
+        "jsonParameters": {
+          "points": 83,
+          "host": "10.7.21.220",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.286637306213379,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170159,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 81-82",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge81-82"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge81-89",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.21.210",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.238584995269775,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170161,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 81-89",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge81-89"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge81-91",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.21.211",
+          "output": 1,
+          "ledOffset": 185,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.238584995269775,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170163,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 81-91",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge81-91"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge81-92",
+        "jsonParameters": {
+          "points": 89,
+          "host": "10.7.21.220",
+          "output": 1,
+          "ledOffset": 211,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.318037271499634,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170165,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 81-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge81-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge82-92",
+        "jsonParameters": {
+          "points": 128,
+          "host": "10.7.21.220",
+          "output": 1,
+          "ledOffset": 83,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.331299781799316,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170167,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 82-92",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge82-92"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge82-122",
+        "jsonParameters": {
+          "points": 218,
+          "host": "10.7.6.14",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.160789966583252,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170169,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 82-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge82-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge83-84",
+        "jsonParameters": {
+          "points": 165,
+          "host": "10.7.18.110",
+          "output": 4,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.000546932220459,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170171,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 83-84",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge83-84"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge83-85",
+        "jsonParameters": {
+          "points": 133,
+          "host": "10.7.19.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.71339750289917,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170173,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 83-85",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge83-85"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge83-114",
+        "jsonParameters": {
+          "points": 76,
+          "host": "10.7.19.122",
+          "output": 1,
+          "ledOffset": 132,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.3542160987854,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170175,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 83-114",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge83-114"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge84-85",
+        "jsonParameters": {
+          "points": 159,
+          "host": "10.7.18.110",
+          "output": 4,
+          "ledOffset": 165,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.310825347900391,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170177,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 84-85",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge84-85"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge84-86",
+        "jsonParameters": {
+          "points": 68,
+          "host": "10.7.17.110",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.6571402549743652,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170179,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 84-86",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge84-86"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge84-88",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.17.110",
+          "output": 1,
+          "ledOffset": 68,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.572225093841553,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170181,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 84-88",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge84-88"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge86-88",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.17.120",
+          "output": 1,
+          "ledOffset": 261,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.467125415802002,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170183,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 86-88",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge86-88"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge86-120",
+        "jsonParameters": {
+          "points": 107,
+          "host": "10.7.17.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.877974987030029,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170185,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 86-120",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge86-120"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge88-110",
+        "jsonParameters": {
+          "points": 116,
+          "host": "10.7.17.121",
+          "output": 1,
+          "ledOffset": 294,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.353405952453613,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170187,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 88-110",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge88-110"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge88-119",
+        "jsonParameters": {
+          "points": 147,
+          "host": "10.7.17.121",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.64788293838501,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170189,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 88-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge88-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge88-120",
+        "jsonParameters": {
+          "points": 154,
+          "host": "10.7.17.120",
+          "output": 1,
+          "ledOffset": 107,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.7726874351501465,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170191,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 88-120",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge88-120"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge89-91",
+        "jsonParameters": {
+          "points": 185,
+          "host": "10.7.21.211",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.6296000480651855,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170193,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 89-91",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge89-91"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge89-125",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.10.21",
+          "output": 1,
+          "ledOffset": 260,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.637704372406006,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170195,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 89-125",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge89-125"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge89-126",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.10.23",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.527910232543945,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170197,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 89-126",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge89-126"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge89-127",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.10.22",
+          "output": 4,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.069464206695557,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170199,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 89-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge89-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge90-93",
+        "jsonParameters": {
+          "points": 166,
+          "host": "10.7.9.10",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.113073348999023,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170201,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 90-93",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge90-93"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge91-126",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.1.23",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.527910232543945,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170203,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 91-126",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge91-126"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge91-128",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.1.22",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.069464206695557,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170205,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 91-128",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge91-128"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge91-129",
+        "jsonParameters": {
+          "points": 133,
+          "host": "10.7.1.21",
+          "output": 1,
+          "ledOffset": 260,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.309604167938232,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170207,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 91-129",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge91-129"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge92-122",
+        "jsonParameters": {
+          "points": 218,
+          "host": "10.7.6.114",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.160789966583252,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170209,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 92-122",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge92-122"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge93-127",
+        "jsonParameters": {
+          "points": 76,
+          "host": "10.7.10.22",
+          "output": 4,
+          "ledOffset": 132,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.495628356933594,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170211,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 93-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge93-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge96-97",
+        "jsonParameters": {
+          "points": 166,
+          "host": "10.7.12.110",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.113073348999023,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170213,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 96-97",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge96-97"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge97-128",
+        "jsonParameters": {
+          "points": 76,
+          "host": "10.7.1.22",
+          "output": 1,
+          "ledOffset": 132,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.495628356933594,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170215,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 97-128",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge97-128"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge98-99",
+        "jsonParameters": {
+          "points": 159,
+          "host": "10.7.2.10",
+          "output": 2,
+          "ledOffset": 165,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.310825347900391,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170217,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 98-99",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge98-99"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge98-100",
+        "jsonParameters": {
+          "points": 129,
+          "host": "10.7.11.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.025797367095947,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170219,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 98-100",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge98-100"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge99-100",
+        "jsonParameters": {
+          "points": 165,
+          "host": "10.7.2.10",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.000546932220459,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170221,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 99-100",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge99-100"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge99-101",
+        "jsonParameters": {
+          "points": 68,
+          "host": "10.7.3.10",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.6571402549743652,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170223,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 99-101",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge99-101"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge99-102",
+        "jsonParameters": {
+          "points": 113,
+          "host": "10.7.3.10",
+          "output": 2,
+          "ledOffset": 68,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 6.572225093841553,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170225,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 99-102",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge99-102"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge100-115",
+        "jsonParameters": {
+          "points": 76,
+          "host": "10.7.11.122",
+          "output": 1,
+          "ledOffset": 132,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 6.3542160987854,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170227,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 100-115",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge100-115"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge101-102",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.3.20",
+          "output": 2,
+          "ledOffset": 261,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.467125415802002,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170229,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 101-102",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge101-102"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge101-121",
+        "jsonParameters": {
+          "points": 107,
+          "host": "10.7.3.20",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.877974987030029,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170231,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 101-121",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge101-121"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge102-111",
+        "jsonParameters": {
+          "points": 116,
+          "host": "10.7.3.21",
+          "output": 2,
+          "ledOffset": 294,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.353405952453613,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170233,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 102-111",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge102-111"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge102-119",
+        "jsonParameters": {
+          "points": 147,
+          "host": "10.7.3.21",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.64788293838501,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170235,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 102-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge102-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge102-121",
+        "jsonParameters": {
+          "points": 154,
+          "host": "10.7.3.20",
+          "output": 2,
+          "ledOffset": 107,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.7726874351501465,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170237,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 102-121",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge102-121"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge109-110",
+        "jsonParameters": {
+          "points": 83,
+          "host": "10.7.20.220",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.286637306213379,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170239,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 109-110",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge109-110"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge109-111",
+        "jsonParameters": {
+          "points": 83,
+          "host": "10.7.20.220",
+          "output": 1,
+          "ledOffset": 211,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.286637306213379,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170241,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 109-111",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge109-111"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge109-112",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.20.210",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.238584995269775,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170243,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 109-112",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge109-112"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge109-113",
+        "jsonParameters": {
+          "points": 138,
+          "host": "10.7.20.211",
+          "output": 1,
+          "ledOffset": 185,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.238584995269775,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170245,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 109-113",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge109-113"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge110-111",
+        "jsonParameters": {
+          "points": 128,
+          "host": "10.7.20.220",
+          "output": 1,
+          "ledOffset": 83,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.331299781799316,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170247,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 110-111",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge110-111"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge110-119",
+        "jsonParameters": {
+          "points": 147,
+          "host": "10.7.17.121",
+          "output": 1,
+          "ledOffset": 147,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.467164039611816,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170249,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 110-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge110-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge111-119",
+        "jsonParameters": {
+          "points": 147,
+          "host": "10.7.3.21",
+          "output": 2,
+          "ledOffset": 147,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.467164039611816,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170251,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 111-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge111-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge112-113",
+        "jsonParameters": {
+          "points": 185,
+          "host": "10.7.20.211",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.6296000480651855,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170253,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 112-113",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge112-113"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge112-114",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.19.122",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.069464206695557,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170255,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 112-114",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge112-114"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge112-116",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.19.121",
+          "output": 1,
+          "ledOffset": 267,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.637704372406006,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170257,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 112-116",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge112-116"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge112-124",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.19.123",
+          "output": 2,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.527910232543945,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170259,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 112-124",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge112-124"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge113-115",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.11.122",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 5.069464206695557,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170261,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 113-115",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge113-115"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge113-117",
+        "jsonParameters": {
+          "points": 132,
+          "host": "10.7.11.121",
+          "output": 1,
+          "ledOffset": 260,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.637704372406006,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170263,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 113-117",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge113-117"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge113-124",
+        "jsonParameters": {
+          "points": 145,
+          "host": "10.7.11.123",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.527910232543945,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170265,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 113-124",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge113-124"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge114-116",
+        "jsonParameters": {
+          "points": 100,
+          "host": "10.7.19.121",
+          "output": 1,
+          "ledOffset": 167,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 1.7920259237289429,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170267,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 114-116",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge114-116"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge115-117",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.11.121",
+          "output": 1,
+          "ledOffset": 167,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.088726043701172,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170269,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 115-117",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge115-117"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge116-124",
+        "jsonParameters": {
+          "points": 104,
+          "host": "10.7.19.123",
+          "output": 2,
+          "ledOffset": 145,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.7955923080444336,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170271,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 116-124",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge116-124"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge117-124",
+        "jsonParameters": {
+          "points": 104,
+          "host": "10.7.11.123",
+          "output": 1,
+          "ledOffset": 145,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.7955923080444336,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170273,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 117-124",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge117-124"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge118-119",
+        "jsonParameters": {
+          "points": 175,
+          "host": "10.7.4.10",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.489487171173096,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170275,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 118-119",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge118-119"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge119-120",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.4.120",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.305822372436523,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170277,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 119-120",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge119-120"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge119-121",
+        "jsonParameters": {
+          "points": 142,
+          "host": "10.7.4.12",
+          "output": 1,
+          "ledOffset": 0,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 5.305822372436523,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170279,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 119-121",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge119-121"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge125-126",
+        "jsonParameters": {
+          "points": 104,
+          "host": "10.7.10.23",
+          "output": 2,
+          "ledOffset": 145,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 3.7955923080444336,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170281,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 125-126",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge125-126"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge125-127",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.10.21",
+          "output": 1,
+          "ledOffset": 167,
+          "artnetSequence": false,
+          "reverse": true,
+          "xOffset": 4.088726043701172,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170283,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 125-127",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge125-127"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge126-129",
+        "jsonParameters": {
+          "points": 104,
+          "host": "10.7.1.23",
+          "output": 1,
+          "ledOffset": 145,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 3.7955923080444336,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170285,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 126-129",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": false,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge126-129"
+        },
+        "children": {}
+      },
+      {
+        "jsonFixtureType": "TE/edge/Edge128-129",
+        "jsonParameters": {
+          "points": 93,
+          "host": "10.7.1.21",
+          "output": 1,
+          "ledOffset": 167,
+          "artnetSequence": false,
+          "reverse": false,
+          "xOffset": 4.088726043701172,
+          "onCar": true,
+          "hasOutput": true
+        },
+        "id": 170287,
+        "class": "heronarts.lx.structure.JsonFixture",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Edge 128-129",
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "yaw": 0.0,
+          "pitch": 0.0,
+          "roll": 0.0,
+          "scale": 1.0,
+          "selected": true,
+          "deactivate": false,
+          "enabled": true,
+          "brightness": 1.0,
+          "identify": false,
+          "mute": false,
+          "solo": false,
+          "tags": "",
+          "fixtureType": "TE/edge/Edge128-129"
+        },
+        "children": {}
+      }
+    ]
+  },
+  "engine": {
+    "id": 1,
+    "class": "heronarts.lx.LXEngine",
+    "internal": {
+      "modulationColor": 0,
+      "modulationControlsExpanded": true,
+      "modulationsExpanded": true
+    },
+    "parameters": {
+      "label": "Engine",
+      "multithreaded": true,
+      "channelMultithreaded": false,
+      "networkMultithreaded": false,
+      "framesPerSecond": 60.0,
+      "speed": 1.0,
+      "performanceMode": false
+    },
+    "children": {
+      "palette": {
+        "id": 6,
+        "class": "heronarts.lx.color.LXPalette",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette",
+          "transitionEnabled": false,
+          "transitionTimeSecs": 0.1,
+          "transitionMode": 1,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "autoCycleCursor": 3,
+          "triggerSwatchCycle": false,
+          "expandedPerformance": true,
+          "label1": "1",
+          "label2": "2",
+          "label3": "3",
+          "label4": "4",
+          "label5": "5"
+        },
+        "children": {
+          "swatch": {
+            "id": 7,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "GreenRod",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 8,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 81.05549812316895,
+                  "primary/hue": 0.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 82.5,
+                  "secondary/hue": 96.00000762939453
+                },
+                "children": {}
+              },
+              {
+                "id": 43784,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 100.0,
+                  "primary/hue": 188.27359282970428,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 98.33333587646484,
+                  "secondary/hue": 72.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        },
+        "swatches": [
+          {
+            "id": 243821,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "PlumIce",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243822,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 40.0,
+                  "primary/saturation": 95.0,
+                  "primary/hue": 294.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 243824,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243826,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "IceGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243827,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 61.00000087171793,
+                  "primary/hue": 192.58998466096818,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243829,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 47.0,
+                  "primary/hue": 258.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 28.333335876464844,
+                  "secondary/hue": 273.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243831,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "IceYelGrad",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243832,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.0,
+                  "primary/saturation": 61.0,
+                  "primary/hue": 194.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 42.5,
+                  "secondary/hue": 188.99998474121094
+                },
+                "children": {}
+              },
+              {
+                "id": 243834,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 20.833328247070312,
+                  "primary/hue": 225.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 288.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243836,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "GreenRod",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243837,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 95.49999237060547,
+                  "primary/saturation": 80.83333587646484,
+                  "primary/hue": 78.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 82.5,
+                  "secondary/hue": 96.00000762939453
+                },
+                "children": {}
+              },
+              {
+                "id": 243839,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 99.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 98.33333587646484,
+                  "secondary/hue": 72.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243841,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SunWave",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243842,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 100.0,
+                  "primary/saturation": 55.83333206176758,
+                  "primary/hue": 204.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 85.0,
+                  "secondary/hue": 210.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243844,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 24.0,
+                  "primary/brightness": 96.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 273.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 300.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243846,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWv",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243847,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 9.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243849,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 77.25000762939453,
+                  "primary/hue": 256.0,
+                  "secondary/brightness": 76.66666412353516,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243851,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SynWvDyn",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243852,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 89.0,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 84.99996185302734,
+                  "secondary/saturation": 38.33333206176758,
+                  "secondary/hue": 330.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243854,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 8.0,
+                  "primary/brightness": 75.00000046938658,
+                  "primary/saturation": 78.91667175292969,
+                  "primary/hue": 249.0,
+                  "secondary/brightness": 44.9999885559082,
+                  "secondary/saturation": 77.25000762939453,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243856,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Sunset",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243857,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 69.33331298828125,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 267.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243859,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 30.0,
+                  "primary/brightness": 63.33330154418945,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 323.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 100.0,
+                  "secondary/hue": 120.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243861,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-13",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243862,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 71.66666412353516,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 59.99995040893555,
+                  "secondary/saturation": 58.333335876464844,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243864,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 98.33333587646484,
+                  "primary/hue": 219.0,
+                  "secondary/brightness": 38.3332633972168,
+                  "secondary/saturation": 71.66666412353516,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243866,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-14",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243867,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 56.66666793823242,
+                  "primary/hue": 195.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243869,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 62.5,
+                  "primary/hue": 174.0,
+                  "secondary/brightness": 64.16655731201172,
+                  "secondary/saturation": 70.0,
+                  "secondary/hue": 186.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243871,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-15",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243872,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 30.0,
+                  "primary/hue": 300.0,
+                  "secondary/brightness": 61.6666145324707,
+                  "secondary/saturation": 59.16666793823242,
+                  "secondary/hue": 303.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243874,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 68.333251953125,
+                  "primary/saturation": 73.33332824707031,
+                  "primary/hue": 318.0,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 40.833335876464844,
+                  "secondary/hue": 312.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243876,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-16",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243877,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 32.0,
+                  "primary/brightness": 89.01960754394531,
+                  "primary/saturation": 97.5,
+                  "primary/hue": 159.0,
+                  "secondary/brightness": 94.99999237060547,
+                  "secondary/saturation": 68.08334350585938,
+                  "secondary/hue": 90.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243879,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 24.0,
+                  "primary/brightness": 62.30385208129883,
+                  "primary/saturation": 96.66666412353516,
+                  "primary/hue": 165.0,
+                  "secondary/brightness": 100.0,
+                  "secondary/saturation": 95.83333587646484,
+                  "secondary/hue": 60.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243881,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-17",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243882,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 58.333335876464844,
+                  "primary/hue": 188.99998474121094,
+                  "secondary/brightness": 49.99996566772461,
+                  "secondary/saturation": 65.0,
+                  "secondary/hue": 180.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243884,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 72.5,
+                  "primary/hue": 201.0,
+                  "secondary/brightness": 84.99995422363281,
+                  "secondary/saturation": 61.66666793823242,
+                  "secondary/hue": 219.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243886,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-18",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243887,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 75.0,
+                  "primary/hue": 198.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243889,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 1,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 77.5,
+                  "primary/hue": 216.00001525878906,
+                  "secondary/brightness": 66.66657257080078,
+                  "secondary/saturation": 69.16666412353516,
+                  "secondary/hue": 225.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243891,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-19",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243892,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 95.83333587646484,
+                  "primary/hue": 192.00001525878906,
+                  "secondary/brightness": 62.49994659423828,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 195.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243894,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 70.0,
+                  "primary/hue": 212.99998474121094,
+                  "secondary/brightness": 98.33332824707031,
+                  "secondary/saturation": 48.333335876464844,
+                  "secondary/hue": 204.0
+                },
+                "children": {}
+              }
+            ]
+          },
+          {
+            "id": 243896,
+            "class": "heronarts.lx.color.LXSwatch",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Swatch-20",
+              "recall": false,
+              "autoCycleEligible": true
+            },
+            "children": {},
+            "colors": [
+              {
+                "id": 243897,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 91.00000020116568,
+                  "primary/saturation": 55.0,
+                  "primary/hue": 342.0,
+                  "secondary/brightness": 73.33330535888672,
+                  "secondary/saturation": 77.5,
+                  "secondary/hue": 258.0
+                },
+                "children": {}
+              },
+              {
+                "id": 243899,
+                "class": "heronarts.lx.color.LXDynamicColor",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "LX",
+                  "mode": 0,
+                  "period": 16.0,
+                  "primary/brightness": 95.0,
+                  "primary/saturation": 51.66666793823242,
+                  "primary/hue": 333.0,
+                  "secondary/brightness": 66.66656494140625,
+                  "secondary/saturation": 55.83333206176758,
+                  "secondary/hue": 324.0
+                },
+                "children": {}
+              }
+            ]
+          }
+        ]
+      },
+      "tempo": {
+        "id": 10,
+        "class": "heronarts.lx.Tempo",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Tempo",
+          "clockSource": 0,
+          "period": 483.8709677419355,
+          "bpm": 124.0,
+          "tap": false,
+          "nudgeUp": false,
+          "nudgeDown": false,
+          "beatsPerBar": 4,
+          "trigger": false,
+          "enabled": true
+        },
+        "children": {
+          "nudge": {
+            "id": 11,
+            "class": "heronarts.lx.modulator.LinearEnvelope",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LENV",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "loop": false,
+              "tempoSync": false,
+              "tempoMultiplier": 5,
+              "tempoLock": true
+            },
+            "children": {},
+            "basis": 0.0
+          }
+        }
+      },
+      "clips": {
+        "id": 12,
+        "class": "heronarts.lx.clip.LXClipEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "focusedClip": 0.0,
+          "numScenes": 8,
+          "snapshotTransitionEnabled": false,
+          "snapshotTransitionTimeSecs": 5.0,
+          "stopClips": false,
+          "triggerPatternCycle": false,
+          "gridMode": 0,
+          "gridViewOffset": 0,
+          "gridPatternOffset": 0,
+          "gridViewExpanded": false,
+          "clipInspectorExpanded": false,
+          "scene-1": false,
+          "pattern-1": false,
+          "scene-2": false,
+          "pattern-2": false,
+          "scene-3": false,
+          "pattern-3": false,
+          "scene-4": false,
+          "pattern-4": false,
+          "scene-5": false,
+          "pattern-5": false,
+          "scene-6": false,
+          "pattern-6": false,
+          "scene-7": false,
+          "pattern-7": false,
+          "scene-8": false,
+          "pattern-8": false,
+          "scene-9": false,
+          "pattern-9": false,
+          "scene-10": false,
+          "pattern-10": false,
+          "scene-11": false,
+          "pattern-11": false,
+          "scene-12": false,
+          "pattern-12": false,
+          "scene-13": false,
+          "pattern-13": false,
+          "scene-14": false,
+          "pattern-14": false,
+          "scene-15": false,
+          "pattern-15": false,
+          "scene-16": false,
+          "pattern-16": false,
+          "scene-17": false,
+          "pattern-17": false,
+          "scene-18": false,
+          "pattern-18": false,
+          "scene-19": false,
+          "pattern-19": false,
+          "scene-20": false,
+          "pattern-20": false,
+          "scene-21": false,
+          "pattern-21": false,
+          "scene-22": false,
+          "pattern-22": false,
+          "scene-23": false,
+          "pattern-23": false,
+          "scene-24": false,
+          "pattern-24": false,
+          "scene-25": false,
+          "pattern-25": false,
+          "scene-26": false,
+          "pattern-26": false,
+          "scene-27": false,
+          "pattern-27": false,
+          "scene-28": false,
+          "pattern-28": false,
+          "scene-29": false,
+          "pattern-29": false,
+          "scene-30": false,
+          "pattern-30": false,
+          "scene-31": false,
+          "pattern-31": false,
+          "scene-32": false,
+          "pattern-32": false,
+          "scene-33": false,
+          "pattern-33": false,
+          "scene-34": false,
+          "pattern-34": false,
+          "scene-35": false,
+          "pattern-35": false,
+          "scene-36": false,
+          "pattern-36": false,
+          "scene-37": false,
+          "pattern-37": false,
+          "scene-38": false,
+          "pattern-38": false,
+          "scene-39": false,
+          "pattern-39": false,
+          "scene-40": false,
+          "pattern-40": false,
+          "scene-41": false,
+          "pattern-41": false,
+          "scene-42": false,
+          "pattern-42": false,
+          "scene-43": false,
+          "pattern-43": false,
+          "scene-44": false,
+          "pattern-44": false,
+          "scene-45": false,
+          "pattern-45": false,
+          "scene-46": false,
+          "pattern-46": false,
+          "scene-47": false,
+          "pattern-47": false,
+          "scene-48": false,
+          "pattern-48": false,
+          "scene-49": false,
+          "pattern-49": false,
+          "scene-50": false,
+          "pattern-50": false,
+          "scene-51": false,
+          "pattern-51": false,
+          "scene-52": false,
+          "pattern-52": false,
+          "scene-53": false,
+          "pattern-53": false,
+          "scene-54": false,
+          "pattern-54": false,
+          "scene-55": false,
+          "pattern-55": false,
+          "scene-56": false,
+          "pattern-56": false,
+          "scene-57": false,
+          "pattern-57": false,
+          "scene-58": false,
+          "pattern-58": false,
+          "scene-59": false,
+          "pattern-59": false,
+          "scene-60": false,
+          "pattern-60": false,
+          "scene-61": false,
+          "pattern-61": false,
+          "scene-62": false,
+          "pattern-62": false,
+          "scene-63": false,
+          "pattern-63": false,
+          "scene-64": false,
+          "pattern-64": false,
+          "scene-65": false,
+          "pattern-65": false,
+          "scene-66": false,
+          "pattern-66": false,
+          "scene-67": false,
+          "pattern-67": false,
+          "scene-68": false,
+          "pattern-68": false,
+          "scene-69": false,
+          "pattern-69": false,
+          "scene-70": false,
+          "pattern-70": false,
+          "scene-71": false,
+          "pattern-71": false,
+          "scene-72": false,
+          "pattern-72": false,
+          "scene-73": false,
+          "pattern-73": false,
+          "scene-74": false,
+          "pattern-74": false,
+          "scene-75": false,
+          "pattern-75": false,
+          "scene-76": false,
+          "pattern-76": false,
+          "scene-77": false,
+          "pattern-77": false,
+          "scene-78": false,
+          "pattern-78": false,
+          "scene-79": false,
+          "pattern-79": false,
+          "scene-80": false,
+          "pattern-80": false,
+          "scene-81": false,
+          "pattern-81": false,
+          "scene-82": false,
+          "pattern-82": false,
+          "scene-83": false,
+          "pattern-83": false,
+          "scene-84": false,
+          "pattern-84": false,
+          "scene-85": false,
+          "pattern-85": false,
+          "scene-86": false,
+          "pattern-86": false,
+          "scene-87": false,
+          "pattern-87": false,
+          "scene-88": false,
+          "pattern-88": false,
+          "scene-89": false,
+          "pattern-89": false,
+          "scene-90": false,
+          "pattern-90": false,
+          "scene-91": false,
+          "pattern-91": false,
+          "scene-92": false,
+          "pattern-92": false,
+          "scene-93": false,
+          "pattern-93": false,
+          "scene-94": false,
+          "pattern-94": false,
+          "scene-95": false,
+          "pattern-95": false,
+          "scene-96": false,
+          "pattern-96": false,
+          "scene-97": false,
+          "pattern-97": false,
+          "scene-98": false,
+          "pattern-98": false,
+          "scene-99": false,
+          "pattern-99": false,
+          "scene-100": false,
+          "pattern-100": false,
+          "scene-101": false,
+          "pattern-101": false,
+          "scene-102": false,
+          "pattern-102": false,
+          "scene-103": false,
+          "pattern-103": false,
+          "scene-104": false,
+          "pattern-104": false,
+          "scene-105": false,
+          "pattern-105": false,
+          "scene-106": false,
+          "pattern-106": false,
+          "scene-107": false,
+          "pattern-107": false,
+          "scene-108": false,
+          "pattern-108": false,
+          "scene-109": false,
+          "pattern-109": false,
+          "scene-110": false,
+          "pattern-110": false,
+          "scene-111": false,
+          "pattern-111": false,
+          "scene-112": false,
+          "pattern-112": false,
+          "scene-113": false,
+          "pattern-113": false,
+          "scene-114": false,
+          "pattern-114": false,
+          "scene-115": false,
+          "pattern-115": false,
+          "scene-116": false,
+          "pattern-116": false,
+          "scene-117": false,
+          "pattern-117": false,
+          "scene-118": false,
+          "pattern-118": false,
+          "scene-119": false,
+          "pattern-119": false,
+          "scene-120": false,
+          "pattern-120": false,
+          "scene-121": false,
+          "pattern-121": false,
+          "scene-122": false,
+          "pattern-122": false,
+          "scene-123": false,
+          "pattern-123": false,
+          "scene-124": false,
+          "pattern-124": false,
+          "scene-125": false,
+          "pattern-125": false,
+          "scene-126": false,
+          "pattern-126": false,
+          "scene-127": false,
+          "pattern-127": false,
+          "scene-128": false,
+          "pattern-128": false
+        },
+        "children": {}
+      },
+      "audio": {
+        "id": 13,
+        "class": "heronarts.lx.audio.LXAudioEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true,
+          "ioExpanded": false,
+          "numSoundObjects": 0.0
+        },
+        "parameters": {
+          "label": "Audio",
+          "enabled": true,
+          "mode": 0,
+          "expandedPerformance": true
+        },
+        "children": {
+          "input": {
+            "id": 14,
+            "class": "heronarts.lx.audio.LXAudioInput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Input",
+              "device": 0
+            },
+            "children": {}
+          },
+          "output": {
+            "id": 15,
+            "class": "heronarts.lx.audio.LXAudioOutput",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Output",
+              "file": "",
+              "trigger": false,
+              "looping": false,
+              "play": false
+            },
+            "children": {}
+          },
+          "soundStage": {
+            "id": 16,
+            "class": "heronarts.lx.audio.SoundStage",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "SoundStage",
+              "mode": 0,
+              "xAbsolute": 0.0,
+              "yAbsolute": 0.0,
+              "zAbsolute": 0.0,
+              "widthAbsolute": 100.0,
+              "heightAbsolute": 100.0,
+              "depthAbsolute": 100.0,
+              "azimuthAbsolute": 0.0,
+              "elevationAbsolute": 0.0,
+              "xRelative": 0.0,
+              "yRelative": 0.0,
+              "zRelative": 0.0,
+              "widthRelative": 1.0,
+              "heightRelative": 1.0,
+              "depthRelative": 1.0,
+              "azimuthRelative": 0.0,
+              "elevationRelative": 0.0,
+              "showSoundStage": false,
+              "showSoundObjects": true,
+              "soundObjectMeterMode": 0,
+              "soundObjectSize": 10.0
+            },
+            "children": {}
+          },
+          "adm": {
+            "id": 17,
+            "class": "heronarts.lx.audio.ADM",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "ADM"
+            },
+            "children": {}
+          },
+          "envelop": {
+            "id": 82,
+            "class": "heronarts.lx.audio.Envelop",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Envelop",
+              "running": false,
+              "trigger": false
+            },
+            "children": {
+              "source": {
+                "id": 83,
+                "class": "heronarts.lx.audio.Envelop$Source",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Source",
+                  "running": true,
+                  "trigger": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "source-1": 0.0,
+                  "source-2": 0.0,
+                  "source-3": 0.0,
+                  "source-4": 0.0,
+                  "source-5": 0.0,
+                  "source-6": 0.0,
+                  "source-7": 0.0,
+                  "source-8": 0.0,
+                  "source-9": 0.0,
+                  "source-10": 0.0,
+                  "source-11": 0.0,
+                  "source-12": 0.0,
+                  "source-13": 0.0,
+                  "source-14": 0.0,
+                  "source-15": 0.0,
+                  "source-16": 0.0,
+                  "source-17": 0.0,
+                  "source-18": 0.0,
+                  "source-19": 0.0,
+                  "source-20": 0.0,
+                  "source-21": 0.0,
+                  "source-22": 0.0,
+                  "source-23": 0.0,
+                  "source-24": 0.0,
+                  "source-25": 0.0,
+                  "source-26": 0.0,
+                  "source-27": 0.0,
+                  "source-28": 0.0,
+                  "source-29": 0.0,
+                  "source-30": 0.0,
+                  "source-31": 0.0,
+                  "source-32": 0.0
+                },
+                "children": {}
+              },
+              "decode": {
+                "id": 84,
+                "class": "heronarts.lx.audio.Envelop$Decode",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Decode",
+                  "running": true,
+                  "trigger": false,
+                  "gain": 0.0,
+                  "range": 24.0,
+                  "attack": 0.0,
+                  "release": 50.0,
+                  "decode-1": 0.0,
+                  "decode-2": 0.0,
+                  "decode-3": 0.0,
+                  "decode-4": 0.0,
+                  "decode-5": 0.0,
+                  "decode-6": 0.0,
+                  "decode-7": 0.0,
+                  "decode-8": 0.0
+                },
+                "children": {}
+              }
+            }
+          },
+          "reaper": {
+            "id": 85,
+            "class": "heronarts.lx.audio.Reaper",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "metersExpanded": false
+            },
+            "parameters": {
+              "label": "Reaper",
+              "running": false,
+              "trigger": false,
+              "meterAttack": 0.0,
+              "meterRelease": 0.0,
+              "foldMode": 1,
+              "master": 0.0,
+              "master-active": false,
+              "meter-1": 0.0,
+              "meter-1-active": false,
+              "meter-2": 0.0,
+              "meter-2-active": false,
+              "meter-3": 0.0,
+              "meter-3-active": false,
+              "meter-4": 0.0,
+              "meter-4-active": false,
+              "meter-5": 0.0,
+              "meter-5-active": false,
+              "meter-6": 0.0,
+              "meter-6-active": false,
+              "meter-7": 0.0,
+              "meter-7-active": false,
+              "meter-8": 0.0,
+              "meter-8-active": false,
+              "meter-9": 0.0,
+              "meter-9-active": false,
+              "meter-10": 0.0,
+              "meter-10-active": false,
+              "meter-11": 0.0,
+              "meter-11-active": false,
+              "meter-12": 0.0,
+              "meter-12-active": false,
+              "meter-13": 0.0,
+              "meter-13-active": false,
+              "meter-14": 0.0,
+              "meter-14-active": false,
+              "meter-15": 0.0,
+              "meter-15-active": false,
+              "meter-16": 0.0,
+              "meter-16-active": false,
+              "meter-17": 0.0,
+              "meter-17-active": false,
+              "meter-18": 0.0,
+              "meter-18-active": false,
+              "meter-19": 0.0,
+              "meter-19-active": false,
+              "meter-20": 0.0,
+              "meter-20-active": false,
+              "meter-21": 0.0,
+              "meter-21-active": false,
+              "meter-22": 0.0,
+              "meter-22-active": false,
+              "meter-23": 0.0,
+              "meter-23-active": false,
+              "meter-24": 0.0,
+              "meter-24-active": false,
+              "meter-25": 0.0,
+              "meter-25-active": false,
+              "meter-26": 0.0,
+              "meter-26-active": false,
+              "meter-27": 0.0,
+              "meter-27-active": false,
+              "meter-28": 0.0,
+              "meter-28-active": false,
+              "meter-29": 0.0,
+              "meter-29-active": false,
+              "meter-30": 0.0,
+              "meter-30-active": false,
+              "meter-31": 0.0,
+              "meter-31-active": false,
+              "meter-32": 0.0,
+              "meter-32-active": false
+            },
+            "children": {}
+          },
+          "meter": {
+            "id": 86,
+            "class": "heronarts.lx.audio.LXAudioEngine$Meter",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "Meter",
+              "running": true,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "gain": 48.0,
+              "range": 60.59999942500144,
+              "attack": 8.666666317731142,
+              "release": 215.0309717563906,
+              "slope": 6.0,
+              "band-1": 0.4476502122436994,
+              "band-2": 0.455257719436136,
+              "band-3": 0.42485651497275023,
+              "band-4": 0.234547080568548,
+              "band-5": 0.16976062320909024,
+              "band-6": 0.0663938972829714,
+              "band-7": 0.11304721622921499,
+              "band-8": 0.14647503502753945,
+              "band-9": 0.17851576904931565,
+              "band-10": 0.19917076087041286,
+              "band-11": 0.20830773578857176,
+              "band-12": 0.28012103283771017,
+              "band-13": 0.35531930743065143,
+              "band-14": 0.6844570716443882,
+              "band-15": 0.7546364875726382,
+              "band-16": 0.7616060525148302
+            },
+            "children": {}
+          }
+        }
+      },
+      "mixer": {
+        "id": 87,
+        "class": "heronarts.lx.mixer.LXMixerEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Mixer",
+          "crossfader": 0.5748031496062992,
+          "crossfaderBlendMode": 1,
+          "focusedChannel": 1,
+          "focusedChannelAux": 1,
+          "cueA": false,
+          "cueB": false,
+          "auxA": false,
+          "auxB": false,
+          "viewCondensed": false,
+          "viewStacked": false,
+          "viewDeviceBin": true
+        },
+        "children": {
+          "master": {
+            "id": 95,
+            "class": "heronarts.lx.mixer.LXMasterBus",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false
+            },
+            "parameters": {
+              "label": "Master",
+              "fader": 0.8224330366356298,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "previewMode": 0
+            },
+            "children": {
+              "modulation": {
+                "id": 96,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [
+              {
+                "id": 128304,
+                "class": "heronarts.lx.effect.HueSaturationEffect",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Hue + Saturation",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": false,
+                  "locked": false,
+                  "hue": 0.0,
+                  "saturation": 0.0,
+                  "brightness": -100.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 128305,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              },
+              {
+                "id": 252487,
+                "class": "titanicsend.app.director.DirectorEffect",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "Director",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "locked": true
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252488,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              },
+              {
+                "id": 252542,
+                "class": "titanicsend.effect.RandomStrobeEffect",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "RandomStrobe",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "locked": false,
+                  "speed": 0.0,
+                  "depth": 0.0,
+                  "bias": 0.5,
+                  "waveshape": 0,
+                  "tempoSync": false,
+                  "tempoDivision": 5,
+                  "tempoPhaseOffset": 0.0,
+                  "minFrequency": 0.55,
+                  "maxFrequency": 30.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252543,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1
+              }
+            ],
+            "clips": []
+          }
+        },
+        "channels": [
+          {
+            "id": 157386,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "BOOTUP-NDI",
+              "fader": 0.0,
+              "arm": false,
+              "selected": false,
+              "stopClips": false,
+              "enabled": true,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "blendMode": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 0,
+              "compositeMode": 0,
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleTimeSecs": 30.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 0,
+              "triggerPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 248992,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 0,
+            "patterns": [
+              {
+                "id": 252490,
+                "class": "titanicsend.pattern.sinas.TdNdiPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "TdNdi",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252491,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              }
+            ]
+          },
+          {
+            "id": 252546,
+            "class": "heronarts.lx.mixer.LXChannel",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true,
+              "controlsExpandedCue": true,
+              "controlsExpandedAux": true,
+              "modulationExpanded": false,
+              "controlsExpanded": true,
+              "viewPatternLabel": false
+            },
+            "parameters": {
+              "label": "BOOTUP",
+              "fader": 0.0,
+              "arm": false,
+              "selected": true,
+              "stopClips": false,
+              "enabled": false,
+              "cue": false,
+              "aux": false,
+              "crossfadeGroup": 0,
+              "blendMode": 0,
+              "midiFilter/enabled": false,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "view": 0,
+              "compositeMode": 0,
+              "compositeDampingEnabled": true,
+              "compositeDampingTimeSecs": 0.1,
+              "autoCycleEnabled": false,
+              "autoCycleMode": 0,
+              "autoCycleTimeSecs": 60.0,
+              "transitionEnabled": false,
+              "transitionTimeSecs": 5.0,
+              "transitionBlendMode": 0,
+              "focusedPattern": 2,
+              "triggerPatternCycle": false
+            },
+            "children": {
+              "modulation": {
+                "id": 252547,
+                "class": "heronarts.lx.modulation.LXModulationEngine",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true
+                },
+                "parameters": {
+                  "label": "Modulation"
+                },
+                "children": {},
+                "modulators": [],
+                "modulations": [],
+                "triggers": []
+              }
+            },
+            "effects": [],
+            "clips": [],
+            "patternIndex": 2,
+            "patterns": [
+              {
+                "id": 252591,
+                "class": "titanicsend.pattern.justin.TESolidPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "TESolid",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.0,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.1,
+                  "te_freq": 0.1,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 0.0,
+                  "te_color/saturation": 0.0,
+                  "te_color/hue": 359.0,
+                  "te_color/solidSource": 0,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252592,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 252565,
+                "class": "titanicsend.pattern.jon.SpiralDiamonds",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "SpiralDiamonds",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 1.660493528272438,
+                  "te_xpos": 0.2933333199471235,
+                  "te_ypos": 0.21333332546055317,
+                  "te_size": 0.9999999908730386,
+                  "te_quantity": 4.0,
+                  "te_spin": 0.04551110695732974,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.0,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 0.20666665956377983,
+                  "te_freq": 0.13599999509751798,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252566,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              },
+              {
+                "id": 252578,
+                "class": "titanicsend.pattern.yoffa.config.ShaderPanelsPatternConfig$NeonCells",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "NeonCells",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "compositeMode": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "setDefaults": false,
+                  "te_speed": 0.5,
+                  "te_xpos": 0.0,
+                  "te_ypos": 0.0,
+                  "te_size": 1.5249999777879566,
+                  "te_quantity": 0.5,
+                  "te_spin": 0.0,
+                  "te_brightness": 1.0,
+                  "te_wow1": 0.1,
+                  "te_wow2": 0.0,
+                  "te_wowtrigger": false,
+                  "te_angle": 0.0,
+                  "te_level": 1.119999890960753,
+                  "te_freq": 0.9333333281800151,
+                  "te_twist": false,
+                  "panic": false,
+                  "te_color/brightness": 100.0,
+                  "te_color/saturation": 100.0,
+                  "te_color/hue": 0.0,
+                  "te_color/solidSource": 1,
+                  "te_color/blendMode": 0,
+                  "te_color/offset": 0.0,
+                  "width": 0.5
+                },
+                "children": {
+                  "modulation": {
+                    "id": 252579,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "remoteControls": [
+                  "/te_level",
+                  "/te_freq",
+                  "/view",
+                  "/te_speed",
+                  "/te_xpos",
+                  "/te_ypos",
+                  "/te_quantity",
+                  "/te_size",
+                  "/te_angle",
+                  "/te_spin",
+                  "/panic",
+                  null,
+                  "/te_wow1",
+                  "/te_wow2",
+                  "/te_wowtrigger",
+                  "/te_color/offset",
+                  "/setDefaults"
+                ],
+                "effects": [],
+                "defaults": {}
+              }
+            ]
+          }
+        ]
+      },
+      "modulation": {
+        "id": 97,
+        "class": "heronarts.lx.modulation.LXModulationEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Modulation"
+        },
+        "children": {},
+        "modulators": [
+          {
+            "id": 111303,
+            "class": "heronarts.lx.modulator.MacroSwitches",
+            "internal": {
+              "modulationColor": 1,
+              "modulationControlsExpanded": false,
+              "modulationsExpanded": true,
+              "showEight": false
+            },
+            "parameters": {
+              "label": "ALL DMX ON",
+              "running": true,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "macro1": false,
+              "macro2": false,
+              "macro3": false,
+              "macro4": false,
+              "macro5": false,
+              "macro6": false,
+              "macro7": false,
+              "macro8": false,
+              "label1": "DMXIN",
+              "label2": "-",
+              "label3": "-",
+              "label4": "-",
+              "label5": "-",
+              "label6": "-",
+              "label7": "-",
+              "label8": "-"
+            },
+            "children": {}
+          },
+          {
+            "id": 45092,
+            "class": "heronarts.lx.dmx.DmxModulator",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "DMX 1 Dimmer",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "universe": 31,
+              "channel": 99,
+              "mode": 0,
+              "min": 0,
+              "max": 255,
+              "rangeActive": false
+            },
+            "children": {}
+          },
+          {
+            "id": 45106,
+            "class": "titanicsend.modulator.dmx.DmxColorModulator",
+            "internal": {
+              "modulationColor": 1,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "DMX 2 Color 1",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "universe": 31,
+              "channel": 100,
+              "mode": 0,
+              "min": 0,
+              "max": 255,
+              "rangeActive": false,
+              "byteOrder": 0,
+              "colorPosition": 3
+            },
+            "children": {}
+          },
+          {
+            "id": 45107,
+            "class": "titanicsend.modulator.dmx.DmxColorModulator",
+            "internal": {
+              "modulationColor": 2,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "DMX 5 Color 2",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "universe": 31,
+              "channel": 103,
+              "mode": 0,
+              "min": 0,
+              "max": 255,
+              "rangeActive": false,
+              "byteOrder": 0,
+              "colorPosition": 4
+            },
+            "children": {}
+          },
+          {
+            "id": 45112,
+            "class": "titanicsend.modulator.dmx.DmxDualRangeModulator",
+            "internal": {
+              "modulationColor": 3,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "DMX 8 Strobe",
+              "running": false,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "universe": 31,
+              "channel": 106,
+              "mode": 0,
+              "min": 0,
+              "max": 255,
+              "rangeActive": false,
+              "isZero": true,
+              "range1active": false,
+              "range2active": false,
+              "output1": 0.0,
+              "output2": 0.0
+            },
+            "children": {}
+          },
+          {
+            "id": 195499,
+            "class": "heronarts.lx.modulator.VariableLFO",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LFO",
+              "running": true,
+              "trigger": false,
+              "midiFilter/enabled": true,
+              "midiFilter/channel": 16,
+              "midiFilter/minNote": 0,
+              "midiFilter/noteRange": 128,
+              "midiFilter/minVelocity": 1,
+              "midiFilter/velocityRange": 127,
+              "loop": true,
+              "tempoSync": false,
+              "tempoMultiplier": 5,
+              "tempoLock": true,
+              "clockMode": 0,
+              "periodFast": 13260.66564682978,
+              "periodSlow": 10000.0,
+              "wave": 0,
+              "skew": 0.0,
+              "shape": 0.0,
+              "bias": 0.0,
+              "phase": 0.0,
+              "exp": 0.0
+            },
+            "children": {},
+            "basis": 0.01204340433329053
+          }
+        ],
+        "modulations": [
+          {
+            "source": {
+              "id": 45092,
+              "path": "/modulation/modulator/2"
+            },
+            "target": {
+              "componentId": 128304,
+              "parameterPath": "brightness",
+              "path": "/mixer/master/effect/1/brightness"
+            },
+            "id": 128308,
+            "class": "heronarts.lx.modulation.LXCompoundModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "polarity": 0,
+              "range": 0.4781738272868097
+            },
+            "children": {}
+          }
+        ],
+        "triggers": [
+          {
+            "source": {
+              "componentId": 111303,
+              "parameterPath": "macro1",
+              "path": "/modulation/modulator/1/macro1"
+            },
+            "target": {
+              "componentId": 45092,
+              "parameterPath": "running",
+              "path": "/modulation/modulator/2/running"
+            },
+            "id": 111306,
+            "class": "heronarts.lx.modulation.LXTriggerModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "toggleMode": 0,
+              "momentaryToggleMode": 0,
+              "toggleMomentaryMode": 0
+            },
+            "children": {}
+          },
+          {
+            "source": {
+              "componentId": 111303,
+              "parameterPath": "macro1",
+              "path": "/modulation/modulator/1/macro1"
+            },
+            "target": {
+              "componentId": 45106,
+              "parameterPath": "running",
+              "path": "/modulation/modulator/3/running"
+            },
+            "id": 111307,
+            "class": "heronarts.lx.modulation.LXTriggerModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "toggleMode": 0,
+              "momentaryToggleMode": 0,
+              "toggleMomentaryMode": 0
+            },
+            "children": {}
+          },
+          {
+            "source": {
+              "componentId": 111303,
+              "parameterPath": "macro1",
+              "path": "/modulation/modulator/1/macro1"
+            },
+            "target": {
+              "componentId": 45107,
+              "parameterPath": "running",
+              "path": "/modulation/modulator/4/running"
+            },
+            "id": 111308,
+            "class": "heronarts.lx.modulation.LXTriggerModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "toggleMode": 0,
+              "momentaryToggleMode": 0,
+              "toggleMomentaryMode": 0
+            },
+            "children": {}
+          },
+          {
+            "source": {
+              "componentId": 111303,
+              "parameterPath": "macro1",
+              "path": "/modulation/modulator/1/macro1"
+            },
+            "target": {
+              "componentId": 45112,
+              "parameterPath": "running",
+              "path": "/modulation/modulator/5/running"
+            },
+            "id": 111309,
+            "class": "heronarts.lx.modulation.LXTriggerModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "toggleMode": 0,
+              "momentaryToggleMode": 0,
+              "toggleMomentaryMode": 0
+            },
+            "children": {}
+          },
+          {
+            "source": {
+              "componentId": 45092,
+              "parameterPath": "running",
+              "path": "/modulation/modulator/2/running"
+            },
+            "target": {
+              "componentId": 128304,
+              "parameterPath": "enabled",
+              "path": "/mixer/master/effect/1/enabled"
+            },
+            "id": 128307,
+            "class": "heronarts.lx.modulation.LXTriggerModulation",
+            "internal": {
+              "modulationColor": 0,
+              "modulationControlsExpanded": true,
+              "modulationsExpanded": true
+            },
+            "parameters": {
+              "label": "LX",
+              "enabled": true,
+              "toggleMode": 0,
+              "momentaryToggleMode": 0,
+              "toggleMomentaryMode": 0
+            },
+            "children": {}
+          }
+        ]
+      },
+      "output": {
+        "id": 98,
+        "class": "heronarts.lx.LXEngine$Output",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Output",
+          "enabled": false,
+          "brightness": 1.0,
+          "fps": 0.0,
+          "gamma": 1.0,
+          "gammaMode": 1,
+          "whitePointRed": 255,
+          "whitePointGreen": 255,
+          "whitePointBlue": 255,
+          "whitePointWhite": 255
+        },
+        "children": {}
+      },
+      "snapshots": {
+        "id": 100,
+        "class": "heronarts.lx.snapshot.LXSnapshotEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Snapshots",
+          "recallMixer": true,
+          "recallModulation": true,
+          "recallPattern": true,
+          "recallEffect": true,
+          "recallMaster": true,
+          "recallOutput": true,
+          "channelMode": 0,
+          "missingChannelMode": 0,
+          "transitionEnabled": false,
+          "transitionTimeSecs": 5.0,
+          "autoCycleEnabled": false,
+          "autoCycleMode": 0,
+          "autoCycleTimeSecs": 60.0,
+          "autoCycleCursor": -1,
+          "triggerSnapshotCycle": false
+        },
+        "children": {},
+        "snapshots": []
+      },
+      "dmx": {
+        "id": 101,
+        "class": "heronarts.lx.dmx.LXDmxEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "artNetReceivePort": 6454,
+          "artNetReceiveActive": true
+        },
+        "children": {}
+      },
+      "midi": {
+        "id": 102,
+        "class": "heronarts.lx.midi.LXMidiEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "LX",
+          "computerKeyboardEnabled": false,
+          "computerKeyboardOctave": 5,
+          "computerKeyboardVelocity": 5
+        },
+        "children": {},
+        "inputs": [
+          {
+            "name": "FoH: APC40 mkII",
+            "channel": false,
+            "control": true,
+            "sync": false
+          },
+          {
+            "name": "FoH: Midi Fighter Twister",
+            "channel": false,
+            "control": false,
+            "sync": false
+          },
+          {
+            "name": "FoH: Midi Fighter Twister (2)",
+            "channel": false,
+            "control": false,
+            "sync": false
+          },
+          {
+            "name": "FoH: Midi Fighter 64",
+            "channel": true,
+            "control": true,
+            "sync": false
+          }
+        ],
+        "surfaces": [
+          {
+            "name": "FoH: APC40 mkII",
+            "settings": {
+              "masterFaderEnabled": true,
+              "crossfaderEnabled": true,
+              "deviceControl": false,
+              "performanceLock": true
+            }
+          },
+          {
+            "name": "FoH: Midi Fighter Twister",
+            "settings": {
+              "knobClickMode": 0,
+              "focusMode": 0,
+              "isAux": false,
+              "currentBank": 0
+            }
+          },
+          {
+            "name": "FoH: Midi Fighter Twister (2)",
+            "settings": {
+              "knobClickMode": 0,
+              "focusMode": 0,
+              "isAux": true,
+              "currentBank": 0
+            }
+          }
+        ],
+        "mapping": [
+          {
+            "channel": 0,
+            "type": "CONTROL_CHANGE",
+            "path": "/lx/audio/modulator/1/gain",
+            "componentId": 86,
+            "parameterPath": "gain",
+            "cc": 16,
+            "minValue": -48.0,
+            "maxValue": 48.0
+          },
+          {
+            "channel": 0,
+            "type": "CONTROL_CHANGE",
+            "path": "/lx/audio/modulator/1/release",
+            "componentId": 86,
+            "parameterPath": "release",
+            "cc": 17,
+            "minValue": 0.0,
+            "maxValue": 1000.0
+          }
+        ]
+      },
+      "osc": {
+        "id": 103,
+        "class": "heronarts.lx.osc.LXOscEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "OSC",
+          "receiveHost": "0.0.0.0",
+          "receivePort": 3030,
+          "receiveActive": true,
+          "transmitHost": "127.0.0.1",
+          "transmitPort": 7892,
+          "transmitActive": true,
+          "logInput": false,
+          "logOutput": false
+        },
+        "children": {}
+      },
+      "virtualOverlays": {
+        "id": 104,
+        "class": "titanicsend.app.TEVirtualOverlays",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "TEVirtualOverlays",
+          "vertexSpheresVisible": false,
+          "vertexLabelsVisible": false,
+          "panelLabelsVisible": false,
+          "unknownPanelsVisible": true,
+          "opaqueBackPanelsVisible": true,
+          "backingOpacity": 1.0,
+          "powerBoxesVisible": false,
+          "lasersVisible": false
+        },
+        "children": {}
+      },
+      "globalPatternControls": {
+        "id": 105,
+        "class": "titanicsend.app.TEGlobalPatternControls",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "TEGlobalPatternControls"
+        },
+        "children": {}
+      },
+      "NDIEngine": {
+        "id": 108,
+        "class": "titanicsend.ndi.NDIEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "NDIEngine"
+        },
+        "children": {}
+      },
+      "GLEngine": {
+        "id": 109,
+        "class": "titanicsend.pattern.glengine.GLEngine",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "GLEngine"
+        },
+        "children": {}
+      },
+      "audioStems": {
+        "id": 156,
+        "class": "titanicsend.audio.AudioStems",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "audioStems",
+          "gain": 0.0
+        },
+        "children": {}
+      },
+      "paletteManagerA": {
+        "id": 157,
+        "class": "titanicsend.color.ColorPaletteManager",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "Color Palette Manager",
+          "hue": 0.0,
+          "saturation": 100.0,
+          "brightness": 100.0,
+          "paletteStrategy": 0,
+          "color1/brightness": 100.0,
+          "color1/saturation": 100.0,
+          "color1/hue": 0.0,
+          "color2/brightness": 100.0,
+          "color2/saturation": 100.0,
+          "color2/hue": 0.0,
+          "color3/brightness": 100.0,
+          "color3/saturation": 100.0,
+          "color3/hue": 0.0,
+          "pushSwatch": false,
+          "pinSwatch": false
+        },
+        "children": {}
+      },
+      "focus": {
+        "id": 172,
+        "class": "titanicsend.osc.CrutchOSC",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "CrutchOSC"
+        },
+        "children": {}
+      },
+      "director": {
+        "id": 173,
+        "class": "titanicsend.app.director.Director",
+        "internal": {
+          "modulationColor": 0,
+          "modulationControlsExpanded": true,
+          "modulationsExpanded": true
+        },
+        "parameters": {
+          "label": "director",
+          "te": 1.0,
+          "panels": 1.0,
+          "edges": 1.0,
+          "foh": 1.0,
+          "lasers": 1.0,
+          "beacons": 1.0,
+          "master": 1.0
+        },
+        "children": {}
+      }
+    }
+  },
+  "externals": {
+    "ui": {
+      "leftPaneActiveSection": 2,
+      "audioExpanded": true,
+      "envelopExpanded": true,
+      "reaperExpanded": true,
+      "paletteExpanded": true,
+      "cameraExpanded": true,
+      "mixerCentered": false,
+      "fixtureInspectorExpanded": true,
+      "viewsExpanded": true,
+      "soundStageExpanded": true,
+      "preview": {
+        "animation": false,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 1.0,
+        "camera": {
+          "active": false,
+          "radius": 748.0485913539053,
+          "theta": 351.6190745399799,
+          "phi": 5.072981901001185,
+          "x": 17.563656642334536,
+          "y": 222.75736218248494,
+          "z": 125.00981016363949
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 748.0485913539053,
+            "theta": 351.6190745399799,
+            "phi": 5.072981901001185,
+            "x": 17.563656642334536,
+            "y": 222.75736218248494,
+            "z": 125.00981016363949
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 0,
+          "pointSize": 3.0,
+          "alphaRef": 8,
+          "feather": 0.5,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 45.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": false
+        }
+      },
+      "previewAux": {
+        "animation": false,
+        "animationTime": 1000.0,
+        "projection": 0,
+        "perspective": 60.0,
+        "depth": 2.0,
+        "camera": {
+          "active": false,
+          "radius": 120.0,
+          "theta": 270.0,
+          "phi": -6.0,
+          "x": 0.0,
+          "y": 229.6736297607422,
+          "z": -0.00849151611328125
+        },
+        "cue": [
+          {
+            "active": false,
+            "radius": 1.771279523645438E7,
+            "theta": 270.0,
+            "phi": -6.0,
+            "x": -505275.51171875,
+            "y": 4807375.3623046875,
+            "z": 759096.1650390625
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          },
+          {
+            "active": false,
+            "radius": 120.0,
+            "theta": 0.0,
+            "phi": 0.0,
+            "x": 0.0,
+            "y": 0.0,
+            "z": 0.0
+          }
+        ],
+        "focus": 0,
+        "pointCloud": {
+          "ledStyle": 0,
+          "pointSize": 80000.0,
+          "alphaRef": 8,
+          "feather": 0.5,
+          "sparkle": 1.0,
+          "sparkleCurve": 2.0,
+          "sparkleRotate": 45.0,
+          "contrast": 1.0,
+          "depthTest": true,
+          "useCustomParams": false
+        },
+        "grid": {
+          "visible": false,
+          "spacing": 100.0,
+          "size": 10,
+          "plane": 0,
+          "planes": 1,
+          "x": 0.0,
+          "y": 0.0,
+          "z": 0.0,
+          "neg1": false,
+          "neg2": false
+        },
+        "axes": {
+          "visible": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new project which has a template set of channels for the bootup sequence.

The bootup sequence is using 2 extra channels now: 1. BOOTUP-NDI 2. BOOTUP

This is to allow us to fade between the NDI and the shader patterns during the bootup sequence.