### PR TITLE
Beacons: tilt limit, flight-style joystick

### DIFF
--- a/Fixtures/Beacons/Beacon1.lxf
+++ b/Fixtures/Beacons/Beacon1.lxf
@@ -5,7 +5,7 @@
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",
     "dmx_host": "10.128.102.221",
-    "tiltLimit": "95"
+    "tiltLimit": ".37"
   },
 
   "components": [

--- a/Fixtures/Beacons/Beacon2.lxf
+++ b/Fixtures/Beacons/Beacon2.lxf
@@ -5,7 +5,7 @@
   "meta": {
     "dmx": "titanicsend.dmx.model.BeaconModel",
     "dmx_host": "10.128.105.37",
-    "tiltLimit": "95"
+    "tiltLimit": ".37"
   },
 
   "components": [

--- a/src/main/java/titanicsend/dmx/model/BeaconModel.java
+++ b/src/main/java/titanicsend/dmx/model/BeaconModel.java
@@ -2,6 +2,7 @@ package titanicsend.dmx.model;
 
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
+import heronarts.lx.utils.LXUtils;
 import titanicsend.dmx.DmxBuffer;
 import titanicsend.dmx.parameter.DmxCompoundParameter;
 import titanicsend.dmx.parameter.DmxDiscreteParameter;
@@ -90,14 +91,12 @@ public class BeaconModel extends DmxModel {
 
   private void initialize(float tiltLimit){
     DmxCompoundParameter pan = new DmxCompoundParameter("Pan").setNumBytes(2);
-/*
-    DmxCompoundParameter tilt =
-      new DmxCompoundParameter("Tilt", 0, TILT_MIN, TILT_MAX).setNumBytes(2);
-*/
     DmxCompoundParameter tilt =
       new DmxCompoundParameter("Tilt", .5, 0, 1).setNumBytes(2);
     // Apply tilt limit from config file to beacon
-    //tilt.getLimiter().setLimits(0 - tiltLimit, tiltLimit).setLimitType(LimitType.ZOOM);
+    tilt.getLimiter()
+      .setLimits(.5 - LXUtils.max(0,tiltLimit / 2), Math.min(1, .5 + (tiltLimit / 2)))
+      .setLimitType(LimitType.ZOOM);
     DmxCompoundParameter cyan = new DmxCompoundParameter("Cyan", 0, 0, 100);
     DmxCompoundParameter magenta = new DmxCompoundParameter("Magenta", 0, 0, 100);
     DmxCompoundParameter yellow = new DmxCompoundParameter("Yellow", 0, 0, 100);

--- a/src/main/java/titanicsend/dmx/pattern/BeaconPattern.java
+++ b/src/main/java/titanicsend/dmx/pattern/BeaconPattern.java
@@ -16,6 +16,7 @@
 package titanicsend.dmx.pattern;
 
 import heronarts.lx.LX;
+import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.studio.TEApp;
 import titanicsend.dmx.model.BeaconModel;
 import titanicsend.dmx.parameter.DmxCompoundParameter;
@@ -27,6 +28,10 @@ public abstract class BeaconPattern extends DmxPattern {
 
   protected final TEWholeModel modelTE;
 
+  public static final double BEACON_BAY_TILT = 22.5;
+  public static final double BEACON_TILT_RANGE = 120;
+  public static final double BEACON_TILT_DEFAULT_NORMALIZED = 0.5 + (BEACON_BAY_TILT / BEACON_TILT_RANGE);
+
   public final int[] gobo1CycleValues = new int[] {0,22,32,42,52,62,72,82,92};
   public final int[] gobo2CycleValues = new int[] {0,5,10,15,20,25,30,35,40,45,50,55,60,65,70,75,80,85};
   public final int[] clrWheelCycleValues = new int[] {0,16,23,30,37,44,51,58,65,79,86,93,100,107,114};
@@ -34,14 +39,14 @@ public abstract class BeaconPattern extends DmxPattern {
   // Don't mind this code duplication with the model class.
   // It's just a coincidence.
 
-  DmxCompoundParameter pan = new DmxCompoundParameter("Pan").setNumBytes(2);
-/*
+  DmxCompoundParameter pan = (DmxCompoundParameter)
+    new DmxCompoundParameter("Pan", .5, 0, 1)
+    .setNumBytes(2)
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
   DmxCompoundParameter tilt =
-      new DmxCompoundParameter("Tilt", BeaconModel.TILT_MIN, BeaconModel.TILT_MIN, BeaconModel.TILT_MAX)
-          .setNumBytes(2);
-*/
-  DmxCompoundParameter tilt =
-    new DmxCompoundParameter("Tilt", .5, 0, 1).setNumBytes(2);
+    (DmxCompoundParameter) new DmxCompoundParameter("Tilt", BEACON_TILT_DEFAULT_NORMALIZED, 0, 1)
+    .setNumBytes(2)
+    .setPolarity(LXParameter.Polarity.BIPOLAR);
   DmxCompoundParameter cyan = new DmxCompoundParameter("Cyan", 0, 0, 100);
   DmxCompoundParameter magenta = new DmxCompoundParameter("Magenta", 0, 0, 100);
   DmxCompoundParameter yellow = new DmxCompoundParameter("Yellow", 0, 0, 100);


### PR DESCRIPTION
Per feedback from George:

- Added tilt limiter so we can't hit the ground
- Default position is 22.5 degrees up to compensate for bay angle (unless I got it backwards)
- Changed joysticks from absolute position to acceleration, aka FPS/flight style
- Pan/tilt are both on left joystick
- Position will be held when joystick is release
- Clicking left joystick resets position
- Left trigger increases pan/tilt acceleration aka jerk

Right joystick is now unassigned.  Out of time to work on it further.