### PR TITLE
3D Branch Docs + Cleanup

### DIFF
--- a/.run/Titanic's End Dynamic.run.xml
+++ b/.run/Titanic's End Dynamic.run.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="LXStudio-TE" />
     <option name="PROGRAM_PARAMETERS" value="dynamic Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true " />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/.run/Titanic's End Dynamic.run.xml
+++ b/.run/Titanic's End Dynamic.run.xml
@@ -1,10 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Titanic's End Dynamic" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17.0.8" />
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-17" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="LXStudio-TE" />
     <option name="PROGRAM_PARAMETERS" value="dynamic Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/resources/docs/ShaderFramework.md
+++ b/resources/docs/ShaderFramework.md
@@ -319,6 +319,29 @@ current pixel you're working on. For example:
 
 `vec4 pix = texelFetch(iBackbuffer, ivec2(gl_FragCoord.xy), 0);`
 
+### iMappedBuffer (uniform sampler2D iMappedBuffer)
+
+iMappedBuffer is an optional texture containing the data rendered by the previous shader in "normal"
+rectangular buffer form.  It is currently available only to effect shaders, and can be used for convolution
+and other effects that need rectangular "neighborhoods" of pixels.
+
+Note that only pixels that actually exist on the target LED fixture will be colored. All other pixels
+will be zero.  So blur, bloom and similar filters may not have the expected effect.
+
+It is currently not supported in pattern shaders, but will be available as an option at some point in the future.
+
+### lxModelCoords (uniform sampler2D lxModelCoords)
+
+A floating point array containing normalized 3D coordinates for the selected view of the current LX model.
+The points are in linear order corresponding to the order of pixels in the corresponding Java LXModel. 
+
+An appropriately scaled 2D version of these coordinates is automatically supplied to shaders in the
+fragCoord uniform, so most shaders will not need to interact directly with `lxModelCoords`.  However,
+if you need to access the full 3D coordinates of the current pixel, you can use texelFetch() on the
+`gl_FragCoords` passed to the shader to access the values for the pixel you're working on. For example:
+
+`vec3 coords3D = texelFetch(lxModelCoords, ivec2(gl_FragCoord.xy), 0).xyz;`
+
 -----
 
 ### Automatic LX Control Uniforms

--- a/resources/docs/ShaderFramework.md
+++ b/resources/docs/ShaderFramework.md
@@ -22,6 +22,44 @@ While GPUs vary greatly in capability, they will all run your shader in parallel
 on many cores at the same time. This means you can make much more interesting, organic-looking,
 realistic, etc. graphics without bogging down the CPU.
 
+## How it works on TE
+If you've worked with shaders before, you've most likely seen them used to apply textures to geometry.  In games,
+for example, a shader might be used to apply a texture to a 3D character, or create explosions or water effects.  In 
+programs like ShaderToy, the geometry is less complicated.  Shaders are used to draw in 2D rectangles that are displayed
+on the screen.
+
+TE's shader engine is a little different. It's mostly Shadertoy compatible, but it is designed to work with the LED
+fixtures on our vehicles.  The shader engine takes the output of your shader and maps it to the vehicle's LEDs, so
+that the pattern you create is displayed on the car.  It is possible to do this by taking a Shadertoy-like rectangular texture
+and mapping each of its pixels to the nearest corresponding LED, but this has some important limitations when dealing with 3D 
+objects like TE and Mothership. Our art cars are definitely not rectangular, and they contain a lot of empty spaces where LEDs
+are sparse or nonexistent. (Think, the hole in the middle of Mothership, or the big space for the DJ booth on TE.)  
+
+Mapping a rectangular texture to this sort of object requires rendering a lot of pixels that will never be displayed.  Also
+the pixels in the map are not always well aligned with the LEDs, so the texture needs to be filtered to get the right color
+for each LED. This is somewhat computationally expensive, and can produce undesirable artifacts, like blurring and color bleed.  
+
+To solve these problems, and to give shaders the ability to address each pixel on our vehicles in full 3D, the latest TE shader engine
+uses a different approach.  Instead of rendering a rectangle and mapping it to the car's LEDs, the engine renders only the exact pixels
+found on the car. This is done by giving the shader access to the normalized physical space coordinates of the pixel it is rendering.
+
+In general, this means that fewer pixels need to be rendered, and the images produced on the LEDs are sharper, smoother in motion,
+and just plain better looking.
+
+For the most part, this happens automatically and does not affect how shaders are written.  But there are a few things
+to be aware of, especially if you want to use the engine's more advanced features:  
+
+- iBackbuffer, the sampler containing the previous frame is not a rectangular texture. It contains pixel values from the previous frame
+in linear order, matching the order of pixels in the current Java LXModel view.  See the section on iBackbuffer below for more
+information on how to use the backbuffer in your shader.
+
+- For shaders that do filtering or other convolution effects, the iMappedBuffer texture is available.  This texture contains the
+data rendered by the previous shader in "normal" rectangular buffer form.  It is currently available only to effect shaders. See
+the section on iMappedBuffer below for more information.
+
+- If you want to work directly with the normalized 3D model coordinates in your shader, use the lxModelCoords uniform sampler as
+described below.
+
 ## Uniforms - Data Supplied by the TE Framework
 Patterns on Titanic's End are highly interactive. Each show is unique, with visuals
 generated in real time in response to audio, directed by a VJ running the controls.

--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -2,29 +2,34 @@
 
 out vec4 finalColor;
 
-// standard shadertoy
+// shared uniforms that are set once per run
+layout (std140) uniform PerRunBlock {
+  vec4 iMouse;
+  vec2 iResolution;
+};
+
+// shared uniforms that are set once per frame
+layout (std140) uniform PerFrameBlock {
+// Legacy TE Audio uniforms
+    uniform float beat;
+    uniform float sinPhaseBeat;
+    uniform float bassLevel;
+    uniform float trebleLevel;
+
+    uniform float volumeRatio;
+    uniform float bassRatio;
+    uniform float trebleRatio;
+
+// Values from audio stem splitter
+    uniform float stemBass;
+    uniform float stemDrums;
+    uniform float stemVocals;
+    uniform float stemOther;
+};
+
+// standard shadertoy uniforms (updated per frame for each
+// running pattern.)
 uniform float iTime;
-uniform vec2 iResolution;
-uniform vec4 iMouse;
-
-// TE Audio
-uniform float beat;
-uniform float sinPhaseBeat;
-uniform float bassLevel;
-uniform float trebleLevel;
-
-uniform float volumeRatio;
-uniform float bassRatio;
-uniform float trebleRatio;
-
-uniform float levelReact;
-uniform float frequencyReact;
-
-// Current values from audio stems
-uniform float stemBass;
-uniform float stemDrums;
-uniform float stemVocals;
-uniform float stemOther;
 
 // TE Colors
 uniform vec3 iColorRGB;
@@ -43,6 +48,8 @@ uniform float iBrightness;
 uniform float iWow1;
 uniform float iWow2;
 uniform bool iWowTrigger;
+uniform float frequencyReact;
+uniform float levelReact;
 
 // Shadertoy audio channel
 uniform sampler2D iChannel0;
@@ -158,7 +165,7 @@ void main() {
     finalColor = _blendFix(finalColor);
     #else
     // Old EDC blending - force black pixels to full transparency, otherwise
-    //use shader provided alpha
+    // use shader provided alpha
     finalColor.a = ((finalColor.r + finalColor.g + finalColor.b) == 0.0) ? 0.0 : finalColor.a;
     #endif
     #endif

--- a/resources/shaders/framework/template.fs
+++ b/resources/shaders/framework/template.fs
@@ -63,6 +63,16 @@ uniform sampler2D iChannel3;
 
 // returns the normalized model coordinates for the current fragment
 vec4 _getModelCoordinates() {
+    // create 3d rotation matrix rotating around the x axis by iRotationAngle
+    // TODO: Yes, this works, now we need to do it for real using LXMatrix
+    // TODO: operations from Java.  Keeping demo code for reference and reminder.
+    //float c = cos(iRotationAngle);
+    //float s = sin(iRotationAngle);
+    //mat3 rotX = mat3(1, 0, 0, 0, c, -s, 0, s, c);
+    //vec4 nc = texelFetch(lxModelCoords, ivec2(gl_FragCoord.xy), 0);
+    // apply rotation
+    //return vec4(rotX * nc.xyz, nc.w);
+
     return texelFetch(lxModelCoords, ivec2(gl_FragCoord.xy), 0);
 }
 

--- a/src/main/java/titanicsend/pattern/TEAudioPattern.java
+++ b/src/main/java/titanicsend/pattern/TEAudioPattern.java
@@ -88,7 +88,7 @@ public abstract class TEAudioPattern extends TEPattern {
     trebleLevel = GLEngine.getTrebleLevel();
 
     /* Compute the ratio of the current instantaneous frequency levels to
-     * their new, updated moving averages.
+     * their current moving averages.
      */
     volumeRatio = GLEngine.getVolumeRatio();
     bassRatio = GLEngine.getBassRatio();

--- a/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/src/main/java/titanicsend/pattern/TEPattern.java
@@ -1,8 +1,5 @@
 package titanicsend.pattern;
 
-import static java.lang.Math.PI;
-import static java.lang.Math.sin;
-
 import heronarts.lx.LX;
 import heronarts.lx.Tempo;
 import heronarts.lx.audio.GraphicMeter;
@@ -27,6 +24,7 @@ import titanicsend.dmx.pattern.DmxPattern;
 import titanicsend.model.TELaserModel;
 import titanicsend.model.TEPanelModel;
 import titanicsend.model.TEWholeModel;
+import titanicsend.pattern.glengine.GLEngine;
 import titanicsend.util.TEColor;
 
 public abstract class TEPattern extends DmxPattern {
@@ -159,7 +157,7 @@ public abstract class TEPattern extends DmxPattern {
 
   // Sine modulator alternative between 0 and 1 on beat
   public double sinePhaseOnBeat() {
-    return .5 * sin(PI * lx.engine.tempo.getCompositeBasis()) + .5;
+    return GLEngine.getSinPhaseOnBeat();
   }
 
   /**

--- a/src/main/java/titanicsend/pattern/glengine/GLEffectControl.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEffectControl.java
@@ -26,13 +26,6 @@ public class GLEffectControl implements GLControlData {
   // send a subset of the controls we use with patterns
   public void setUniforms(GLShader s) {
     s.setUniform("iTime", (float) effect.getTime());
-    s.setUniform("iResolution", (float) GLEngine.getWidth(), (float) GLEngine.getHeight());
-
-    // Current values from audio stems
-    s.setUniform("stemBass", (float) AudioStems.get().bass.getValuef());
-    s.setUniform("stemDrums", (float) AudioStems.get().drums.getValuef());
-    s.setUniform("stemVocals", (float) AudioStems.get().vocals.getValuef());
-    s.setUniform("stemOther", (float) AudioStems.get().other.getValuef());
 
     // get current primary and secondary colors
     // TODO - we're just grabbing swatch colors here.  Do we need to worry about modulation?

--- a/src/main/java/titanicsend/pattern/glengine/GLEngine.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEngine.java
@@ -18,487 +18,486 @@ import java.nio.FloatBuffer;
 import static com.jogamp.opengl.GL.*;
 
 public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
-    public static final String PATH = "GLEngine";
-    public static GLEngine current;
+  public static final String PATH = "GLEngine";
+  public static GLEngine current;
 
-    private final int[] audioTextureHandle = new int[1];
-    private final int[] uniformBlockHandles = new int[2];
+  private final int[] audioTextureHandle = new int[1];
+  private final int[] uniformBlockHandles = new int[2];
 
-    // rendering canvas size.  May be changed
-    // via the startup command line.
-    private static int xSize;
-    private static int ySize;
-    private static int maxPoints;
+  // rendering canvas size.  May be changed
+  // via the startup command line.
+  private static int xSize;
+  private static int ySize;
+  private static int maxPoints;
 
-    // Dimensions of mapped texture backbuffer.
+  // Dimensions of mapped texture backbuffer.
+  //
+  // This buffer is never directly rendered by either the GPU or by Java
+  // Instead, the pixel locations corresponding to the lx model's LEDs are
+  // colored at frame time and the buffer is supplied as a read-only sampler
+  // to the shader system.
+  //
+  // So increasing the size of this buffer affects memory usage but does
+  // not affect rendering performance.  The default size is sufficient for
+  // even very large models, but can be increased if necessary.
+  // TODO - make this configurable per pattern or effect.
+  private static final int mappedBufferWidth = 640;
+  private static final int mappedBufferHeight = 640;
+
+  // audio texture size and buffer
+  private static final int audioTextureWidth = 512;
+  private static final int audioTextureHeight = 2;
+  private FloatBuffer audioTextureData;
+
+  // audio data sources & parameters
+  private final double AUDIO_LEVEL_MIN = 0.01;
+  private final GraphicMeter meter;
+  private final float fftResampleFactor;
+
+  private static final TEMath.EMA avgVolume = new TEMath.EMA(0.5, .01);
+  private static final TEMath.EMA avgBass = new TEMath.EMA(0.2, .01);
+  private static final TEMath.EMA avgTreble = new TEMath.EMA(0.2, .01);
+
+  private static double beat = 0.0;
+  private static double sinPhaseBeat = 0.0;
+  private static double volume = 0.0;
+  private static double bassLevel = 0.0;
+  private static double trebleLevel = 0.0;
+  private static double volumeRatio = 0.0;
+  private static double bassRatio = 0.0;
+  private static double trebleRatio = 0.0;
+
+  // audio and related uniform block buffer parameters
+  private FloatBuffer perRunUniformBlock;
+  private int perRunUniformBlockSize;
+  private FloatBuffer perFrameUniformBlock;
+  private int perFrameUniformBlockSize;
+
+  public static final int perRunUniformBlockBinding = 0;
+  public static final int perFrameUniformBlockBinding = 1;
+
+  // Texture cache management
+  private TextureManager textureCache = null;
+  private boolean modelChanged = false;
+
+  private boolean isRunning = false;
+
+  // Data and utility methods for the GL canvas/context.
+  private GLAutoDrawable canvas = null;
+  private GL4 gl4;
+
+  private LXModel model;
+
+  public LXModel getModel() {
+    return model;
+  }
+
+  // Needed for housekeeping, during static-to-dynamic model transition
+  // This lets various shader components know if they're running the static model
+  // and need to swap the x and z axes.
+  // TODO - remove when we move to dynamic model
+  private final boolean isStatic;
+
+  public boolean isStaticModel() {
+    return isStatic;
+  }
+
+  public GLAutoDrawable getCanvas() {
+    return canvas;
+  }
+
+  public static int getWidth() {
+    return xSize;
+  }
+
+  public static int getHeight() {
+    return ySize;
+  }
+
+  public static int getMappedBufferWidth() {
+    return mappedBufferWidth;
+  }
+
+  public static int getMappedBufferHeight() {
+    return mappedBufferHeight;
+  }
+
+  // Utility methods to give java patterns access to the audio texture
+  // should they want it.
+  public FloatBuffer getAudioTextureBuffer() {
+    return audioTextureData;
+  }
+
+  public static int getAudioTextureWidth() {
+    return audioTextureWidth;
+  }
+
+  public static int getAudioTextureHeight() {
+    return audioTextureHeight;
+  }
+
+  /**
+   * Copy a model's normalized coordinates into a special texture for use by shaders. Must be
+   * called by the parent pattern or effect at least once before the first frame is rendered and
+   * Should be called by the pattern's frametime run() function on every frame for full Chromatik view
+   * support.
+   *
+   * @param model The model (view) to copy coordinates from
+   * @return The texture unit number that the view's coordinate texture
+   * is bound to.
+   */
+  public int useViewCoordinates(LXModel model) {
+    return textureCache.useViewCoordinates(model);
+  }
+
+  // Load a static texture from a file and bind it to the next available texture unit
+  // Returns the texture unit number. If the texture is already loaded, just increment
+  // the ref count and return the existing texture unit number.
+  public int useTexture(GL4 gl4, String textureName) {
+    return textureCache.useTexture(gl4, textureName);
+  }
+
+  public void releaseTexture(String textureName) {
+    textureCache.releaseTexture(textureName);
+  }
+
+  // Returns the next available texture unit number, either by reusing a released
+  // texture unit number or by allocating a new one.
+  public int getNextTextureUnit() {
+    return textureCache.getNextTextureUnit();
+  }
+
+  public int releaseTextureUnit(int textureUnit) {
+    return textureCache.releaseTextureUnit(textureUnit);
+  }
+
+  /**
+   * Retrieve a single sample of the current frame's fft data from the engine NOTE: 512 samples can
+   * always be retrieved, regardless of how many bands the engine actually supplies. Data will be
+   * properly distributed (but not smoothed or interpolated) across the full 512 sample range.
+   *
+   * @param index (0-511) of the sample to retrieve.
+   * @return fft sample, normalized to range 0 to 1.
+   */
+  private float getFrequencyData(int index) {
+    return meter.getBandf((int) Math.floor((float) index * fftResampleFactor));
+  }
+
+  /**
+   * Retrieve a single sample of the current frame's waveform data from the engine
+   *
+   * @param index (0-511) of the sample to retrieve
+   * @return waveform sample, range -1 to 1
+   */
+  private float getWaveformData(int index) {
+    return meter.getSamples()[index];
+  }
+
+  /**
+   * Construct texture to hold audio fft and waveform data and bind it to texture unit 0 for the
+   * entire run. Once done, every shader pattern can access the audio data texture with minimal
+   * per-pattern work.
+   */
+  private void initializeAudioTexture() {
+    // allocate backing buffer in native memory
+    this.audioTextureData = GLBuffers.newDirectFloatBuffer(audioTextureHeight * audioTextureWidth);
+
+    // create texture and bind it to texture unit 0, where it will stay for the whole run
+    gl4.glActiveTexture(GL_TEXTURE0);
+    gl4.glEnable(GL_TEXTURE_2D);
+    gl4.glGenTextures(1, audioTextureHandle, 0);
+    gl4.glBindTexture(GL4.GL_TEXTURE_2D, audioTextureHandle[0]);
+
+    // configure texture coordinate handling
+    // TODO - would GL_LINEAR filtering look more interesting here?
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  }
+
+  /**
+   * Update audio texture object with new fft and waveform data. This is called once per frame.
+   */
+  private void updateAudioTexture() {
+    // load frequency and waveform data into our texture buffer, fft data
+    // in the first row, normalized audio waveform data in the second.
+    for (int n = 0; n < audioTextureWidth; n++) {
+      audioTextureData.put(n, getFrequencyData(n));
+      audioTextureData.put(n + audioTextureWidth, getWaveformData(n));
+    }
+
+    // update audio texture on the GPU from our buffer
+    gl4.glActiveTexture(GL_TEXTURE0);
+    gl4.glBindTexture(GL_TEXTURE_2D, audioTextureHandle[0]);
+
+    gl4.glTexImage2D(
+      GL4.GL_TEXTURE_2D,
+      0,
+      GL4.GL_R32F,
+      audioTextureWidth,
+      audioTextureHeight,
+      0,
+      GL4.GL_RED,
+      GL_FLOAT,
+      audioTextureData);
+  }
+
+  /**
+   * Return a properly aligned size for a uniform block. This is necessary, particularly on
+   * macOS, where the size of a uniform block must be a multiple of GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT.
+   * (NVidia drivers on Windows and Linux are more forgiving.  I always discover things like this the
+   * hard way!)
+   *
+   * @param elements The number of 4-byte elements in the uniform block
+   * @return The size of the uniform block in bytes, aligned to the GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT
+   */
+  private int getUBOAlignedSize(int elements) {
+    int[] alignment = new int[1];
+    gl4.glGetIntegerv(GL4.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, alignment, 0);
+    return ((elements * 4) + alignment[0] - 1) & ~(alignment[0] - 1);
+  }
+
+  /**
+   * Initialize shared uniform blocks. These blocks let us centrally
+   * manage uniforms that are common to all shaders and are only updated once per run,
+   * or once per frame. Keeping a single copy of these uniforms in GPU memory saves space
+   * and reduces the number of uniform setup and data transfer calls needed for each
+   * running shader.
+   */
+  private void initializeUniformBlocks() {
+
+    // Allocate backing buffer for per run uniforms in native memory
+    // First determine the size of the buffer.  Unfortunately, in Java this
+    // needs to be done manually, as we can't directly get the size of the corresponding
+    // c-language struct. Fortunately, it's not difficult, but the layout rules
+    // must be followed exactly.   If you need to add elements to a uniform block,
+    // see the spec at: http://www.opengl.org/registry/specs/ARB/uniform_buffer_object.txt
     //
-    // This buffer is never directly rendered by either the GPU or by Java
-    // Instead, the pixel locations corresponding to the lx model's LEDs are
-    // colored at frame time and the buffer is supplied as a read-only sampler
-    // to the shader system.
+
+    // At present,we need 6 floats for per run uniforms:
+    // 4 floats for vec4 iMouse
+    // 2 floats for vec2 iResolution
     //
-    // So increasing the size of this buffer affects memory usage but does
-    // not affect rendering performance.  The default size is sufficient for
-    // even very large models, but can be increased if necessary.
-    // TODO - make this configurable per pattern or effect.
-    private static final int mappedBufferWidth = 640;
-    private static final int mappedBufferHeight = 640;
+    this.perRunUniformBlockSize = getUBOAlignedSize(6);
+    this.perRunUniformBlock = GLBuffers.newDirectFloatBuffer(perRunUniformBlockSize / 4);
 
-    // audio texture size and buffer
-    private static final int audioTextureWidth = 512;
-    private static final int audioTextureHeight = 2;
-    private FloatBuffer audioTextureData;
+    // copy data to the perRunUniformBlock buffer
+    // iMouse is not used, but is retained for Shadertoy compatibility.
+    // We'll just zero it out.
+    perRunUniformBlock.put(0, 0f);
+    perRunUniformBlock.put(1, 0f);
+    perRunUniformBlock.put(2, 0f);
+    perRunUniformBlock.put(3, 0f);
 
-    // audio data sources & parameters
-    private final GraphicMeter meter;
-    private final float fftResampleFactor;
+    // iResolution is the size of the canvas
+    perRunUniformBlock.put(4, (float) xSize);
+    perRunUniformBlock.put(5, (float) ySize);
 
-    private static final TEMath.EMA avgVolume = new TEMath.EMA(0.5, .01);
-    private static final TEMath.EMA avgBass = new TEMath.EMA(0.2, .01);
-    private static final TEMath.EMA avgTreble = new TEMath.EMA(0.2, .01);
+    // Do the same thing for per frame uniforms
+    // The items in the block are, in order:
+    // 1 float for beat
+    // 1 float for sinPhaseBeat
+    // 1 float for bassLevel
+    // 1 float for trebleLevel
+    // 1 float for bassRatio
+    // 1 float for trebleRatio
+    // 1 float for volumeRatio
+    // 1 float for stemBass
+    // 1 float for stemDrums
+    // 1 float for stemVocals
+    // 1 float for stemOther
+    // VERY IMPORTANT NOTE: whatever order this buffer is loaded in MUST be replicated exactly
+    // in the shader framework code's uniform block declaration. Otherwise, the uniforms will not
+    // have the correct values in the shader.
+    this.perFrameUniformBlockSize = getUBOAlignedSize(11);
+    this.perFrameUniformBlock = GLBuffers.newDirectFloatBuffer(perFrameUniformBlockSize / 4);
 
-    private static double beat = 0.0;
-    private static double sinPhaseBeat = 0.0;
-    private static double volume = 0.0;
-    private static double bassLevel = 0.0;
-    private static double trebleLevel = 0.0;
-    private static double volumeRatio = 0.0;
-    private static double bassRatio = 0.0;
-    private static double trebleRatio = 0.0;
+    // Generate the uniform block buffers
+    gl4.glGenBuffers(2, uniformBlockHandles, 0);
 
-    // audio and related uniform block buffer parameters
-    private FloatBuffer perRunUniformBlock;
-    private int perRunUniformBlockSize;
-    private FloatBuffer perFrameUniformBlock;
-    private int perFrameUniformBlockSize;
+    // Bind the per-run uniform block to the gl buffer object
+    gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[0]);
 
-    public static final int perRunUniformBlockBinding = 0;
-    public static final int perFrameUniformBlockBinding = 1;
+    // copy the per-run uniform block data to the buffer
+    gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockSize, perRunUniformBlock, GL4.GL_DYNAMIC_DRAW);
+    gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockBinding, uniformBlockHandles[0], 0, perRunUniformBlockSize);
 
-    // Texture cache management
-    private TextureManager textureCache = null;
-    private boolean modelChanged = false;
+    // Do the same for the per-frame uniform block and its initial data
+    gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
+    gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockSize, perFrameUniformBlock, GL4.GL_DYNAMIC_DRAW);
+    gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockBinding, uniformBlockHandles[1], 0, perFrameUniformBlockSize);
+  }
 
-    private boolean isRunning = false;
+  // Update once-per-frame audio data and all the calculated
+  // values derived from it.
+  private void updateAudioFrameData(double deltaMs) {
+    beat = lx.engine.tempo.basis();
+    sinPhaseBeat = 0.5 + 0.5 * Math.sin(Math.PI * beat);
 
-    // Data and utility methods for the GL canvas/context.
-    private GLAutoDrawable canvas = null;
-    private GL4 gl4;
+    // current instantaneous levels of frequency ranges we're interested in
+    volume = Math.max(AUDIO_LEVEL_MIN, meter.getNormalized());
+    bassLevel = Math.max(AUDIO_LEVEL_MIN, meter.getAverage(0, 2));
+    trebleLevel = Math.max(AUDIO_LEVEL_MIN, meter.getAverage(meter.numBands / 2, meter.numBands / 2));
 
-    private LXModel model;
+    // Compute the ratios of current instantaneous levels
+    // to their slow EMAs.  See TEAudioPattern.java for more info.
+    volumeRatio = volume / avgVolume.update(volume, deltaMs);
+    bassRatio = bassLevel / avgBass.update(bassLevel, deltaMs);
+    trebleRatio = trebleLevel / avgTreble.update(trebleLevel, deltaMs);
+  }
 
-    public LXModel getModel() {
-        return model;
+  // update the per-frame shared uniform block with current audio data
+  private void updatePerFrameUniforms() {
+    perFrameUniformBlock.put((float) beat);                        // beat
+    perFrameUniformBlock.put((float) sinPhaseBeat);                // sinPhaseBeat
+    perFrameUniformBlock.put((float) bassLevel);                   // bassLevel
+    perFrameUniformBlock.put((float) trebleLevel);                 // trebleLevel
+    perFrameUniformBlock.put((float) bassRatio);                   // bassRatio
+    perFrameUniformBlock.put((float) trebleRatio);                 // trebleRatio
+    perFrameUniformBlock.put((float) volumeRatio);                 // volumeRatio
+    perFrameUniformBlock.put(AudioStems.get().bass.getValuef());   // stemBass
+    perFrameUniformBlock.put(AudioStems.get().drums.getValuef());  // stemDrums
+    perFrameUniformBlock.put(AudioStems.get().vocals.getValuef()); // stemVocals
+    perFrameUniformBlock.put(AudioStems.get().other.getValuef());  // stemOther
+
+    // update the GPU buffer with the new data
+    perFrameUniformBlock.rewind();
+    gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
+    gl4.glBufferSubData(GL4.GL_UNIFORM_BUFFER, 0, perFrameUniformBlockSize, perFrameUniformBlock);
+  }
+
+  public GLEngine(LX lx, int width, int height, boolean isStaticModel) {
+    current = this;
+    // The shape the user gives us affects the rendered aspect ratio,
+    // but what really matters is that it needs to have room for the
+    // largest number of points we're going to encounter during a run.
+    // TODO - adjust buffer size & shape dynamically as the model changes.
+    // TODO - this will require a lot of GPU memory management, so is
+    // TODO - a longer-term goal.
+    xSize = width;
+    ySize = height;
+
+    maxPoints = xSize * ySize;
+    TE.log("GLEngine: Rendering canvas size: " + xSize + "x" + ySize + " = " + GLEngine.maxPoints + " total points");
+
+    // register glEngine so we can access it from patterns.
+    // and add it as an engine task for audio analysis and buffer management
+    lx.engine.registerComponent(PATH, this);
+    lx.engine.addLoopTask(this);
+
+    this.isStatic = isStaticModel;
+    this.model = lx.getModel();
+
+    // set up audio fft and waveform handling
+    // TODO - strongly consider expanding the number of FFT bands.
+    // TODO - LX defaults to 16, but more bands would let us do more
+    // TODO - interesting audio analysis.
+    this.meter = lx.engine.audio.meter;
+    fftResampleFactor = meter.bands.length / 512f;
+  }
+
+  @Override
+  public void modelGenerationChanged(LX lx, LXModel model) {
+    this.model = model;
+    this.modelChanged = true;
+  }
+
+  public void loop(double deltaMs) {
+
+    // On first frame...
+    if (canvas == null) {
+      // create and initialize offscreen drawable for gl rendering
+      canvas = ShaderUtils.createGLSurface(xSize, ySize);
+      canvas.display();
+      gl4 = canvas.getGL().getGL4();
+
+      // activate our context and do initialization tasks
+      canvas.getContext().makeCurrent();
+
+      // set up shared uniform blocks
+      initializeUniformBlocks();
+
+      // set up the per-frame audio info texture
+      initializeAudioTexture();
+      textureCache = new TextureManager(gl4);
+
+      // start listening for model changes
+      lx.addListener(this);
+
+      // set running flag once initialization is complete
+      isRunning = true;
     }
 
-    // Needed for housekeeping, during static-to-dynamic model transition
-    // This lets various shader components know if they're running the static model
-    // and need to swap the x and z axes.
-    // TODO - remove when we move to dynamic model
-    private final boolean isStatic;
+    // On every frame, after initial setup
+    if (isRunning) {
+      // activate our context and do per-frame tasks
+      canvas.getContext().makeCurrent();
+      updateAudioFrameData(deltaMs);
+      updateAudioTexture();
+      updatePerFrameUniforms();
 
-    public boolean isStaticModel() {
-        return isStatic;
+      if (modelChanged) {
+        // if the model has changed, discard all existing view coordinate textures
+        textureCache.clearCoordinateTextures();
+        modelChanged = false;
+      }
+
     }
-
-    public GLAutoDrawable getCanvas() {
-        return canvas;
-    }
-
-    public static int getWidth() {
-        return xSize;
-    }
-
-    public static int getHeight() {
-        return ySize;
-    }
-
-    public static int getMappedBufferWidth() {
-        return mappedBufferWidth;
-    }
-
-    public static int getMappedBufferHeight() {
-        return mappedBufferHeight;
-    }
-
-    // Utility methods to give java patterns access to the audio texture
-    // should they want it.
-    public FloatBuffer getAudioTextureBuffer() {
-        return audioTextureData;
-    }
-
-    public static int getAudioTextureWidth() {
-        return audioTextureWidth;
-    }
-
-    public static int getAudioTextureHeight() {
-        return audioTextureHeight;
-    }
-
-    /**
-     * Copy a model's normalized coordinates into a special texture for use by shaders. Must be
-     * called by the parent pattern or effect at least once before the first frame is rendered and
-     * Should be called by the pattern's frametime run() function on every frame for full Chromatik view
-     * support.
-     *
-     * @param model The model (view) to copy coordinates from
-     * @return The texture unit number that the view's coordinate texture
-     * is bound to.
-     */
-    public int useViewCoordinates(LXModel model) {
-        return textureCache.useViewCoordinates(model);
-    }
-
-    // Load a static texture from a file and bind it to the next available texture unit
-    // Returns the texture unit number. If the texture is already loaded, just increment
-    // the ref count and return the existing texture unit number.
-    public int useTexture(GL4 gl4, String textureName) {
-        return textureCache.useTexture(gl4, textureName);
-    }
-
-    public void releaseTexture(String textureName) {
-        textureCache.releaseTexture(textureName);
-    }
-
-    // Returns the next available texture unit number, either by reusing a released
-    // texture unit number or by allocating a new one.
-    public int getNextTextureUnit() {
-        return textureCache.getNextTextureUnit();
-    }
-
-    public int releaseTextureUnit(int textureUnit) {
-        return textureCache.releaseTextureUnit(textureUnit);
-    }
-
-    /**
-     * Retrieve a single sample of the current frame's fft data from the engine NOTE: 512 samples can
-     * always be retrieved, regardless of how many bands the engine actually supplies. Data will be
-     * properly distributed (but not smoothed or interpolated) across the full 512 sample range.
-     *
-     * @param index (0-511) of the sample to retrieve.
-     * @return fft sample, normalized to range 0 to 1.
-     */
-    private float getFrequencyData(int index) {
-        return meter.getBandf((int) Math.floor((float) index * fftResampleFactor));
-    }
-
-    /**
-     * Retrieve a single sample of the current frame's waveform data from the engine
-     *
-     * @param index (0-511) of the sample to retrieve
-     * @return waveform sample, range -1 to 1
-     */
-    private float getWaveformData(int index) {
-        return meter.getSamples()[index];
-    }
-
-    /**
-     * Construct texture to hold audio fft and waveform data and bind it to texture unit 0 for the
-     * entire run. Once done, every shader pattern can access the audio data texture with minimal
-     * per-pattern work.
-     */
-    private void initializeAudioTexture() {
-        // allocate backing buffer in native memory
-        this.audioTextureData = GLBuffers.newDirectFloatBuffer(audioTextureHeight * audioTextureWidth);
-
-        // create texture and bind it to texture unit 0, where it will stay for the whole run
-        gl4.glActiveTexture(GL_TEXTURE0);
-        gl4.glEnable(GL_TEXTURE_2D);
-        gl4.glGenTextures(1, audioTextureHandle, 0);
-        gl4.glBindTexture(GL4.GL_TEXTURE_2D, audioTextureHandle[0]);
-
-        // configure texture coordinate handling
-        // TODO - would GL_LINEAR filtering look more interesting here?
-        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-    }
-
-    /**
-     * Update audio texture object with new fft and waveform data. This is called once per frame.
-     */
-    private void updateAudioTexture() {
-        // load frequency and waveform data into our texture buffer, fft data
-        // in the first row, normalized audio waveform data in the second.
-        for (int n = 0; n < audioTextureWidth; n++) {
-            audioTextureData.put(n, getFrequencyData(n));
-            audioTextureData.put(n + audioTextureWidth, getWaveformData(n));
-        }
-
-        // update audio texture on the GPU from our buffer
-        gl4.glActiveTexture(GL_TEXTURE0);
-        gl4.glBindTexture(GL_TEXTURE_2D, audioTextureHandle[0]);
-
-        gl4.glTexImage2D(
-                GL4.GL_TEXTURE_2D,
-                0,
-                GL4.GL_R32F,
-                audioTextureWidth,
-                audioTextureHeight,
-                0,
-                GL4.GL_RED,
-                GL_FLOAT,
-                audioTextureData);
-    }
-
-    /**
-     * Return a properly aligned size for a uniform block. This is necessary, particularly on
-     * macOS, where the size of a uniform block must be a multiple of GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT.
-     * (NVidia drivers on Windows and Linux are more forgiving.  I always discover things like this the
-     * hard way!)
-     *
-     * @param elements The number of 4-byte elements in the uniform block
-     * @return The size of the uniform block in bytes, aligned to the GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT
-     */
-    private int getUBOAlignedSize(int elements) {
-        int[] alignment = new int[1];
-        gl4.glGetIntegerv(GL4.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, alignment, 0);
-        return ((elements * 4) + alignment[0] - 1) & ~(alignment[0] - 1);
-    }
-
-    /**
-     * Initialize shared uniform blocks. These blocks let us centrally
-     * manage uniforms that are common to all shaders and are only updated once per run,
-     * or once per frame. Keeping a single copy of these uniforms in GPU memory saves space
-     * and reduces the number of uniform setup and data transfer calls needed for each
-     * running shader.
-     */
-    private void initializeUniformBlocks() {
-
-        // Allocate backing buffer for per run uniforms in native memory
-        // First determine the size of the buffer.  Unfortunately, in Java this
-        // needs to be done manually, as we can't directly get the size of the corresponding
-        // c-language struct. Fortunately, it's not difficult, but the layout rules
-        // must be followed exactly.   If you need to add elements to a uniform block,
-        // see the spec at: http://www.opengl.org/registry/specs/ARB/uniform_buffer_object.txt
-        //
-
-        // At present,we need 6 floats for per run uniforms:
-        // 4 floats for vec4 iMouse
-        // 2 floats for vec2 iResolution
-        //
-        this.perRunUniformBlockSize = getUBOAlignedSize(6);
-        this.perRunUniformBlock = GLBuffers.newDirectFloatBuffer(perRunUniformBlockSize / 4);
-
-        // copy data to the perRunUniformBlock buffer
-        // iMouse is not used, but is retained for Shadertoy compatibility.
-        // We'll just zero it out.
-        perRunUniformBlock.put(0, 0f);
-        perRunUniformBlock.put(1, 0f);
-        perRunUniformBlock.put(2, 0f);
-        perRunUniformBlock.put(3, 0f);
-
-        // iResolution is the size of the canvas
-        perRunUniformBlock.put(4, (float) xSize);
-        perRunUniformBlock.put(5, (float) ySize);
-
-        // Do the same thing for per frame uniforms
-        // The items in the block are, in order:
-        // 1 float for beat
-        // 1 float for sinPhaseBeat
-        // 1 float for bassLevel
-        // 1 float for trebleLevel
-        // 1 float for bassRatio
-        // 1 float for trebleRatio
-        // 1 float for volumeRatio
-        // 1 float for stemBass
-        // 1 float for stemDrums
-        // 1 float for stemVocals
-        // 1 float for stemOther
-        // VERY IMPORTANT NOTE: whatever order this buffer is loaded in MUST be replicated exactly
-        // in the shader framework code's uniform block declaration. Otherwise, the uniforms will not
-        // have the correct values in the shader.
-        this.perFrameUniformBlockSize = getUBOAlignedSize(11);
-        this.perFrameUniformBlock = GLBuffers.newDirectFloatBuffer(perFrameUniformBlockSize / 4);
-
-        // Generate the uniform block buffers
-        gl4.glGenBuffers(2, uniformBlockHandles, 0);
-
-        // Bind the per-run uniform block to the gl buffer object
-        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[0]);
-
-        // copy the per-run uniform block data to the buffer
-        gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockSize, perRunUniformBlock, GL4.GL_DYNAMIC_DRAW);
-        gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockBinding, uniformBlockHandles[0], 0, perRunUniformBlockSize);
-
-        // Do the same for the per-frame uniform block and its initial data
-        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
-        gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockSize, perFrameUniformBlock, GL4.GL_DYNAMIC_DRAW);
-        gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockBinding, uniformBlockHandles[1], 0, perFrameUniformBlockSize);
-    }
-
-    // Update once-per-frame audio data and all the calculated
-    // values derived from it.
-    private void updateAudioFrameData(double deltaMs) {
-        double levelMin = 0.01;
-
-        beat = lx.engine.tempo.basis();
-        sinPhaseBeat = 0.5 + 0.5 * Math.sin(Math.PI * beat);
-
-        // current instantaneous levels of frequency ranges we're interested in
-        volume = Math.max(levelMin, meter.getNormalized());
-        bassLevel = Math.max(levelMin, meter.getAverage(0, 2));
-        trebleLevel = Math.max(levelMin, meter.getAverage(meter.numBands / 2, meter.numBands / 2));
-
-        // Compute the ratios of current instantaneous levels
-        // to their slow EMAs.  See TEAudioPattern.java for more info.
-        volumeRatio = volume / avgVolume.update(volume, deltaMs);
-        bassRatio = bassLevel / avgBass.update(bassLevel, deltaMs);
-        trebleRatio = trebleLevel / avgTreble.update(trebleLevel, deltaMs);
-    }
-
-    // update the per-frame shared uniform block with current audio data
-    private void updatePerFrameUniforms() {
-        perFrameUniformBlock.put((float) beat);                        // beat
-        perFrameUniformBlock.put((float) sinPhaseBeat);                // sinPhaseBeat
-        perFrameUniformBlock.put((float) bassLevel);                   // bassLevel
-        perFrameUniformBlock.put((float) trebleLevel);                 // trebleLevel
-        perFrameUniformBlock.put((float) bassRatio);                   // bassRatio
-        perFrameUniformBlock.put((float) trebleRatio);                 // trebleRatio
-        perFrameUniformBlock.put((float) volumeRatio);                 // volumeRatio
-        perFrameUniformBlock.put(AudioStems.get().bass.getValuef());   // stemBass
-        perFrameUniformBlock.put(AudioStems.get().drums.getValuef());  // stemDrums
-        perFrameUniformBlock.put(AudioStems.get().vocals.getValuef()); // stemVocals
-        perFrameUniformBlock.put(AudioStems.get().other.getValuef());  // stemOther
-
-        // update the GPU buffer with the new data
-        perFrameUniformBlock.rewind();
-        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
-        gl4.glBufferSubData(GL4.GL_UNIFORM_BUFFER, 0, perFrameUniformBlockSize, perFrameUniformBlock);
-    }
-
-    public GLEngine(LX lx, int width, int height, boolean isStaticModel) {
-        current = this;
-        // The shape the user gives us affects the rendered aspect ratio,
-        // but what really matters is that it needs to have room for the
-        // largest number of points we're going to encounter during a run.
-        // TODO - adjust buffer size & shape dynamically as the model changes.
-        // TODO - this will require a lot of GPU memory management, so is
-        // TODO - a longer-term goal.
-        xSize = width;
-        ySize = height;
-
-        maxPoints = xSize * ySize;
-        TE.log("GLEngine: Rendering canvas size: " + xSize + "x" + ySize + " = " + GLEngine.maxPoints + " total points");
-
-        // register glEngine so we can access it from patterns.
-        // and add it as an engine task for audio analysis and buffer management
-        lx.engine.registerComponent(PATH, this);
-        lx.engine.addLoopTask(this);
-
-        this.isStatic = isStaticModel;
-        this.model = lx.getModel();
-
-        // set up audio fft and waveform handling
-        // TODO - strongly consider expanding the number of FFT bands.
-        // TODO - LX defaults to 16, but more bands would let us do more
-        // TODO - interesting audio analysis.
-        this.meter = lx.engine.audio.meter;
-        fftResampleFactor = meter.bands.length / 512f;
-    }
-
-    @Override
-    public void modelGenerationChanged(LX lx, LXModel model) {
-        this.model = model;
-        this.modelChanged = true;
-    }
-
-    public void loop(double deltaMs) {
-
-        // On first frame...
-        if (canvas == null) {
-            // create and initialize offscreen drawable for gl rendering
-            canvas = ShaderUtils.createGLSurface(xSize, ySize);
-            canvas.display();
-            gl4 = canvas.getGL().getGL4();
-
-            // activate our context and do initialization tasks
-            canvas.getContext().makeCurrent();
-
-            // set up shared uniform blocks
-            initializeUniformBlocks();
-
-            // set up the per-frame audio info texture
-            initializeAudioTexture();
-            textureCache = new TextureManager(gl4);
-
-            // start listening for model changes
-            lx.addListener(this);
-
-            // set running flag once initialization is complete
-            isRunning = true;
-        }
-
-        // On every frame, after initial setup
-        if (isRunning) {
-            // activate our context and do per-frame tasks
-            canvas.getContext().makeCurrent();
-            updateAudioFrameData(deltaMs);
-            updateAudioTexture();
-            updatePerFrameUniforms();
-
-            if (modelChanged) {
-                // if the model has changed, discard all existing view coordinate textures
-                textureCache.clearCoordinateTextures();
-                modelChanged = false;
-            }
-
-        }
-    }
-
-    public void dispose() {
-        // free GPU resources that we directly allocated
-        gl4.glDeleteTextures(audioTextureHandle.length, audioTextureHandle, 0);
-        gl4.glDeleteBuffers(uniformBlockHandles.length, uniformBlockHandles, 0);
-    }
-
-    // Static getters for per-frame audio parameters
-    // TEPattern and derived pattern classes can access these, which are evaluated
-    // only once per frame, instead of recalculating the values for every running pattern
-    // instance.
-    public static double getAvgVolume() {
-        return avgVolume.getValue();
-    }
-
-    public static double getAvgBass() {
-        return avgBass.getValue();
-    }
-
-    public static double getAvgTreble() {
-        return avgTreble.getValue();
-    }
-
-    public static double getBeat() {
-        return beat;
-    }
-
-    public static double getSinPhaseOnBeat() {
-        return sinPhaseBeat;
-    }
-
-    public static double getVolume() {
-        return volume;
-    }
-
-    public static double getBassLevel() {
-        return bassLevel;
-    }
-
-    public static double getTrebleLevel() {
-        return trebleLevel;
-    }
-
-    public static double getVolumeRatio() {
-        return volumeRatio;
-    }
-
-    public static double getBassRatio() {
-        return bassRatio;
-    }
-
-    public static double getTrebleRatio() {
-        return trebleRatio;
-    }
+  }
+
+  public void dispose() {
+    // free GPU resources that we directly allocated
+    gl4.glDeleteTextures(audioTextureHandle.length, audioTextureHandle, 0);
+    gl4.glDeleteBuffers(uniformBlockHandles.length, uniformBlockHandles, 0);
+  }
+
+  // Static getters for per-frame audio parameters
+  // TEPattern and derived pattern classes can access these, which are evaluated
+  // only once per frame, instead of recalculating the values for every running pattern
+  // instance.
+  public static double getAvgVolume() {
+    return avgVolume.getValue();
+  }
+
+  public static double getAvgBass() {
+    return avgBass.getValue();
+  }
+
+  public static double getAvgTreble() {
+    return avgTreble.getValue();
+  }
+
+  public static double getBeat() {
+    return beat;
+  }
+
+  public static double getSinPhaseOnBeat() {
+    return sinPhaseBeat;
+  }
+
+  public static double getVolume() {
+    return volume;
+  }
+
+  public static double getBassLevel() {
+    return bassLevel;
+  }
+
+  public static double getTrebleLevel() {
+    return trebleLevel;
+  }
+
+  public static double getVolumeRatio() {
+    return volumeRatio;
+  }
+
+  public static double getBassRatio() {
+    return bassRatio;
+  }
+
+  public static double getTrebleRatio() {
+    return trebleRatio;
+  }
 
 }

--- a/src/main/java/titanicsend/pattern/glengine/GLEngine.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLEngine.java
@@ -13,412 +13,487 @@ import titanicsend.pattern.yoffa.shader_engine.ShaderUtils;
 import titanicsend.util.TE;
 import titanicsend.util.TEMath;
 
-import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 
 import static com.jogamp.opengl.GL.*;
 
 public class GLEngine extends LXComponent implements LXLoopTask, LX.Listener {
-  public static final String PATH = "GLEngine";
-  public static GLEngine current;
+    public static final String PATH = "GLEngine";
+    public static GLEngine current;
 
-  private final int[] audioTextureHandle = new int[1];
-  private final int[] uniformBlockHandles = new int[2];
+    private final int[] audioTextureHandle = new int[1];
+    private final int[] uniformBlockHandles = new int[2];
 
-  // rendering canvas size.  May be changed
-  // via the startup command line.
-  private static int xSize;
-  private static int ySize;
-  private static int maxPoints;
+    // rendering canvas size.  May be changed
+    // via the startup command line.
+    private static int xSize;
+    private static int ySize;
+    private static int maxPoints;
 
-  // Dimensions of mapped texture backbuffer.
-  //
-  // This buffer is never directly rendered by either the GPU or by Java
-  // Instead, the pixel locations corresponding to the lx model's LEDs are
-  // colored at frame time and the buffer is supplied as a read-only sampler
-  // to the shader system.
-  //
-  // So increasing the size of this buffer affects memory usage but does
-  // not affect rendering performance.  The default size is sufficient for
-  // even very large models, but can be increased if necessary.
-  // TODO - make this configurable per pattern or effect.
-  private static final int mappedBufferWidth = 640;
-  private static final int mappedBufferHeight = 640;
-
-  // audio texture size and buffer
-  private static final int audioTextureWidth = 512;
-  private static final int audioTextureHeight = 2;
-  private FloatBuffer audioTextureData;
-
-  // audio data sources & parameters
-  private final GraphicMeter meter;
-  private final float fftResampleFactor;
-  private final TEMath.EMA avgVolume = new TEMath.EMA(0.5, .01);
-  private final TEMath.EMA avgBass = new TEMath.EMA(0.2, .01);
-  private final TEMath.EMA avgTreble = new TEMath.EMA(0.2, .01);
-
-  // audio and related uniform block buffer parameters
-  private FloatBuffer perRunUniformBlock;
-  private int perRunUniformBlockSize;
-  private FloatBuffer perFrameUniformBlock;
-  private int perFrameUniformBlockSize;
-
-  public static final int perRunUniformBlockBinding = 0;
-  public static final int perFrameUniformBlockBinding = 1;
-
-  // Texture cache management
-  private TextureManager textureCache = null;
-  private boolean modelChanged = false;
-
-  private boolean isRunning = false;
-
-  // Data and utility methods for the GL canvas/context.
-  private GLAutoDrawable canvas = null;
-  private GL4 gl4;
-
-  private LXModel model;
-
-  public LXModel getModel() {
-    return model;
-  }
-
-  // Needed for housekeeping, during static-to-dynamic model transition
-  // This lets various shader components know if they're running the static model
-  // and need to swap the x and z axes.
-  // TODO - remove when we move to dynamic model
-  private final boolean isStatic;
-
-  public boolean isStaticModel() {
-    return isStatic;
-  }
-
-  public GLAutoDrawable getCanvas() {
-    return canvas;
-  }
-
-  public static int getWidth() {
-    return xSize;
-  }
-
-  public static int getHeight() {
-    return ySize;
-  }
-
-  public static int getMappedBufferWidth() {
-    return mappedBufferWidth;
-  }
-
-  public static int getMappedBufferHeight() {
-    return mappedBufferHeight;
-  }
-
-  // Utility methods to give java patterns access to the audio texture
-  // should they want it.
-  public FloatBuffer getAudioTextureBuffer() {
-    return audioTextureData;
-  }
-
-  public static int getAudioTextureWidth() {
-    return audioTextureWidth;
-  }
-
-  public static int getAudioTextureHeight() {
-    return audioTextureHeight;
-  }
-
-  /**
-   * Copy a model's normalized coordinates into a special texture for use by shaders. Must be
-   * called by the parent pattern or effect at least once before the first frame is rendered and
-   * Should be called by the pattern's frametime run() function on every frame for full Chromatik view
-   * support.
-   *
-   * @param model The model (view) to copy coordinates from
-   * @return The texture unit number that the view's coordinate texture
-   * is bound to.
-   */
-  public int useViewCoordinates(LXModel model) {
-    return textureCache.useViewCoordinates(model);
-  }
-
-  // Load a static texture from a file and bind it to the next available texture unit
-  // Returns the texture unit number. If the texture is already loaded, just increment
-  // the ref count and return the existing texture unit number.
-  public int useTexture(GL4 gl4, String textureName) {
-    return textureCache.useTexture(gl4, textureName);
-  }
-
-  public void releaseTexture(String textureName) {
-    textureCache.releaseTexture(textureName);
-  }
-
-  // Returns the next available texture unit number, either by reusing a released
-  // texture unit number or by allocating a new one.
-  public int getNextTextureUnit() {
-    return textureCache.getNextTextureUnit();
-  }
-
-  public int releaseTextureUnit(int textureUnit) {
-    return textureCache.releaseTextureUnit(textureUnit);
-  }
-
-  /**
-   * Retrieve a single sample of the current frame's fft data from the engine NOTE: 512 samples can
-   * always be retrieved, regardless of how many bands the engine actually supplies. Data will be
-   * properly distributed (but not smoothed or interpolated) across the full 512 sample range.
-   *
-   * @param index (0-511) of the sample to retrieve.
-   * @return fft sample, normalized to range 0 to 1.
-   */
-  private float getFrequencyData(int index) {
-    return meter.getBandf((int) Math.floor((float) index * fftResampleFactor));
-  }
-
-  /**
-   * Retrieve a single sample of the current frame's waveform data from the engine
-   *
-   * @param index (0-511) of the sample to retrieve
-   * @return waveform sample, range -1 to 1
-   */
-  private float getWaveformData(int index) {
-    return meter.getSamples()[index];
-  }
-
-  /**
-   * Construct texture to hold audio fft and waveform data and bind it to texture unit 0 for the
-   * entire run. Once done, every shader pattern can access the audio data texture with minimal
-   * per-pattern work.
-   */
-  private void initializeAudioTexture() {
-    // allocate backing buffer in native memory
-    this.audioTextureData = GLBuffers.newDirectFloatBuffer(audioTextureHeight * audioTextureWidth);
-
-    // create texture and bind it to texture unit 0, where it will stay for the whole run
-    gl4.glActiveTexture(GL_TEXTURE0);
-    gl4.glEnable(GL_TEXTURE_2D);
-    gl4.glGenTextures(1, audioTextureHandle, 0);
-    gl4.glBindTexture(GL4.GL_TEXTURE_2D, audioTextureHandle[0]);
-
-    // configure texture coordinate handling
-    // TODO - would GL_LINEAR filtering look more interesting here?
-    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-  }
-
-  /**
-   * Update audio texture object with new fft and waveform data. This is called once per frame.
-   */
-  private void updateAudioTexture() {
-    // load frequency and waveform data into our texture buffer, fft data
-    // in the first row, normalized audio waveform data in the second.
-    for (int n = 0; n < audioTextureWidth; n++) {
-      audioTextureData.put(n, getFrequencyData(n));
-      audioTextureData.put(n + audioTextureWidth, getWaveformData(n));
-    }
-
-    // update audio texture on the GPU from our buffer
-    gl4.glActiveTexture(GL_TEXTURE0);
-    gl4.glBindTexture(GL_TEXTURE_2D, audioTextureHandle[0]);
-
-    gl4.glTexImage2D(
-      GL4.GL_TEXTURE_2D,
-      0,
-      GL4.GL_R32F,
-      audioTextureWidth,
-      audioTextureHeight,
-      0,
-      GL4.GL_RED,
-      GL_FLOAT,
-      audioTextureData);
-  }
-
-  /**
-   * Initialize shared uniform blocks. These blocks let us centrally
-   * manage uniforms that are common to all shaders and are only updated once per run,
-   * or once per frame. Keeping a single copy of these uniforms in GPU memory saves space
-   * and reduces the number of uniform setup and data transfer calls needed for each
-   * running shader.
-   */
-  private void initializeUniformBlocks() {
-    // Allocate backing buffer for per run uniforms in native memory
-    // First determine the size of the buffer.  Unfortunately, in Java this
-    // needs to be done manually, as we can't directly get the size of the corresponding
-    // c-language struct. Fortunately, it's not difficult, but the layout rules
-    // must be followed exactly.   If you need to add elements to a uniform block,
-    // see the spec at: http://www.opengl.org/registry/specs/ARB/uniform_buffer_object.txt
+    // Dimensions of mapped texture backbuffer.
     //
-    // At present,we need 6 floats for per run uniforms:
-    // 4 floats for vec4 iMouse
-    // 2 floats for vec2 iResolution
+    // This buffer is never directly rendered by either the GPU or by Java
+    // Instead, the pixel locations corresponding to the lx model's LEDs are
+    // colored at frame time and the buffer is supplied as a read-only sampler
+    // to the shader system.
     //
-    this.perRunUniformBlockSize = 6;
-    this.perRunUniformBlock = GLBuffers.newDirectFloatBuffer(perRunUniformBlockSize);
+    // So increasing the size of this buffer affects memory usage but does
+    // not affect rendering performance.  The default size is sufficient for
+    // even very large models, but can be increased if necessary.
+    // TODO - make this configurable per pattern or effect.
+    private static final int mappedBufferWidth = 640;
+    private static final int mappedBufferHeight = 640;
 
-    // copy data to the perRunUniformBlock buffer
-    // iMouse is not used, but is retained for Shadertoy compatibility.
-    // We'll just zero it out.
-    perRunUniformBlock.put(0, 0f);
-    perRunUniformBlock.put(1, 0f);
-    perRunUniformBlock.put(2, 0f);
-    perRunUniformBlock.put(3, 0f);
+    // audio texture size and buffer
+    private static final int audioTextureWidth = 512;
+    private static final int audioTextureHeight = 2;
+    private FloatBuffer audioTextureData;
 
-    // iResolution is the size of the canvas
-    perRunUniformBlock.put(4, (float) xSize);
-    perRunUniformBlock.put(5, (float) ySize);
+    // audio data sources & parameters
+    private final GraphicMeter meter;
+    private final float fftResampleFactor;
 
-    // Do the same thing for per frame uniforms
-    // The items in the block are, in order:
-    // 1 float for beat
-    // 1 float for sinPhaseBeat
-    // 1 float for bassLevel
-    // 1 float for trebleLevel
-    // 1 float for bassRatio
-    // 1 float for trebleRatio
-    // 1 float for volumeRatio
-    // 1 float for stemBass
-    // 1 float for stemDrums
-    // 1 float for stemVocals
-    // 1 float for stemOther
-    // VERY IMPORTANT NOTE: whatever order this buffer is loaded in MUST be replicated exactly
-    // in the shader framework code's uniform block declaration. Otherwise, the uniforms will not
-    // have the correct values in the shader.
-    this.perFrameUniformBlockSize = 11;
-    this.perFrameUniformBlock = GLBuffers.newDirectFloatBuffer(perFrameUniformBlockSize);
+    private static final TEMath.EMA avgVolume = new TEMath.EMA(0.5, .01);
+    private static final TEMath.EMA avgBass = new TEMath.EMA(0.2, .01);
+    private static final TEMath.EMA avgTreble = new TEMath.EMA(0.2, .01);
 
-    // initialize the buffer with zeros
-    for (int i = 0; i < perFrameUniformBlockSize; i++) {
-      perFrameUniformBlock.put(i, 0f);
+    private static double beat = 0.0;
+    private static double sinPhaseBeat = 0.0;
+    private static double volume = 0.0;
+    private static double bassLevel = 0.0;
+    private static double trebleLevel = 0.0;
+    private static double volumeRatio = 0.0;
+    private static double bassRatio = 0.0;
+    private static double trebleRatio = 0.0;
+
+    // audio and related uniform block buffer parameters
+    private FloatBuffer perRunUniformBlock;
+    private int perRunUniformBlockSize;
+    private FloatBuffer perFrameUniformBlock;
+    private int perFrameUniformBlockSize;
+
+    public static final int perRunUniformBlockBinding = 0;
+    public static final int perFrameUniformBlockBinding = 1;
+
+    // Texture cache management
+    private TextureManager textureCache = null;
+    private boolean modelChanged = false;
+
+    private boolean isRunning = false;
+
+    // Data and utility methods for the GL canvas/context.
+    private GLAutoDrawable canvas = null;
+    private GL4 gl4;
+
+    private LXModel model;
+
+    public LXModel getModel() {
+        return model;
     }
 
-    // Generate the uniform block buffers
-    gl4.glGenBuffers(2, uniformBlockHandles, 0);
+    // Needed for housekeeping, during static-to-dynamic model transition
+    // This lets various shader components know if they're running the static model
+    // and need to swap the x and z axes.
+    // TODO - remove when we move to dynamic model
+    private final boolean isStatic;
 
-    // Bind the per-run uniform block to the buffer and copy it to the GPU
-    gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockBinding, uniformBlockHandles[0], 0, perRunUniformBlockSize * 4);
-    gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockSize * 4, perRunUniformBlock, GL4.GL_DYNAMIC_DRAW);
-
-    // Do the same for the per-frame uniform block and its initial data
-    perFrameUniformBlock.rewind();
-    gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockBinding, uniformBlockHandles[1], 0, perFrameUniformBlockSize * 4);
-    gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockSize * 4, perFrameUniformBlock, GL4.GL_DYNAMIC_DRAW);
-  }
-
-  private void updatePerFrameUniforms(double deltaMs) {
-    // update the per-frame uniform block with the latest audio data
-    double levelMin = 0.01;
-    double beat = lx.engine.tempo.basis();
-
-    // current instantaneous levels of various bands
-    double volume = Math.max(levelMin, meter.getNormalized());
-    double bassLevel = Math.max(levelMin, meter.getAverage(0, 2));
-    double trebleLevel = Math.max(levelMin, meter.getAverage(meter.numBands / 2, meter.numBands / 2));
-
-    // Compute the ratios of current instantaneous levels
-    // to their slow EMAs.  See TEAudioPattern.java for more info.
-    double volumeRatio = volume / avgVolume.update(volume, deltaMs);
-    double bassRatio = bassLevel / avgBass.update(bassLevel, deltaMs);
-    double trebleRatio = trebleLevel / avgTreble.update(trebleLevel, deltaMs);
-
-    perFrameUniformBlock.put((float) beat);                        // beat
-    perFrameUniformBlock.put((float) (0.5 + 0.5 * Math.sin(Math.PI * beat))); // sinPhaseBeat
-    perFrameUniformBlock.put((float) bassLevel);                   // bassLevel
-    perFrameUniformBlock.put((float) trebleLevel);                 // trebleLevel
-    perFrameUniformBlock.put((float) bassRatio);                   // bassRatio
-    perFrameUniformBlock.put((float) trebleRatio);                 // trebleRatio
-    perFrameUniformBlock.put((float) volumeRatio);                 // volumeRatio
-    perFrameUniformBlock.put(AudioStems.get().bass.getValuef());   // stemBass
-    perFrameUniformBlock.put(AudioStems.get().drums.getValuef());  // stemDrums
-    perFrameUniformBlock.put(AudioStems.get().vocals.getValuef()); // stemVocals
-    perFrameUniformBlock.put(AudioStems.get().other.getValuef());  // stemOther
-
-    // update the GPU buffer with the new data
-    perFrameUniformBlock.rewind();
-    gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
-    gl4.glBufferSubData(GL4.GL_UNIFORM_BUFFER, 0, perFrameUniformBlockSize * 4, perFrameUniformBlock);
-  }
-
-  public GLEngine(LX lx, int width, int height, boolean isStaticModel) {
-    current = this;
-    // The shape the user gives us affects the rendered aspect ratio,
-    // but what really matters is that it needs to have room for the
-    // largest number of points we're going to encounter during a run.
-    // TODO - adjust buffer size & shape dynamically as the model changes.
-    // TODO - this will require a lot of GPU memory management, so is
-    // TODO - a longer-term goal.
-    xSize = width;
-    ySize = height;
-
-    maxPoints = xSize * ySize;
-    TE.log("GLEngine: Rendering canvas size: " + xSize + "x" + ySize + " = " + GLEngine.maxPoints + " total points");
-
-    // register glEngine so we can access it from patterns.
-    // and add it as an engine task for audio analysis and buffer management
-    lx.engine.registerComponent(PATH, this);
-    lx.engine.addLoopTask(this);
-
-    this.isStatic = isStaticModel;
-    this.model = lx.getModel();
-
-    // set up audio fft and waveform handling
-    // TODO - strongly consider expanding the number of FFT bands.
-    // TODO - LX defaults to 16, but more bands would let us do more
-    // TODO - interesting audio analysis.
-    this.meter = lx.engine.audio.meter;
-    fftResampleFactor = meter.bands.length / 512f;
-  }
-
-  @Override
-  public void modelGenerationChanged(LX lx, LXModel model) {
-    this.model = model;
-    this.modelChanged = true;
-  }
-
-  public void loop(double deltaMs) {
-
-    // On first frame...
-    if (canvas == null) {
-      // create and initialize offscreen drawable for gl rendering
-      canvas = ShaderUtils.createGLSurface(xSize, ySize);
-      canvas.display();
-      gl4 = canvas.getGL().getGL4();
-
-      // activate our context and do initialization tasks
-      canvas.getContext().makeCurrent();
-
-      // set up shared uniform blocks
-      initializeUniformBlocks();
-
-      // set up the per-frame audio info texture
-      initializeAudioTexture();
-      textureCache = new TextureManager(gl4);
-
-      // start listening for model changes
-      lx.addListener(this);
-
-      // set running flag once initialization is complete
-      isRunning = true;
+    public boolean isStaticModel() {
+        return isStatic;
     }
 
-    // On every frame, after initial setup
-    if (isRunning) {
-      // activate our context and do per-frame tasks
-      canvas.getContext().makeCurrent();
-      updateAudioTexture();
-      updatePerFrameUniforms(deltaMs);
-
-      if (modelChanged) {
-        // if the model has changed, discard all existing view coordinate textures
-        textureCache.clearCoordinateTextures();
-        modelChanged = false;
-      }
-
+    public GLAutoDrawable getCanvas() {
+        return canvas;
     }
-  }
 
-  public void dispose() {
-    // free GPU resources that we directly allocated
-    gl4.glDeleteTextures(audioTextureHandle.length, audioTextureHandle, 0);
-    gl4.glDeleteBuffers(uniformBlockHandles.length, uniformBlockHandles, 0);
-  }
+    public static int getWidth() {
+        return xSize;
+    }
+
+    public static int getHeight() {
+        return ySize;
+    }
+
+    public static int getMappedBufferWidth() {
+        return mappedBufferWidth;
+    }
+
+    public static int getMappedBufferHeight() {
+        return mappedBufferHeight;
+    }
+
+    // Utility methods to give java patterns access to the audio texture
+    // should they want it.
+    public FloatBuffer getAudioTextureBuffer() {
+        return audioTextureData;
+    }
+
+    public static int getAudioTextureWidth() {
+        return audioTextureWidth;
+    }
+
+    public static int getAudioTextureHeight() {
+        return audioTextureHeight;
+    }
+
+    /**
+     * Copy a model's normalized coordinates into a special texture for use by shaders. Must be
+     * called by the parent pattern or effect at least once before the first frame is rendered and
+     * Should be called by the pattern's frametime run() function on every frame for full Chromatik view
+     * support.
+     *
+     * @param model The model (view) to copy coordinates from
+     * @return The texture unit number that the view's coordinate texture
+     * is bound to.
+     */
+    public int useViewCoordinates(LXModel model) {
+        return textureCache.useViewCoordinates(model);
+    }
+
+    // Load a static texture from a file and bind it to the next available texture unit
+    // Returns the texture unit number. If the texture is already loaded, just increment
+    // the ref count and return the existing texture unit number.
+    public int useTexture(GL4 gl4, String textureName) {
+        return textureCache.useTexture(gl4, textureName);
+    }
+
+    public void releaseTexture(String textureName) {
+        textureCache.releaseTexture(textureName);
+    }
+
+    // Returns the next available texture unit number, either by reusing a released
+    // texture unit number or by allocating a new one.
+    public int getNextTextureUnit() {
+        return textureCache.getNextTextureUnit();
+    }
+
+    public int releaseTextureUnit(int textureUnit) {
+        return textureCache.releaseTextureUnit(textureUnit);
+    }
+
+    /**
+     * Retrieve a single sample of the current frame's fft data from the engine NOTE: 512 samples can
+     * always be retrieved, regardless of how many bands the engine actually supplies. Data will be
+     * properly distributed (but not smoothed or interpolated) across the full 512 sample range.
+     *
+     * @param index (0-511) of the sample to retrieve.
+     * @return fft sample, normalized to range 0 to 1.
+     */
+    private float getFrequencyData(int index) {
+        return meter.getBandf((int) Math.floor((float) index * fftResampleFactor));
+    }
+
+    /**
+     * Retrieve a single sample of the current frame's waveform data from the engine
+     *
+     * @param index (0-511) of the sample to retrieve
+     * @return waveform sample, range -1 to 1
+     */
+    private float getWaveformData(int index) {
+        return meter.getSamples()[index];
+    }
+
+    /**
+     * Construct texture to hold audio fft and waveform data and bind it to texture unit 0 for the
+     * entire run. Once done, every shader pattern can access the audio data texture with minimal
+     * per-pattern work.
+     */
+    private void initializeAudioTexture() {
+        // allocate backing buffer in native memory
+        this.audioTextureData = GLBuffers.newDirectFloatBuffer(audioTextureHeight * audioTextureWidth);
+
+        // create texture and bind it to texture unit 0, where it will stay for the whole run
+        gl4.glActiveTexture(GL_TEXTURE0);
+        gl4.glEnable(GL_TEXTURE_2D);
+        gl4.glGenTextures(1, audioTextureHandle, 0);
+        gl4.glBindTexture(GL4.GL_TEXTURE_2D, audioTextureHandle[0]);
+
+        // configure texture coordinate handling
+        // TODO - would GL_LINEAR filtering look more interesting here?
+        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    }
+
+    /**
+     * Update audio texture object with new fft and waveform data. This is called once per frame.
+     */
+    private void updateAudioTexture() {
+        // load frequency and waveform data into our texture buffer, fft data
+        // in the first row, normalized audio waveform data in the second.
+        for (int n = 0; n < audioTextureWidth; n++) {
+            audioTextureData.put(n, getFrequencyData(n));
+            audioTextureData.put(n + audioTextureWidth, getWaveformData(n));
+        }
+
+        // update audio texture on the GPU from our buffer
+        gl4.glActiveTexture(GL_TEXTURE0);
+        gl4.glBindTexture(GL_TEXTURE_2D, audioTextureHandle[0]);
+
+        gl4.glTexImage2D(
+                GL4.GL_TEXTURE_2D,
+                0,
+                GL4.GL_R32F,
+                audioTextureWidth,
+                audioTextureHeight,
+                0,
+                GL4.GL_RED,
+                GL_FLOAT,
+                audioTextureData);
+    }
+
+    /**
+     * Return a properly aligned size for a uniform block. This is necessary, particularly on
+     * macOS, where the size of a uniform block must be a multiple of GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT.
+     * (NVidia drivers on Windows and Linux are more forgiving.  I always discover things like this the
+     * hard way!)
+     *
+     * @param elements The number of 4-byte elements in the uniform block
+     * @return The size of the uniform block in bytes, aligned to the GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT
+     */
+    private int getUBOAlignedSize(int elements) {
+        int[] alignment = new int[1];
+        gl4.glGetIntegerv(GL4.GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT, alignment, 0);
+        return ((elements * 4) + alignment[0] - 1) & ~(alignment[0] - 1);
+    }
+
+    /**
+     * Initialize shared uniform blocks. These blocks let us centrally
+     * manage uniforms that are common to all shaders and are only updated once per run,
+     * or once per frame. Keeping a single copy of these uniforms in GPU memory saves space
+     * and reduces the number of uniform setup and data transfer calls needed for each
+     * running shader.
+     */
+    private void initializeUniformBlocks() {
+
+        // Allocate backing buffer for per run uniforms in native memory
+        // First determine the size of the buffer.  Unfortunately, in Java this
+        // needs to be done manually, as we can't directly get the size of the corresponding
+        // c-language struct. Fortunately, it's not difficult, but the layout rules
+        // must be followed exactly.   If you need to add elements to a uniform block,
+        // see the spec at: http://www.opengl.org/registry/specs/ARB/uniform_buffer_object.txt
+        //
+
+        // At present,we need 6 floats for per run uniforms:
+        // 4 floats for vec4 iMouse
+        // 2 floats for vec2 iResolution
+        //
+        this.perRunUniformBlockSize = getUBOAlignedSize(6);
+        this.perRunUniformBlock = GLBuffers.newDirectFloatBuffer(perRunUniformBlockSize / 4);
+
+        // copy data to the perRunUniformBlock buffer
+        // iMouse is not used, but is retained for Shadertoy compatibility.
+        // We'll just zero it out.
+        perRunUniformBlock.put(0, 0f);
+        perRunUniformBlock.put(1, 0f);
+        perRunUniformBlock.put(2, 0f);
+        perRunUniformBlock.put(3, 0f);
+
+        // iResolution is the size of the canvas
+        perRunUniformBlock.put(4, (float) xSize);
+        perRunUniformBlock.put(5, (float) ySize);
+
+        // Do the same thing for per frame uniforms
+        // The items in the block are, in order:
+        // 1 float for beat
+        // 1 float for sinPhaseBeat
+        // 1 float for bassLevel
+        // 1 float for trebleLevel
+        // 1 float for bassRatio
+        // 1 float for trebleRatio
+        // 1 float for volumeRatio
+        // 1 float for stemBass
+        // 1 float for stemDrums
+        // 1 float for stemVocals
+        // 1 float for stemOther
+        // VERY IMPORTANT NOTE: whatever order this buffer is loaded in MUST be replicated exactly
+        // in the shader framework code's uniform block declaration. Otherwise, the uniforms will not
+        // have the correct values in the shader.
+        this.perFrameUniformBlockSize = getUBOAlignedSize(11);
+        this.perFrameUniformBlock = GLBuffers.newDirectFloatBuffer(perFrameUniformBlockSize / 4);
+
+        // Generate the uniform block buffers
+        gl4.glGenBuffers(2, uniformBlockHandles, 0);
+
+        // Bind the per-run uniform block to the gl buffer object
+        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[0]);
+
+        // copy the per-run uniform block data to the buffer
+        gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockSize, perRunUniformBlock, GL4.GL_DYNAMIC_DRAW);
+        gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perRunUniformBlockBinding, uniformBlockHandles[0], 0, perRunUniformBlockSize);
+
+        // Do the same for the per-frame uniform block and its initial data
+        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
+        gl4.glBufferData(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockSize, perFrameUniformBlock, GL4.GL_DYNAMIC_DRAW);
+        gl4.glBindBufferRange(GL4.GL_UNIFORM_BUFFER, perFrameUniformBlockBinding, uniformBlockHandles[1], 0, perFrameUniformBlockSize);
+    }
+
+    private void updatePerFrameUniforms(double deltaMs) {
+        // update the per-frame uniform block with the latest audio data
+        double levelMin = 0.01;
+
+        beat = lx.engine.tempo.basis();
+        sinPhaseBeat = 0.5 + 0.5 * Math.sin(Math.PI * beat);
+
+        // current instantaneous levels of various bands
+        volume = Math.max(levelMin, meter.getNormalized());
+        bassLevel = Math.max(levelMin, meter.getAverage(0, 2));
+        trebleLevel = Math.max(levelMin, meter.getAverage(meter.numBands / 2, meter.numBands / 2));
+
+        // Compute the ratios of current instantaneous levels
+        // to their slow EMAs.  See TEAudioPattern.java for more info.
+        volumeRatio = volume / avgVolume.update(volume, deltaMs);
+        bassRatio = bassLevel / avgBass.update(bassLevel, deltaMs);
+        trebleRatio = trebleLevel / avgTreble.update(trebleLevel, deltaMs);
+
+        perFrameUniformBlock.put((float) beat);                        // beat
+        perFrameUniformBlock.put((float) sinPhaseBeat);                // sinPhaseBeat
+        perFrameUniformBlock.put((float) bassLevel);                   // bassLevel
+        perFrameUniformBlock.put((float) trebleLevel);                 // trebleLevel
+        perFrameUniformBlock.put((float) bassRatio);                   // bassRatio
+        perFrameUniformBlock.put((float) trebleRatio);                 // trebleRatio
+        perFrameUniformBlock.put((float) volumeRatio);                 // volumeRatio
+        perFrameUniformBlock.put(AudioStems.get().bass.getValuef());   // stemBass
+        perFrameUniformBlock.put(AudioStems.get().drums.getValuef());  // stemDrums
+        perFrameUniformBlock.put(AudioStems.get().vocals.getValuef()); // stemVocals
+        perFrameUniformBlock.put(AudioStems.get().other.getValuef());  // stemOther
+
+        // update the GPU buffer with the new data
+        perFrameUniformBlock.rewind();
+        gl4.glBindBuffer(GL4.GL_UNIFORM_BUFFER, uniformBlockHandles[1]);
+        gl4.glBufferSubData(GL4.GL_UNIFORM_BUFFER, 0, perFrameUniformBlockSize, perFrameUniformBlock);
+    }
+
+    public GLEngine(LX lx, int width, int height, boolean isStaticModel) {
+        current = this;
+        // The shape the user gives us affects the rendered aspect ratio,
+        // but what really matters is that it needs to have room for the
+        // largest number of points we're going to encounter during a run.
+        // TODO - adjust buffer size & shape dynamically as the model changes.
+        // TODO - this will require a lot of GPU memory management, so is
+        // TODO - a longer-term goal.
+        xSize = width;
+        ySize = height;
+
+        maxPoints = xSize * ySize;
+        TE.log("GLEngine: Rendering canvas size: " + xSize + "x" + ySize + " = " + GLEngine.maxPoints + " total points");
+
+        // register glEngine so we can access it from patterns.
+        // and add it as an engine task for audio analysis and buffer management
+        lx.engine.registerComponent(PATH, this);
+        lx.engine.addLoopTask(this);
+
+        this.isStatic = isStaticModel;
+        this.model = lx.getModel();
+
+        // set up audio fft and waveform handling
+        // TODO - strongly consider expanding the number of FFT bands.
+        // TODO - LX defaults to 16, but more bands would let us do more
+        // TODO - interesting audio analysis.
+        this.meter = lx.engine.audio.meter;
+        fftResampleFactor = meter.bands.length / 512f;
+    }
+
+    @Override
+    public void modelGenerationChanged(LX lx, LXModel model) {
+        this.model = model;
+        this.modelChanged = true;
+    }
+
+    public void loop(double deltaMs) {
+
+        // On first frame...
+        if (canvas == null) {
+            // create and initialize offscreen drawable for gl rendering
+            canvas = ShaderUtils.createGLSurface(xSize, ySize);
+            canvas.display();
+            gl4 = canvas.getGL().getGL4();
+
+            // activate our context and do initialization tasks
+            canvas.getContext().makeCurrent();
+
+            // set up shared uniform blocks
+            initializeUniformBlocks();
+
+            // set up the per-frame audio info texture
+            initializeAudioTexture();
+            textureCache = new TextureManager(gl4);
+
+            // start listening for model changes
+            lx.addListener(this);
+
+            // set running flag once initialization is complete
+            isRunning = true;
+        }
+
+        // On every frame, after initial setup
+        if (isRunning) {
+            // activate our context and do per-frame tasks
+            canvas.getContext().makeCurrent();
+            updateAudioTexture();
+            updatePerFrameUniforms(deltaMs);
+
+            if (modelChanged) {
+                // if the model has changed, discard all existing view coordinate textures
+                textureCache.clearCoordinateTextures();
+                modelChanged = false;
+            }
+
+        }
+    }
+
+    public void dispose() {
+        // free GPU resources that we directly allocated
+        gl4.glDeleteTextures(audioTextureHandle.length, audioTextureHandle, 0);
+        gl4.glDeleteBuffers(uniformBlockHandles.length, uniformBlockHandles, 0);
+    }
+
+    // Static getters for per-frame audio parameters
+    // TEPattern and derived pattern classes can access these, which are evaluated
+    // only once per frame, instead of recalculating the values for every running pattern
+    // instance.
+    public static double getAvgVolume() {
+        return avgVolume.getValue();
+    }
+
+    public static double getAvgBass() {
+        return avgBass.getValue();
+    }
+
+    public static double getAvgTreble() {
+        return avgTreble.getValue();
+    }
+
+    public static double getBeat() {
+        return beat;
+    }
+
+    public static double getSinPhaseOnBeat() {
+        return sinPhaseBeat;
+    }
+
+    public static double getVolume() {
+        return volume;
+    }
+
+    public static double getBassLevel() {
+        return bassLevel;
+    }
+
+    public static double getTrebleLevel() {
+        return trebleLevel;
+    }
+
+    public static double getVolumeRatio() {
+        return volumeRatio;
+    }
+
+    public static double getBassRatio() {
+        return bassRatio;
+    }
+
+    public static double getTrebleRatio() {
+        return trebleRatio;
+    }
+
 }

--- a/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
@@ -15,28 +15,6 @@ public class GLPatternControl implements GLControlData {
   public void setUniforms(GLShader s) {
     // set standard shadertoy-style uniforms
     s.setUniform("iTime", (float) pattern.getTime());
-    s.setUniform("iResolution", (float) GLEngine.getWidth(), (float) GLEngine.getHeight());
-    // s.setUniform("iMouse", 0f, 0f, 0f, 0f);
-
-    // TE standard audio uniforms
-    s.setUniform("beat", (float) pattern.getTempo().basis());
-    s.setUniform("sinPhaseBeat", (float) pattern.sinePhaseOnBeat());
-    s.setUniform("bassLevel", (float) pattern.getBassLevel());
-    s.setUniform("trebleLevel", (float) pattern.getTrebleLevel());
-
-    // added by @look
-    s.setUniform("bassRatio", (float) pattern.getBassRatio());
-    s.setUniform("trebleRatio", (float) pattern.getTrebleRatio());
-    s.setUniform("volumeRatio", pattern.getVolumeRatiof());
-
-    s.setUniform("levelReact", (float) pattern.getLevelReactivity());
-    s.setUniform("frequencyReact", (float) pattern.getFrequencyReactivity());
-
-    // Current values from audio stems
-    s.setUniform("stemBass", (float) AudioStems.get().bass.getValuef());
-    s.setUniform("stemDrums", (float) AudioStems.get().drums.getValuef());
-    s.setUniform("stemVocals", (float) AudioStems.get().vocals.getValuef());
-    s.setUniform("stemOther", (float) AudioStems.get().other.getValuef());
 
     // color-related uniforms
     int col = pattern.calcColor();
@@ -66,5 +44,7 @@ public class GLPatternControl implements GLControlData {
     s.setUniform("iWow1", (float) pattern.getWow1());
     s.setUniform("iWow2", (float) pattern.getWow2());
     s.setUniform("iWowTrigger", pattern.getWowTrigger());
+    s.setUniform("levelReact", (float) pattern.getLevelReactivity());
+    s.setUniform("frequencyReact", (float) pattern.getFrequencyReactivity());
   }
 }

--- a/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -382,6 +382,13 @@ public class GLShader {
 
       gl4.glBindTexture(GL_TEXTURE_2D, 0);
     }
+
+    // assign uniform blocks to binding points
+    int perRunBlockIndex = gl4.glGetUniformBlockIndex(shaderProgram.getProgramId(), "PerRunBlock");
+    gl4.glUniformBlockBinding(shaderProgram.getProgramId(), perRunBlockIndex, GLEngine.perRunUniformBlockBinding);
+
+    int perFrameBlockIndex = gl4.glGetUniformBlockIndex(shaderProgram.getProgramId(), "PerFrameBlock");
+    gl4.glUniformBlockBinding(shaderProgram.getProgramId(), perFrameBlockIndex, GLEngine.perFrameUniformBlockBinding);
   }
 
   /**

--- a/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -383,7 +383,7 @@ public class GLShader {
       gl4.glBindTexture(GL_TEXTURE_2D, 0);
     }
 
-    // assign uniform blocks to binding points
+    // assign shared uniform blocks to the shader's binding points
     int perRunBlockIndex = gl4.glGetUniformBlockIndex(shaderProgram.getProgramId(), "PerRunBlock");
     gl4.glUniformBlockBinding(shaderProgram.getProgramId(), perRunBlockIndex, GLEngine.perRunUniformBlockBinding);
 

--- a/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -23,9 +23,6 @@ public class TurbulenceLines extends DriftEnabledPattern {
     controls.setValue(TEControlTag.XPOS, 0.25);
     controls.setValue(TEControlTag.YPOS, -0.25);
 
-    // let the bass averaging filter respond a little faster
-    avgBass.alpha = 0.02;
-
     // register common controls with LX
     addCommonControls();
 

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioLevels.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.look;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.glengine.GLEngine;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
@@ -27,7 +28,7 @@ public class SigmoidDanceAudioLevels extends GLShaderPattern {
         new GLShaderFrameSetup() {
           @Override
           public void OnFrame(GLShader s) {
-            s.setUniform("avgVolume", avgVolume.getValuef());
+            s.setUniform("avgVolume", (float) GLEngine.getAvgVolume());
           }
         });
   }

--- a/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
+++ b/src/main/java/titanicsend/pattern/look/SigmoidDanceAudioWaveform.java
@@ -2,6 +2,7 @@ package titanicsend.pattern.look;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import titanicsend.pattern.glengine.GLEngine;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
@@ -27,7 +28,7 @@ public class SigmoidDanceAudioWaveform extends GLShaderPattern {
         new GLShaderFrameSetup() {
           @Override
           public void OnFrame(GLShader s) {
-            s.setUniform("avgVolume", avgVolume.getValuef());
+            s.setUniform("avgVolume", (float) GLEngine.getAvgVolume());
           }
         });
   }


### PR DESCRIPTION
Mostly about the docs, plus a couple of efficiency improvements that I've been wanting to do for a while.

### Documentation Update
Shader documentation for authors in /resources/docs/ShaderFrameWork.md has been updated with all the
3D renderer's changes and enhancements.

### Refactored Audio Calculations
Most of the audio data used by shaders and other patterns is now updated in the engine, once per frame, rather than
being recalculated for every running pattern on every frame.   

### Implemented Shared Uniform Blocks
Another time/memory saver. Uniform blocks allow all shaders to share a single set of uniforms - in this case two blocks are shared:

- PerRunUniforms:  Things like resolution that are set at startup and persist through an entire run.
- PerFrameUniforms:  In our case, mostly audio data, which is only updated once per frame but is needed by all shaders.

Previously each shader needed its own copy of this data, set as a uniform variable.  It's not really that much data, but it winds up being a lot of per-shader function calls to collect that data and move it to the GPU.  (I think it wound up being around 12 variables, w/2 function calls each to set up the uniforms. So for each shader, at 60 fps, that's 1440 function calls/sec that we're no longer doing.)

With uniform blocks, the data is only moved once per frame, as a unit.  No per-frame work at all is required from the individual shaders.