### PR TITLE
refactor(TECommonControls): allow adding extraParams

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -5,10 +5,12 @@ import heronarts.lx.LX;
 import heronarts.lx.LXComponent;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.parameter.BoundedParameter;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import java.nio.FloatBuffer;
 import java.util.List;
+import java.util.Map;
 import titanicsend.app.TEGlobalPatternControls;
 import titanicsend.pattern.glengine.ShaderConfiguration;
 import titanicsend.pattern.jon.TEControlTag;
@@ -48,8 +50,13 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
   }
 
   protected TEPerformancePattern(LX lx, TEShaderView defaultView) {
+    this(lx, defaultView, null);
+  }
+
+  protected TEPerformancePattern(
+      LX lx, TEShaderView defaultView, Map<String, LXListenableNormalizedParameter> extraParams) {
     super(lx);
-    controls = new TECommonControls(this);
+    controls = new TECommonControls(this, extraParams);
 
     this.defaultView = defaultView;
 
@@ -325,6 +332,10 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
 
   public double getFrequencyReactivity() {
     return controls.getValue(TEControlTag.FREQREACTIVITY);
+  }
+
+  public Map<String, LXListenableNormalizedParameter> getExtraParams() {
+    return this.controls.extraParams;
   }
 
   /**

--- a/te-app/src/main/java/titanicsend/pattern/glengine/ConstructedShaderPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/ConstructedShaderPattern.java
@@ -1,13 +1,20 @@
 package titanicsend.pattern.glengine;
 
 import heronarts.lx.LX;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
+import java.util.Map;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 public abstract class ConstructedShaderPattern extends GLShaderPattern {
 
   protected ConstructedShaderPattern(LX lx, TEShaderView defaultView) {
-    super(lx, defaultView);
+    this(lx, defaultView, null);
+  }
+
+  protected ConstructedShaderPattern(
+      LX lx, TEShaderView defaultView, Map<String, LXListenableNormalizedParameter> extraParams) {
+    super(lx, defaultView, extraParams);
 
     // create the OpenGL shaders and add them to the pattern
     createShader();

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLPatternControl.java
@@ -1,6 +1,8 @@
 package titanicsend.pattern.glengine;
 
 import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import java.util.Map;
 import titanicsend.color.TEColorParameter;
 import titanicsend.pattern.TEPerformancePattern;
 
@@ -50,5 +52,15 @@ public class GLPatternControl implements GLControlData {
     s.setUniform("iWowTrigger", pattern.getWowTrigger());
     s.setUniform("levelReact", (float) pattern.getLevelReactivity());
     s.setUniform("frequencyReact", (float) pattern.getFrequencyReactivity());
+
+    if (pattern.getExtraParams() != null) {
+      for (Map.Entry<String, LXListenableNormalizedParameter> entry :
+          pattern.getExtraParams().entrySet()) {
+        String paramName = entry.getKey();
+        LXListenableNormalizedParameter param = entry.getValue();
+        // TODO(look): smarter typing based on parameter class?
+        s.setUniform(paramName, param.getValuef());
+      }
+    }
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -2,8 +2,10 @@ package titanicsend.pattern.glengine;
 
 import heronarts.lx.LX;
 import heronarts.lx.model.LXModel;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Map;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
@@ -44,7 +46,12 @@ public class GLShaderPattern extends TEPerformancePattern {
   }
 
   public GLShaderPattern(LX lx, TEShaderView view) {
-    super(lx, view);
+    this(lx, view, null);
+  }
+
+  public GLShaderPattern(
+      LX lx, TEShaderView view, Map<String, LXListenableNormalizedParameter> extraParams) {
+    super(lx, view, extraParams);
     controlData = new GLPatternControl(this);
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/look/TriangleCrossAudioLevels.java
+++ b/te-app/src/main/java/titanicsend/pattern/look/TriangleCrossAudioLevels.java
@@ -2,6 +2,8 @@ package titanicsend.pattern.look;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
+import heronarts.lx.parameter.CompoundParameter;
+import java.util.Map;
 import titanicsend.pattern.glengine.ConstructedShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
@@ -9,8 +11,16 @@ import titanicsend.pattern.yoffa.framework.TEShaderView;
 @LXCategory("Look Shader Patterns")
 public class TriangleCrossAudioLevels extends ConstructedShaderPattern {
 
+  //  public final CompoundParameter energy;
+
   public TriangleCrossAudioLevels(LX lx) {
-    super(lx, TEShaderView.ALL_POINTS);
+    super(
+        lx,
+        TEShaderView.ALL_POINTS,
+        Map.of(
+            "energy",
+            new CompoundParameter("Energy", .1, 0, 1)
+                .setDescription("Amount of motion for various modes")));
   }
 
   @Override


### PR DESCRIPTION
I've found that it's not possible to add additional parameters to `TEPerformancePattern` (even if I just want them available "below the fold", outside of the top 16). Mainly this comes up when I'm working on a new shader, and I have a lot of free parameters I need to experiment with (and it gets cumbersome to map each of them into wow1/wow2 iteratively).

Also, with stem-mapping/modulators, we might be able to benefit from extra parameters even if they're not visible on the midi-twisters during a performance.

I think the main problem here was that `TECommonControls` calls `setRemoteControls()` with a fixed list, right after adding all the params to the pattern. Because of that, I needed to pass a `Map<String, LXListenableNormalizedParameter>` up through the superclass, so it's a bit awkward for child patterns to do that instead of have the param as a class variable and then call `addParameter()`.

In an ideal world, maybe when child patterns called `addParameter` in their usual constructor, there could be a way to:
- call `setRemoteControls` again, with the extra parameters appended to the list
- register this param with `GLPatternControl`, so it's made available as a uniform.

Very open to feedback on the approach, just wanted to get an end-to-end prototype working.

Still TODO:
- [ ] wire up `GLPreprocessorHelpers` so that custom `iUniforms` get added to `extraParams` for auto-shaders.