### PR TITLE
minor README formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Want a personal intro to the project and codebase? Contact current team lead [An
 <details>
     <summary>What if I want to know more?</summary>
     <p>This doc sets out the project vision and has much more information: <a href="https://docs.google.com/document/d/1YK9umrhOodwnRWGRzYOR1iOocrO6Cf9ZpHF7FWgBKKI/edit#">2022 Lighting Design Doc</a></p>
-    <p>Team members can reference several docs on our Notion for more background including [Networking and Front of House](https://www.notion.so/titanicsend/Networking-and-Front-of-House-Setup-fe5360a00b594955b735e02115548ff4) and [Software / Integration Hub](https://www.notion.so/titanicsend/2023-Lighting-Software-Integration-61c9cd5c6e884c6db66d4f843a1b8812).</p>
+    <p>Team members can reference several docs on our Notion for more background including <a href="https://www.notion.so/titanicsend/Networking-and-Front-of-House-Setup-fe5360a00b594955b735e02115548ff4">Networking and Front of House</a> and <a href="https://www.notion.so/titanicsend/2023-Lighting-Software-Integration-61c9cd5c6e884c6db66d4f843a1b8812">Software / Integration Hub</a>.</p>
 </details>
 
 ## JDK Installation
@@ -48,7 +48,7 @@ Steps for setup:
    git clone https://github.com/titanicsend/LXStudio-TE.git
    ```
 
-2. Open the project director you cloned to when you're presented with "New Project" and
+2. Open the project directory you cloned to when you're presented with "New Project" and
    "Open" options. That's the initial screen.
 
 3. File → Project Structure (or ⌘-;)
@@ -88,7 +88,7 @@ cp pre-commit ./git/hooks/pre-commit
 
 Now commits will fail if there's a style violation, since this runs `mvn spotless:check`.
 
-YOu can manually apply formatting fixes using `mvn spotless:apply`.
+You can manually apply formatting fixes using `mvn spotless:apply`.
 
 2. (Optional) Install the IDE plugin
    for [IntelliJ](https://github.com/google/google-java-format#intellij-android-studio-and-other-jetbrains-ides)

--- a/resources/docs/CommonControls.md
+++ b/resources/docs/CommonControls.md
@@ -6,7 +6,7 @@
 made using ConstructedPattern)
 - In your constructor use the ```control.setXXX(TECommonControlTag.xxx,value(s)...)``` helper functions to configure the controls
 as needed. 
-- Once your've configured the common controls, call ```addCommonControls()``` from your constructor to register them
+- Once you've configured the common controls, call ```addCommonControls()``` from your constructor to register them
 with the UI.
 - If your pattern has any additional controls, you should also add them in your constructor, after the call to
 - ```addCommonControls``` so the UI will be consistent across all patterns.  
@@ -98,7 +98,7 @@ default getter function, or to replace the control with a completely new one.
 using the default getter function for the specified control type.
 - ```void setControl(TEControlTag tag,LXListenableParameter lxp,_CommonControlGetter getFn)```  - installs a
 new control and a custom getter function for the specified control type.
-- ```void SetGetterFunction(TEControlTag tag, _CommonControlGetter getFn```)  - installs a custom getter function
+- ```void setGetterFunction(TEControlTag tag, _CommonControlGetter getFn)```  - installs a custom getter function
 for the specified existing control.
 
 For example, to make a custom getter function for the speed control, first define it:
@@ -107,7 +107,7 @@ For example, to make a custom getter function for the speed control, first defin
  return ctl.getValuef(); }
 }
 ```
-Then call ```SetGetterFunction(TEControlTag.SPEED, myNewGetter)``` to install it, and everything that
+Then call ```setGetterFunction(TEControlTag.SPEED, myNewGetter)``` to install it, and everything that
 uses ```TEPerformancePattern.getSpeed()``` will be calling your new function.
 
 To completely replace the speed control, define a new control that can be cast to LXListenableParameter, build a getter,
@@ -137,7 +137,7 @@ other events.  Starts the next variable clock "second" when called.
 ```int getPrimaryGradientColor(lerp)``` Returns a color interpolated from the palette's primary gradient,
 with brightness modified by the Brightness control.
 
-```int getSecondaryGradientColor(lerp``` Returns a color interpolated from the palette's secondary gradient,
+```int getSecondaryGradientColor(lerp)``` Returns a color interpolated from the palette's secondary gradient,
 with brightness modified by the brightness control.
 
 ### Speed and Spin:  Tempo Linked Parameters

--- a/resources/docs/ShaderFramework.md
+++ b/resources/docs/ShaderFramework.md
@@ -376,7 +376,7 @@ from the pattern browser panel.
 //...or...
 #include <library/file.fs>// prefixes with default resource path
 
-// Use the automatic wrapper for ths shader. Recommended, but only required if you
+// Use the automatic wrapper for this shader. Recommended, but only required if you
 // use no other configuration pragmas. 
 #pragma auto 
 
@@ -658,7 +658,7 @@ shader as a texture. The last shader in the sequence is the one that actually dr
 the frame.
 
 To create a multipass pattern, derive your pattern class from ```GLShaderPattern```  
-and configure your controls as described above. Then,before adding any shaders, you must
+and configure your controls as described above. Then, before adding any shaders, you must
 create shared backing store for the intermediate results. The ```GLShader``` class provides
 a function for doing this:
 

--- a/resources/vehicle/Silhouette Edge IDs.txt
+++ b/resources/vehicle/Silhouette Edge IDs.txt
@@ -1,6 +1,6 @@
 These are lists of edge IDs (with the dash omitted) that comprise the car's silhouette, front and back. 
 
-We found at Burning Man 2022 that we almost always wanted these lit up to help people find us from a distance. At shows where the iceberg is ore of a stationary stage, we will probably not want these always lit.
+We found at Burning Man 2022 that we almost always wanted these lit up to help people find us from a distance. At shows where the iceberg is more of a stationary stage, we will probably not want these always lit.
 
 To use these, apply the list as ViewSelectors to a new LX channel (typically labeled "Outline" or "Silhouette"). You can apply something like SolidPattern to these fixtures.
 

--- a/resources/vehicle/views.txt
+++ b/resources/vehicle/views.txt
@@ -12,7 +12,7 @@ Outline;	true	113117;28113;28111;111119;118119;30118;3033;3337;37123;45123;45122
 Outline DJ	true	11-98,98-99,99-101,44-101,44-47,47-90,67-90,65-67
 Outline DJ;	true	11-98;98-99;99-101;44-101;44-47;47-90;67-90;65-67
 #
-# These is how you make a shortcut to the tags.properties file, which is a list of tags and fixtures to which they should be applied:
+# This is how you make a shortcut to the tags.properties file, which is a list of tags and fixtures to which they should be applied:
 # DJ Area Edges	true	dj-e
 #
 # Back Upper is useful for finding the car from behind on playa


### PR DESCRIPTION
`README.md`
1. In the Notion link section, there was a markdown formatting issue with square brackets inside paragraph tags
2. In the "Getting started" section, there was a typo: "project director" should be "project directory"
3. In the "Code Style" section, there was a typo: "YOu" should be "You"

`resources/docs/CommonControls.md`
1. Changed "Once your've" to "Once you've"
2. Added missing parentheses to "addCommonControls()"
3. Fixed the case in "SetGetterFunction" to "setGetterFunction" to match camelCase convention
4. Added missing parenthesis in "getSecondaryGradientColor(lerp)"

`resources/docs/ShaderFramework.md`
1. Changed "ths" to "this" in the automatic wrapper comment
2. Fixed spacing in "Then, before" in the multipass rendering section

`resources/vehicle/Silhouette Edge IDs.txt`
1. fixed the typo by changing "ore" to "more".

`resources/vehicle/views.txt`
1. fixed the typo by changing "These is" to "This is"
