### PR TITLE
Fix package for audio EMA

### DIFF
--- a/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
+++ b/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
@@ -13,7 +13,7 @@ import heronarts.lx.parameter.*;
 import heronarts.lx.studio.LXStudio;
 import heronarts.lx.studio.ui.modulation.UIModulator;
 import heronarts.lx.studio.ui.modulation.UIModulatorControls;
-import titanicsend.util.EMA;
+import titanicsend.audio.util.EMA;
 
 @LXModulator.Global("Audio Stem")
 @LXModulator.Device("Audio Stem")

--- a/audio-stems/src/main/java/titanicsend/audio/util/EMA.java
+++ b/audio-stems/src/main/java/titanicsend/audio/util/EMA.java
@@ -1,4 +1,4 @@
-package titanicsend.util;
+package titanicsend.audio.util;
 
 /** Exponential Moving Average with adjustable smoothing time */
 public class EMA {


### PR DESCRIPTION
Missed a package name when refactoring audio-stems to a maven module.