### PR TITLE
Location texture caching for 3D branch

### DIFF
--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -119,7 +119,18 @@ vec4 _blendFix(vec4 col) {
 }
 
 void main() {
-    vec2 coords = _getModelCoordinates().xy * iResolution;
+    vec2 coords = _getModelCoordinates().xy;
+    // NaN value signals the end of valid coordinates
+    // We can use this to avoid doing work for points that
+    // are not part of the current view.
+    if (isnan(coords.r)) {
+        finalColor = vec4(0.0);
+        return;
+    }
+
+    // Scale the coordinates to the resolution specified by Chromatik
+    // (which can be changed via the --resolution command line option)
+    coords *= iResolution;
 
     // translate according to XPos and YPos controls unless explicitly overriden
     #ifndef TE_NOTRANSLATE

--- a/src/main/java/titanicsend/pattern/glengine/GLEngine.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEngine.java
@@ -57,20 +57,8 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
   private final GraphicMeter meter;
   private final float fftResampleFactor;
 
-  // texture unit management
-  private class TextureUnit {
-    private Texture texture;
-    private int textureUnit;
-    private int refCount;
-  }
-
-  private int nextTextureUnit = 3;
-
-  // staticTextures is a map of texture names to texture unit numbers.
-  private final HashMap<String, TextureUnit> staticTextures = new HashMap<>();
-
-  // a list of that we can use to keep track of released texture unit numbers
-  private final ArrayList<Integer> releasedTextureUnits = new ArrayList<>();
+  // Texture cache management
+  private TextureManager textureCache = new TextureManager();
 
   private boolean isRunning = false;
 
@@ -79,6 +67,7 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
   private GL4 gl4;
 
   private LXModel model;
+
   public LXModel getModel() {
     return model;
   }
@@ -105,7 +94,9 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
     return ySize;
   }
 
-  public float getAspectRatio() { return aspectRatio; }
+  public float getAspectRatio() {
+    return aspectRatio;
+  }
 
   public static int getMappedBufferWidth() {
     return mappedBufferWidth;
@@ -129,75 +120,32 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
     return audioTextureHeight;
   }
 
-  // Returns the next available texture unit number, either by reusing a released
-  // texture unit number or by allocating a new one.
-  public int getNextTextureUnit() {
-    if (releasedTextureUnits.size() > 0) {
-      return releasedTextureUnits.remove(0);
-    } else {
-      return nextTextureUnit++;
-    }
+  // Create a coordinate texture from the normalized coordinates of the given model
+  // and bind it to the next available texture unit.  If the view's coordinate texture
+  // already exists,return the bound texture unit number.
+  public Texture createCoordinateTexture(GL4 gl4, LXModel model) {
+    return textureCache.createCoordinateTexture(gl4, model);
   }
 
-  public int releaseTextureUnit(int textureUnit) {
-    if (textureUnit < 3) {
-      throw new RuntimeException("GLEngine: Attempt to release a reserved texture unit: " + textureUnit);
-    }
-    if (releasedTextureUnits.contains(textureUnit)) {
-      throw new RuntimeException("GLEngine: Attempt to release a texture unit that is already released: " + textureUnit);
-    }
-    releasedTextureUnits.add(textureUnit);
-    return textureUnit;
-  }
-
-  // Add a released (ref count 0) texture unit number to the list of available
-  // texture units
-  private void recycleTextureUnit(TextureUnit t) {
-    if (!releasedTextureUnits.contains(t.textureUnit)) {
-      releasedTextureUnits.add(t.textureUnit);
-    }
-  }
-
+  // Load a static texture from a file and bind it to the next available texture unit
+  // Returns the texture unit number. If the texture is already loaded, just increment
+  // the ref count and return the existing texture unit number.
   public int useTexture(GL4 gl4, String textureName) {
-    TextureUnit t = new TextureUnit();
-
-    try {
-      // if the texture is already loaded, just increment the ref count
-      if (staticTextures.containsKey(textureName)) {
-        t = staticTextures.get(textureName);
-        t.refCount++;
-      } else {
-        // otherwise, load the texture its file and bind it to the next available texture unit
-        File file = new File(textureName);
-        t.texture = TextureIO.newTexture(file, false);
-        t.textureUnit = getNextTextureUnit();
-        t.refCount = 1;
-        staticTextures.put(textureName, t);
-
-        gl4.glActiveTexture(GL_TEXTURE0 + t.textureUnit);
-        gl4.glEnable(GL_TEXTURE_2D);
-        t.texture.enable(gl4);
-        t.texture.bind(gl4);
-      }
-      // return the texture unit number
-      return t.textureUnit;
-
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    return textureCache.useTexture(gl4, textureName);
   }
 
   public void releaseTexture(String textureName) {
-    TextureUnit t = staticTextures.get(textureName);
-    if (t == null) {
-      throw new RuntimeException("Attempt to release texture that was never used: " + textureName);
-    }
-    t.refCount--;
-    if (t.refCount <= 0) {
-      t.texture.destroy(gl4);
-      recycleTextureUnit(t);
-      staticTextures.remove(textureName);
-    }
+    textureCache.releaseTexture(textureName);
+  }
+
+  // Returns the next available texture unit number, either by reusing a released
+  // texture unit number or by allocating a new one.
+  public int getNextTextureUnit() {
+    return textureCache.getNextTextureUnit();
+  }
+
+  public int releaseTextureUnit(int textureUnit) {
+    return textureCache.releaseTextureUnit(textureUnit);
   }
 
   /**
@@ -245,7 +193,9 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
     gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   }
 
-  /** Update audio texture object with new fft and waveform data. This is called once per frame. */
+  /**
+   * Update audio texture object with new fft and waveform data. This is called once per frame.
+   */
   private void updateAudioTexture() {
     // load frequency and waveform data into our texture buffer, fft data
     // in the first row, normalized audio waveform data in the second.
@@ -259,18 +209,18 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
     gl4.glBindTexture(GL_TEXTURE_2D, audioTextureHandle[0]);
 
     gl4.glTexImage2D(
-        GL4.GL_TEXTURE_2D,
-        0,
-        GL4.GL_R32F,
-        audioTextureWidth,
-        audioTextureHeight,
-        0,
-        GL4.GL_RED,
-        GL_FLOAT,
-        audioTextureData);
+      GL4.GL_TEXTURE_2D,
+      0,
+      GL4.GL_R32F,
+      audioTextureWidth,
+      audioTextureHeight,
+      0,
+      GL4.GL_RED,
+      GL_FLOAT,
+      audioTextureData);
   }
 
-  public GLEngine(LX lx, int width, int height,  boolean isStaticModel) {
+  public GLEngine(LX lx, int width, int height, boolean isStaticModel) {
     current = this;
     // The shape the user gives us affects the rendered aspect ratio,
     // but what really matters is that it needs to have room for the
@@ -304,10 +254,9 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
   @Override
   public void modelGenerationChanged(LX lx, LXModel model) {
     this.model = model;
-    // modelChanged = true;
+    // when the model changes, discard all existing view coordinate textures
+    textureCache.clearCoordinateTextures();
   }
-
- // private boolean modelChanged = true;
 
   public void loop(double deltaMs) {
 
@@ -329,7 +278,6 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
 
     // On every frame, after initial setup
     if (isRunning) {
-
       // activate our context and do per-frame tasks
       canvas.getContext().makeCurrent();
       updateAudioTexture();
@@ -337,7 +285,11 @@ public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
   }
 
   public void dispose() {
-    // free GPU resources we directly allocated
+    // free all view coordinate textures (static textures in the cache
+    // will be automatically freed when their associated shaders unload
+    textureCache.clearCoordinateTextures();
+
+    // free other GPU resources that we directly allocated
     gl4.glDeleteTextures(audioTextureHandle.length, audioTextureHandle, 0);
   }
 }

--- a/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -717,10 +717,6 @@ public class GLShader {
             break;
           case SAMPLER2DSTATIC:
           case SAMPLER2D:
-            // TODO - does this really work if you call it every frame?
-            // TODO - (probably, but it might be slow. And
-            // TODO - we need to be sure we're generating a unique name
-            // TODO - per pattern instance.)
             Texture tex = ((Texture) val.value);
             int unit = getTextureUnit(name);
             gl4.glActiveTexture(GL_TEXTURE0 + unit);

--- a/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -12,6 +12,7 @@ import com.jogamp.opengl.util.texture.Texture;
 import heronarts.lx.LX;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.parameter.LXParameter;
+
 import java.io.File;
 import java.nio.*;
 import java.util.*;
@@ -115,14 +116,14 @@ public class GLShader {
   /**
    * Create new OpenGL shader effect
    *
-   * @param lx LX instance
+   * @param lx             LX instance
    * @param fragmentShader fragment shader object to use
-   * @param frameBuf native (GL compatible) ByteBuffer to store render results for use in shaders
-   *     that need to read the previous frame. If null, a buffer will be automatically allocated.
-   * @param controlData control data object to be associated w/this shader
+   * @param frameBuf       native (GL compatible) ByteBuffer to store render results for use in shaders
+   *                       that need to read the previous frame. If null, a buffer will be automatically allocated.
+   * @param controlData    control data object to be associated w/this shader
    */
   public GLShader(
-      LX lx, FragmentShader fragmentShader, ByteBuffer frameBuf, GLControlData controlData) {
+    LX lx, FragmentShader fragmentShader, ByteBuffer frameBuf, GLControlData controlData) {
     this.controlData = controlData;
     this.backBuffer = frameBuf;
 
@@ -143,9 +144,9 @@ public class GLShader {
   /**
    * Create new shader object with default backbuffer
    *
-   * @param lx LX instance
+   * @param lx             LX instance
    * @param fragmentShader fragment shader object shader to use
-   * @param controlData control data object to be associated w/this shader
+   * @param controlData    control data object to be associated w/this shader
    */
   public GLShader(LX lx, FragmentShader fragmentShader, GLControlData controlData) {
     this(lx, fragmentShader, null, controlData);
@@ -154,40 +155,40 @@ public class GLShader {
   /**
    * Creates new shader object with additional texture support
    *
-   * @param lx LX instance
-   * @param shaderFilename shader to use
-   * @param frameBuf native (GL compatible) ByteBuffer to store render results for use in shaders
-   *     that need to read the previous frame. If null, a buffer will be automatically allocated. *
-   * @param controlData control data object to be associated w/this shader
+   * @param lx               LX instance
+   * @param shaderFilename   shader to use
+   * @param frameBuf         native (GL compatible) ByteBuffer to store render results for use in shaders
+   *                         that need to read the previous frame. If null, a buffer will be automatically allocated. *
+   * @param controlData      control data object to be associated w/this shader
    * @param textureFilenames (optional) texture files to load
    */
   public GLShader(
-      LX lx,
-      String shaderFilename,
-      GLControlData controlData,
-      ByteBuffer frameBuf,
-      String... textureFilenames) {
+    LX lx,
+    String shaderFilename,
+    GLControlData controlData,
+    ByteBuffer frameBuf,
+    String... textureFilenames) {
     this(
-        lx,
-        new FragmentShader(
-            new File("resources/shaders/" + shaderFilename),
-            Arrays.stream(textureFilenames)
-                .map(x -> new File("resources/shaders/textures/" + x))
-                .collect(Collectors.toList())),
-        frameBuf,
-        controlData);
+      lx,
+      new FragmentShader(
+        new File("resources/shaders/" + shaderFilename),
+        Arrays.stream(textureFilenames)
+          .map(x -> new File("resources/shaders/textures/" + x))
+          .collect(Collectors.toList())),
+      frameBuf,
+      controlData);
   }
 
   /**
    * Creates new shader object with additional texture support
    *
-   * @param lx LX instance
-   * @param shaderFilename shader to use
-   * @param controlData control data object to be associated w/this shader
+   * @param lx               LX instance
+   * @param shaderFilename   shader to use
+   * @param controlData      control data object to be associated w/this shader
    * @param textureFilenames (optional) texture files to load
    */
   public GLShader(
-      LX lx, String shaderFilename, GLControlData controlData, String... textureFilenames) {
+    LX lx, String shaderFilename, GLControlData controlData, String... textureFilenames) {
     this(lx, shaderFilename, controlData, null, textureFilenames);
   }
 
@@ -229,7 +230,9 @@ public class GLShader {
     this.useMappedBuffer = true;
   }
 
-  /** Activate this shader for rendering in the current context */
+  /**
+   * Activate this shader for rendering in the current context
+   */
   public void useProgram() {
     gl4.glUseProgram(shaderProgram.getProgramId());
   }
@@ -306,11 +309,11 @@ public class GLShader {
 
     if (numPoints > maxPoints) {
       LX.error(
-          "GLEngine resolution ("
-              + maxPoints
-              + ") too small for number of points in the model ("
-              + numPoints
-              + ")");
+        "GLEngine resolution ("
+          + maxPoints
+          + ") too small for number of points in the model ("
+          + numPoints
+          + ")");
     }
   }
 
@@ -369,19 +372,19 @@ public class GLShader {
     vertexBuffer.rewind();
     gl4.glBindBuffer(GL_ARRAY_BUFFER, geometryBufferHandles[0]);
     gl4.glBufferData(
-        GL_ARRAY_BUFFER,
-        (long) vertexBuffer.capacity() * Float.BYTES,
-        vertexBuffer,
-        GL.GL_STATIC_DRAW);
+      GL_ARRAY_BUFFER,
+      (long) vertexBuffer.capacity() * Float.BYTES,
+      vertexBuffer,
+      GL.GL_STATIC_DRAW);
 
     // geometry (triangles built from vertices)
     indexBuffer.rewind();
     gl4.glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, geometryBufferHandles[1]);
     gl4.glBufferData(
-        GL_ELEMENT_ARRAY_BUFFER,
-        (long) indexBuffer.capacity() * Integer.BYTES,
-        indexBuffer,
-        GL.GL_STATIC_DRAW);
+      GL_ELEMENT_ARRAY_BUFFER,
+      (long) indexBuffer.capacity() * Integer.BYTES,
+      indexBuffer,
+      GL.GL_STATIC_DRAW);
 
     // initialize location texture object
     gl4.glActiveTexture(GL_TEXTURE1);
@@ -427,7 +430,9 @@ public class GLShader {
     }
   }
 
-  /** Set up geometry at frame generation time */
+  /**
+   * Set up geometry at frame generation time
+   */
   private void render() {
     // set uniforms
     setUniforms();
@@ -471,15 +476,15 @@ public class GLShader {
     gl4.glActiveTexture(GL_TEXTURE1);
     gl4.glBindTexture(GL_TEXTURE_2D, modelCoordsHandle[0]);
     gl4.glTexImage2D(
-        GL4.GL_TEXTURE_2D,
-        0,
-        GL4.GL_RGB32F,
-        xResolution,
-        yResolution,
-        0,
-        GL4.GL_RGB,
-        GL_FLOAT,
-        modelCoords);
+      GL4.GL_TEXTURE_2D,
+      0,
+      GL4.GL_RGB32F,
+      xResolution,
+      yResolution,
+      0,
+      GL4.GL_RGB,
+      GL_FLOAT,
+      modelCoords);
 
     setUniform("lxModelCoords", 1);
 
@@ -490,15 +495,15 @@ public class GLShader {
     gl4.glBindTexture(GL4.GL_TEXTURE_2D, backbufferHandle[0]);
 
     gl4.glTexImage2D(
-        GL4.GL_TEXTURE_2D,
-        0,
-        GL4.GL_RGBA,
-        xResolution,
-        yResolution,
-        0,
-        GL4.GL_BGRA,
-        GL_UNSIGNED_BYTE,
-        backBuffer);
+      GL4.GL_TEXTURE_2D,
+      0,
+      GL4.GL_RGBA,
+      xResolution,
+      yResolution,
+      0,
+      GL4.GL_BGRA,
+      GL_UNSIGNED_BYTE,
+      backBuffer);
 
     setUniform("iBackbuffer", 2);
 
@@ -509,15 +514,15 @@ public class GLShader {
       gl4.glBindTexture(GL4.GL_TEXTURE_2D, mappedBufferHandle[0]);
 
       gl4.glTexImage2D(
-          GL4.GL_TEXTURE_2D,
-          0,
-          GL4.GL_RGBA,
-          mappedBufferWidth,
-          mappedBufferHeight,
-          0,
-          GL4.GL_BGRA,
-          GL_UNSIGNED_BYTE,
-          mappedBuffer);
+        GL4.GL_TEXTURE_2D,
+        0,
+        GL4.GL_RGBA,
+        mappedBufferWidth,
+        mappedBufferHeight,
+        0,
+        GL4.GL_BGRA,
+        GL_UNSIGNED_BYTE,
+        mappedBuffer);
 
       setUniform("iMappedBuffer", mappedBufferUnit);
     }
@@ -541,14 +546,14 @@ public class GLShader {
 
   private void loadTextureFiles(GL4 gl4, FragmentShader fragmentShader) {
     for (Map.Entry<Integer, String> textureInput :
-        fragmentShader.getChannelToTexture().entrySet()) {
+      fragmentShader.getChannelToTexture().entrySet()) {
 
       TextureInfo ti = new TextureInfo();
       ti.textureUnit = glEngine.useTexture(gl4, textureInput.getValue());
       ti.name = textureInput.getValue();
       ti.channel = textureInput.getKey();
       ti.uniformLocation =
-          gl4.glGetUniformLocation(shaderProgram.getProgramId(), "iChannel" + ti.channel);
+        gl4.glGetUniformLocation(shaderProgram.getProgramId(), "iChannel" + ti.channel);
 
       textures.add(ti);
     }
@@ -733,52 +738,68 @@ public class GLShader {
     }
   }
 
-  /** setter -- single int */
+  /**
+   * setter -- single int
+   */
   public void setUniform(String name, int x) {
-    addUniform(name, INT1, new int[] {x});
+    addUniform(name, INT1, new int[]{x});
   }
 
-  /** 2 element int array or ivec2 */
+  /**
+   * 2 element int array or ivec2
+   */
   public void setUniform(String name, int x, int y) {
-    addUniform(name, INT2, new int[] {x, y});
+    addUniform(name, INT2, new int[]{x, y});
   }
 
-  /** 3 element int array or ivec3 */
+  /**
+   * 3 element int array or ivec3
+   */
   public void setUniform(String name, int x, int y, int z) {
-    addUniform(name, INT3, new int[] {x, y, z});
+    addUniform(name, INT3, new int[]{x, y, z});
   }
 
-  /** 4 element int array or ivec4 */
+  /**
+   * 4 element int array or ivec4
+   */
   public void setUniform(String name, int x, int y, int z, int w) {
-    addUniform(name, UniformTypes.INT4, new int[] {x, y, z, w});
+    addUniform(name, UniformTypes.INT4, new int[]{x, y, z, w});
   }
 
-  /** single float */
+  /**
+   * single float
+   */
   public void setUniform(String name, float x) {
-    addUniform(name, UniformTypes.FLOAT1, new float[] {x});
+    addUniform(name, UniformTypes.FLOAT1, new float[]{x});
   }
 
-  /** 2 element float array or vec2 */
+  /**
+   * 2 element float array or vec2
+   */
   public void setUniform(String name, float x, float y) {
-    addUniform(name, UniformTypes.FLOAT2, new float[] {x, y});
+    addUniform(name, UniformTypes.FLOAT2, new float[]{x, y});
   }
 
-  /** 3 element float array or vec3 */
+  /**
+   * 3 element float array or vec3
+   */
   public void setUniform(String name, float x, float y, float z) {
-    addUniform(name, UniformTypes.FLOAT3, new float[] {x, y, z});
+    addUniform(name, UniformTypes.FLOAT3, new float[]{x, y, z});
   }
 
-  /** 4 element float array or vec4 */
+  /**
+   * 4 element float array or vec4
+   */
   public void setUniform(String name, float x, float y, float z, float w) {
-    addUniform(name, UniformTypes.FLOAT4, new float[] {x, y, z, w});
+    addUniform(name, UniformTypes.FLOAT4, new float[]{x, y, z, w});
   }
 
   public void setUniform(String name, boolean x) {
-    addUniform(name, INT1, new int[] {(x) ? 1 : 0});
+    addUniform(name, INT1, new int[]{(x) ? 1 : 0});
   }
 
   public void setUniform(String name, boolean x, boolean y) {
-    addUniform(name, INT2, new int[] {(x) ? 1 : 0, (y) ? 1 : 0});
+    addUniform(name, INT2, new int[]{(x) ? 1 : 0, (y) ? 1 : 0});
   }
 
   /**
@@ -847,8 +868,8 @@ public class GLShader {
    * Internal - Creates a uniform for a square floating point matrix, of size 2x2, 3x3 or 4x4
    *
    * @param name of uniform
-   * @param vec Floating point matrix data, in row major order
-   * @param sz Size of matrix (Number of rows & columns. 2,3 or 4)
+   * @param vec  Floating point matrix data, in row major order
+   * @param sz   Size of matrix (Number of rows & columns. 2,3 or 4)
    */
   public void setUniformMatrix(String name, FloatBuffer vec, int sz) {
     switch (sz) {

--- a/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -93,34 +93,23 @@ public class GLShaderEffect extends TEEffect {
     return iTime.getTime();
   }
 
-  LXModel lastModel = null;
-
   protected void run(double deltaMs, double enabledAmount) {
     LXModel m = getModel();
     ShaderInfo s;
     this.deltaMs = deltaMs;
     iTime.tick();
 
-    // update location texture if the model has changed
-    int n = shaderInfo.size();
-
-    if (lastModel != m) {
-      for (int i = 0; i < n; i++) {
-        s = shaderInfo.get(i);
-        s.shader.updateLocationTexture(m);
-      }
-      lastModel = m;
-    }
-
+    // set up rectangular texture buffers for effects that need them
     ShaderPainter.mapToBufferDirect(m.points, imageBuffer, colors);
     ShaderPainter.mapFromLinearBuffer(
         m.points, mappedBufferWidth, mappedBufferHeight, mappedBuffer, colors);
 
-
     // run the chain of shaders, except for the last one,
     // copying the output of each to the next shader's input texture
+    int n = shaderInfo.size();
     for (int i = 0; i < n; i++) {
       s = shaderInfo.get(i);
+      s.shader.useViewCoordinates(m);
       s.shader.useProgram();
       s.setup.OnFrame(s.shader);
       s.shader.run();

--- a/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -80,8 +80,6 @@ public class GLShaderPattern extends TEPerformancePattern {
     addShader(new GLShader(lx, shaderName, controlData), setup);
   }
 
-  private LXModel lastModel = null;
-
   @Override
   public void runTEAudioPattern(double deltaMs) {
     LXModel m = getModel();
@@ -89,19 +87,11 @@ public class GLShaderPattern extends TEPerformancePattern {
     this.deltaMs = deltaMs;
     int n = shaderInfo.size();
 
-    // update location texture if the model has changed
-    if (lastModel != m) {
-      for (int i = 0; i < n; i++) {
-        s = shaderInfo.get(i);
-        s.shader.updateLocationTexture(m);
-      }
-      lastModel = m;
-    }
-
     // run the chain of shaders, except for the last one,
     // copying the output of each to the next shader's input texture
     for (int i = 0; i < n; i++) {
       s = shaderInfo.get(i);
+      s.shader.useViewCoordinates(m);
       s.shader.useProgram();
       s.setup.OnFrame(s.shader);
       s.shader.run();

--- a/src/main/java/titanicsend/pattern/glengine/TextureManager.java
+++ b/src/main/java/titanicsend/pattern/glengine/TextureManager.java
@@ -5,6 +5,8 @@ import com.jogamp.opengl.util.GLBuffers;
 import com.jogamp.opengl.util.texture.Texture;
 import com.jogamp.opengl.util.texture.TextureData;
 import com.jogamp.opengl.util.texture.TextureIO;
+import heronarts.lx.LX;
+import heronarts.lx.model.LXModel;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,33 +16,50 @@ import java.util.HashMap;
 
 import static com.jogamp.opengl.GL.*;
 
+// Manages the lifecycle of the (relatively) static OpenGL textures used by
+// the shader engine.  We use are two types of textures: coordinate and static.
+// Coordinate textures hold floating point normalized XYZ coordinates of the
+// points in the various views of the model.  Static textures are loaded from
+// image files, and are used as 2D textures in the shaders.
+//
 public class TextureManager {
+
+  private enum TextureType {
+    COORDINATE,
+    STATIC
+  }
 
   private GL4 gl4;
 
-  // texture unit management
-  private class TextureUnit {
+  // per texture data for the texture cache
+  private class CachedTexture {
     private Texture texture;
     private int textureUnit;
+    private TextureType type;
     private int refCount;
   }
 
-  private int nextTextureUnit = 3;
+  // the next available OpenGL texture unit number
+  private static final int FIRST_UNRESERVED_TEXTURE_UNIT = 3;
+  private int nextTextureUnit = FIRST_UNRESERVED_TEXTURE_UNIT;
 
-  // textures is a map of integer hash codes for textures to texture unit numbers.
-  // The hash code is used to identify the texture, and the texture unit number is
-  // used to bind the texture to the GPU.
-  private final HashMap<Integer, TextureUnit> textures = new HashMap<>();
+  // map of texture hash codes to texture data
+  // The hash code uniquely identifies the texture, the texture unit number is
+  // used to bind the texture to the GPU, and the other data is used for
+  // cache management.
+  private final HashMap<Integer, CachedTexture> textures = new HashMap<>();
 
   // a list of that we can use to keep track of released texture unit numbers
   private final ArrayList<Integer> releasedTextureUnits = new ArrayList<>();
 
-  // Almost certainly reliable hashing function!
-  // This generates a hash code for a texture file name string, which is
-  // then used to look up the texture unit number in our static textures map.
-  // It is, as mentioned, almost certainly reliable for our use case, but
-  // not absolutely guaranteed to generate a unique code for every
-  // possible filename.
+  /**
+   * Almost certainly reliable hashing function!
+   * This generates a hash code for a texture file name string, which is
+   * then used to look up the texture unit number in our static textures map.
+   * It is, as mentioned, almost certainly reliable for our use case, but
+   * not absolutely guaranteed to generate a unique code for every
+   * possible filename.
+   */
   private int stringToHash(String s) {
     int hash = 0;
     for (int i = 0; i < s.length(); i++) {
@@ -49,13 +68,89 @@ public class TextureManager {
     return hash;
   }
 
-  public static Texture createCoordinateTexture(GL4 gl4, FloatBuffer coords, int width, int height) {
-    // Create a TextureData object for a set of normalized floating point coordinates
+  /**
+   * Copy LXPoints' normalized coordinates into textures for use by shaders. Must be called by the
+   * parent pattern or effect at least once before the first frame is rendered. And should be called
+   * by the pattern's frametime run() function if the model has changed since the last frame.
+   */
+  public int useCoordinateTexture(LXModel model, FloatBuffer modelCoords) {
+    CachedTexture t;
+
+    // if the view's coordinate texture is already loaded, just use it
+    // NOTE: We don't use the cache's texture reference counting mechanism
+    // for the coordinate texture. Once a view coord texture is loaded, it's never
+    // released until the model changes.
+    int textureHash = model.hashCode();
+    if (textures.containsKey(textureHash)) {
+      t = textures.get(textureHash);
+    } else {
+      // otherwise, create a new coordinate texture and bind it to the next available texture unit
+      t = new CachedTexture();
+      t.type = TextureType.COORDINATE;
+      t.texture = createCoordinateTexture(gl4, model);
+      t.textureUnit = getNextTextureUnit();
+      t.refCount = 1;
+      textures.put(textureHash, t);
+
+      gl4.glActiveTexture(GL_TEXTURE0 + t.textureUnit);
+      gl4.glEnable(GL_TEXTURE_2D);
+      t.texture.enable(gl4);
+      t.texture.bind(gl4);
+    }
+    // return the texture unit number
+    return t.textureUnit;
+  }
+
+  /**
+   * Create a coordinate texture from the normalized coordinates of the given model
+   * and bind it to the next available texture unit.  If the view's coordinate texture
+   * already exists,return the bound texture unit number.
+   */
+  public Texture createCoordinateTexture(GL4 gl4, LXModel model) {
+    // get data we need to create the texture from the system and
+    // the model
+    int xSize = GLEngine.getWidth();
+    int ySize = GLEngine.getHeight();
+    int maxPoints = xSize * ySize;
+
+    final int numPoints = model.points.length;
+
+    // Create a FloatBuffer to hold the normalized coordinates of the model points
+    FloatBuffer coords = GLBuffers.newDirectFloatBuffer(maxPoints * 3);
+
+    // Copy the normalized model coordinates to the buffer
+    coords.rewind();
+    for (int i = 0; i < maxPoints; i++) {
+      if (i < numPoints) {
+        coords.put(model.points[i].xn);
+        coords.put(model.points[i].yn);
+        coords.put(model.points[i].zn);
+      } else {
+        coords.put(0);
+        coords.put(0);
+        coords.put(0);
+      }
+    }
+    coords.rewind();
+
+    // Sanity check: make sure the system resolution has enough points
+    // to hold the model.
+    // This should really never fail, but we're checkin' anyway.
+    if (numPoints > maxPoints) {
+      LX.error(
+        "GLEngine resolution ("
+          + maxPoints
+          + ") too small for number of points in the model ("
+          + numPoints
+          + ")");
+    }
+
+    // Now that we have our model data, use it to create an OpenGL texture
     TextureData textureData = new TextureData(
       gl4.getGLProfile(),
       GL4.GL_RGB32F,
-      width,
-      height,
+      xSize,
+      ySize,
       0,
       GL4.GL_RGB,
       GL4.GL_FLOAT,
@@ -66,25 +161,25 @@ public class TextureManager {
       null
     );
 
-    // Create a Texture object from the TextureData
+    // Create a jogamp Texture object from the TextureData
     Texture texture = TextureIO.newTexture(textureData);
 
     // Bind the texture to the GL context
     texture.bind(gl4);
 
-    // TODO - set texture parameters and do all the other things that useTexture does
-    // TODO - for file-based textures
-    // TODO - or keep this as a separate function and call it from a useTexture variant
-    // TODO - that takes an LX model (a view) instead of a filename.
-    // TODO - once that's done, convert all texture management in the shader to this system.
-    // TODO - it'll be faster, simpler and more reliable
-    // TODO - DEFINITELY remember to unload/free/delete the texture when done with it
+    // Set the texture parameters
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
     return texture;
   }
 
-  // Returns the next available texture unit number, either by reusing a released
-  // texture unit number or by allocating a new one.
+  /**
+   Returns the next available texture unit number, either by reusing a released
+   texture unit number or by allocating a new one.
+  */
   public int getNextTextureUnit() {
     if (releasedTextureUnits.size() > 0) {
       return releasedTextureUnits.remove(0);
@@ -94,7 +189,7 @@ public class TextureManager {
   }
 
   public int releaseTextureUnit(int textureUnit) {
-    if (textureUnit < 3) {
+    if (textureUnit < FIRST_UNRESERVED_TEXTURE_UNIT) {
       throw new RuntimeException("GLEngine: Attempt to release a reserved texture unit: " + textureUnit);
     }
     if (releasedTextureUnits.contains(textureUnit)) {
@@ -106,14 +201,19 @@ public class TextureManager {
 
   // Add a released (ref count 0) texture unit number to the list of available
   // texture units
-  private void recycleTextureUnit(TextureUnit t) {
+  private void recycleTextureUnit(CachedTexture t) {
     if (!releasedTextureUnits.contains(t.textureUnit)) {
       releasedTextureUnits.add(t.textureUnit);
     }
   }
 
+  /**
+   * Load a static texture from a file and bind it to the next available texture unit
+   * Returns the texture unit number. If the texture is already loaded, just increment
+   * the ref count and return the existing texture unit number.
+   */
   public int useTexture(GL4 gl4, String textureName) {
-    TextureUnit t = new TextureUnit();
+    CachedTexture t;
 
     try {
       // if the texture is already loaded, just increment the ref count
@@ -124,6 +224,8 @@ public class TextureManager {
       } else {
         // otherwise, load the texture its file and bind it to the next available texture unit
         File file = new File(textureName);
+        t = new CachedTexture();
+        t.type = TextureType.STATIC;
         t.texture = TextureIO.newTexture(file, false);
         t.textureUnit = getNextTextureUnit();
         t.refCount = 1;
@@ -142,12 +244,29 @@ public class TextureManager {
     }
   }
 
+  /**
+   * This function must be called when the model changes (when it is
+   * edited, or when a project is loaded/unloaded) to delete
+   * all existing view coordinate textures and remove them from the
+   * textures map.
+   */
+  public void clearCoordinateTextures() {
+    CachedTexture t;
+    for (int k : textures.keySet()) {
+      t = textures.get(k);
+      if (t.type == TextureType.COORDINATE) {
+        t.refCount = 0; // just making sure
+        releaseTexture(k);
+      }
+    }
+  }
+
   public void releaseTexture(String textureName) {
     releaseTexture(stringToHash(textureName));
   }
 
   public void releaseTexture(int textureHash) {
-    TextureUnit t = textures.get(textureHash);
+    CachedTexture t = textures.get(textureHash);
     if (t == null) {
       throw new RuntimeException("Attempt to release texture that was never used:");
     }

--- a/src/main/java/titanicsend/pattern/glengine/TextureManager.java
+++ b/src/main/java/titanicsend/pattern/glengine/TextureManager.java
@@ -1,0 +1,161 @@
+package titanicsend.pattern.glengine;
+
+import com.jogamp.opengl.GL4;
+import com.jogamp.opengl.util.GLBuffers;
+import com.jogamp.opengl.util.texture.Texture;
+import com.jogamp.opengl.util.texture.TextureData;
+import com.jogamp.opengl.util.texture.TextureIO;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import static com.jogamp.opengl.GL.*;
+
+public class TextureManager {
+
+  private GL4 gl4;
+
+  // texture unit management
+  private class TextureUnit {
+    private Texture texture;
+    private int textureUnit;
+    private int refCount;
+  }
+
+  private int nextTextureUnit = 3;
+
+  // textures is a map of integer hash codes for textures to texture unit numbers.
+  // The hash code is used to identify the texture, and the texture unit number is
+  // used to bind the texture to the GPU.
+  private final HashMap<Integer, TextureUnit> textures = new HashMap<>();
+
+  // a list of that we can use to keep track of released texture unit numbers
+  private final ArrayList<Integer> releasedTextureUnits = new ArrayList<>();
+
+  // Almost certainly reliable hashing function!
+  // This generates a hash code for a texture file name string, which is
+  // then used to look up the texture unit number in our static textures map.
+  // It is, as mentioned, almost certainly reliable for our use case, but
+  // not absolutely guaranteed to generate a unique code for every
+  // possible filename.
+  private int stringToHash(String s) {
+    int hash = 0;
+    for (int i = 0; i < s.length(); i++) {
+      hash = (hash << 5) - hash + s.charAt(i);
+    }
+    return hash;
+  }
+
+  public static Texture createCoordinateTexture(GL4 gl4, FloatBuffer coords, int width, int height) {
+    // Create a TextureData object for a set of normalized floating point coordinates
+    TextureData textureData = new TextureData(
+      gl4.getGLProfile(),
+      GL4.GL_RGB32F,
+      width,
+      height,
+      0,
+      GL4.GL_RGB,
+      GL4.GL_FLOAT,
+      false,
+      false,
+      false,
+      coords,
+      null
+    );
+
+    // Create a Texture object from the TextureData
+    Texture texture = TextureIO.newTexture(textureData);
+
+    // Bind the texture to the GL context
+    texture.bind(gl4);
+
+    // TODO - set texture parameters and do all the other things that useTexture does
+    // TODO - for file-based textures
+    // TODO - or keep this as a separate function and call it from a useTexture variant
+    // TODO - that takes an LX model (a view) instead of a filename.
+    // TODO - once that's done, convert all texture management in the shader to this system.
+    // TODO - it'll be faster, simpler and more reliable
+    // TODO - DEFINITELY remember to unload/free/delete the texture when done with it
+
+    return texture;
+  }
+
+  // Returns the next available texture unit number, either by reusing a released
+  // texture unit number or by allocating a new one.
+  public int getNextTextureUnit() {
+    if (releasedTextureUnits.size() > 0) {
+      return releasedTextureUnits.remove(0);
+    } else {
+      return nextTextureUnit++;
+    }
+  }
+
+  public int releaseTextureUnit(int textureUnit) {
+    if (textureUnit < 3) {
+      throw new RuntimeException("GLEngine: Attempt to release a reserved texture unit: " + textureUnit);
+    }
+    if (releasedTextureUnits.contains(textureUnit)) {
+      throw new RuntimeException("GLEngine: Attempt to release a texture unit that is already released: " + textureUnit);
+    }
+    releasedTextureUnits.add(textureUnit);
+    return textureUnit;
+  }
+
+  // Add a released (ref count 0) texture unit number to the list of available
+  // texture units
+  private void recycleTextureUnit(TextureUnit t) {
+    if (!releasedTextureUnits.contains(t.textureUnit)) {
+      releasedTextureUnits.add(t.textureUnit);
+    }
+  }
+
+  public int useTexture(GL4 gl4, String textureName) {
+    TextureUnit t = new TextureUnit();
+
+    try {
+      // if the texture is already loaded, just increment the ref count
+      int textureHash = stringToHash(textureName);
+      if (textures.containsKey(textureHash)) {
+        t = textures.get(textureHash);
+        t.refCount++;
+      } else {
+        // otherwise, load the texture its file and bind it to the next available texture unit
+        File file = new File(textureName);
+        t.texture = TextureIO.newTexture(file, false);
+        t.textureUnit = getNextTextureUnit();
+        t.refCount = 1;
+        textures.put(textureHash, t);
+
+        gl4.glActiveTexture(GL_TEXTURE0 + t.textureUnit);
+        gl4.glEnable(GL_TEXTURE_2D);
+        t.texture.enable(gl4);
+        t.texture.bind(gl4);
+      }
+      // return the texture unit number
+      return t.textureUnit;
+
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public void releaseTexture(String textureName) {
+    releaseTexture(stringToHash(textureName));
+  }
+
+  public void releaseTexture(int textureHash) {
+    TextureUnit t = textures.get(textureHash);
+    if (t == null) {
+      throw new RuntimeException("Attempt to release texture that was never used:");
+    }
+    t.refCount--;
+    if (t.refCount <= 0) {
+      t.texture.destroy(gl4);
+      recycleTextureUnit(t);
+      textures.remove(textureHash);
+    }
+  }
+}


### PR DESCRIPTION
#### Adds long-promised caching of view coordinate textures to the 3D branch.
With this PR, the 3d branch is ready to merge with main.  What it does:
- Uses a **lot** less memory, particularly when using many channels and patterns, since the coordinate texture for each view is stored only once (instead of per-pattern as in the current implementation).
- Much faster view switching, since view coord textures, once loaded, are kept resident on the GPU.  No coordinate data has to be copied when you switch views.
- Lower CPU load because it eliminates quite a lot of the data movement involved in setting up the coordinate textures.
- lower GPU load.  Less loading/unloading of textures, plus the shader engine is now able to avoid computing pixel values for points not in the view.  (Previously, it ran the pattern fragment shader over its whole internal buffer.)  Depending on what the pattern is doing, this can be a huge win for sparse views, like "Edges".

Notes for the Future:
**Question**:  It is now possible, with very little performance impact, to support full 3d rotation/translation/scale/skew operations on the model coordinates.  This is something that has come up a few times as a feature request in the Chromatik forums.  Certainly it'd be fantastic for working with physically animated sculptures.  I didn't do it here, b/c I'm not sure (a) we have a great use case yet, and (b) how the heck we'd control it.   Do we want this feature in, just on general principles?



