### PR TITLE
Avoid CPU buffer work on helper effects

### DIFF
--- a/te-app/src/main/java/titanicsend/app/director/DirectorEffect.java
+++ b/te-app/src/main/java/titanicsend/app/director/DirectorEffect.java
@@ -1,12 +1,13 @@
 package titanicsend.app.director;
 
+import heronarts.lx.GpuDevice;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.effect.TEEffect;
 
 /** Applies filters from the Director component. Should be used on the Master channel. */
 @LXCategory("Titanics End")
-public class DirectorEffect extends TEEffect {
+public class DirectorEffect extends TEEffect implements GpuDevice {
 
   public DirectorEffect(LX lx) {
     super(lx);

--- a/te-app/src/main/java/titanicsend/effect/GlobalPatternControl.java
+++ b/te-app/src/main/java/titanicsend/effect/GlobalPatternControl.java
@@ -1,12 +1,13 @@
 package titanicsend.effect;
 
+import heronarts.lx.GpuDevice;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.parameter.*;
 import titanicsend.app.TEGlobalPatternControls;
 
 @LXCategory("Titanics End")
-public class GlobalPatternControl extends TEEffect {
+public class GlobalPatternControl extends TEEffect implements GpuDevice {
 
   public final BooleanParameter speedEnable =
       new BooleanParameter("Enable", false).setDescription("Use speed from global controller");

--- a/te-app/src/main/java/titanicsend/effect/PanelAdjustEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/PanelAdjustEffect.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
 import heronarts.glx.ui.UI2dContainer.Layout;
 import heronarts.glx.ui.component.UITextBox;
+import heronarts.lx.GpuDevice;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.parameter.BooleanParameter;
@@ -26,7 +27,8 @@ import java.util.Map;
 import titanicsend.model.TEPanelModel;
 
 @LXCategory("Utility")
-public class PanelAdjustEffect extends TEEffect implements UIDeviceControls<PanelAdjustEffect> {
+public class PanelAdjustEffect extends TEEffect
+    implements UIDeviceControls<PanelAdjustEffect>, GpuDevice {
 
   private static final String RESOURCES_PATH = "./resources/vehicle/";
   private static final int MAX_ADJUST = 200000;

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -1,5 +1,6 @@
 package titanicsend.pattern.glengine;
 
+import heronarts.lx.GpuDevice;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXModel;
@@ -15,7 +16,7 @@ import titanicsend.pattern.jon.VariableSpeedTimer;
  * Wrapper class for OpenGL shaders. Simplifies handling of context and native memory management,
  * and provides a convenient interface for adding shaders to a pattern.
  */
-public class GLShaderEffect extends TEEffect {
+public class GLShaderEffect extends TEEffect implements GpuDevice {
 
   private final VariableSpeedTimer iTime = new VariableSpeedTimer();
   protected ByteBuffer imageBuffer;


### PR DESCRIPTION
Minor housekeeping.  Marking effects with the `GpuDevice` interface which says that the device (effect or pattern) does not work with CPU buffers.

This allows us to perform CPU buffer operations only where necessary in GPU Mixer mode.