### PR TITLE
Beyond plugin for sync to lasers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
 		<gov-nist-math-jama.version>1.1.1</gov-nist-math-jama.version>
 		<junit-jupiter.version>5.9.2</junit-jupiter.version>
 		<supermod.version>0.1.5-SNAPSHOT</supermod.version>
+		<beyond-plugin.version>0.1.5</beyond-plugin.version>
 	</properties>
 
 	<!-- Define a local repository -->
@@ -225,6 +226,26 @@
 				<groupId>me.walkerknapp</groupId>
 				<artifactId>devolay</artifactId>
 				<version>2.1.0-te</version>
+			</dependency>
+
+			<dependency>
+				<groupId>studio.jkb</groupId>
+				<artifactId>beyond</artifactId>
+				<version>${beyond-plugin.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>com.heronarts</groupId>
+						<artifactId>lx</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.heronarts</groupId>
+						<artifactId>glx</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>com.heronarts</groupId>
+						<artifactId>glxstudio</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>

--- a/te-app/pom.xml
+++ b/te-app/pom.xml
@@ -93,6 +93,11 @@
 
 		<dependency>
 			<groupId>studio.jkb</groupId>
+			<artifactId>beyond</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>studio.jkb</groupId>
 			<artifactId>supermod</artifactId>
 		</dependency>
 

--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -35,6 +35,7 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.function.Function;
 import org.lwjgl.system.Platform;
+import studio.jkb.beyond.BeyondPlugin;
 import studio.jkb.supermod.SuperMod;
 import titanicsend.app.*;
 import titanicsend.app.autopilot.*;
@@ -58,7 +59,6 @@ import titanicsend.effect.RandomStrobeEffect;
 import titanicsend.effect.SimplifyEffect;
 import titanicsend.gamepad.GamepadEngine;
 import titanicsend.lasercontrol.PangolinHost;
-import titanicsend.lasercontrol.TELaserTask;
 import titanicsend.lx.APC40Mk2;
 import titanicsend.lx.APC40Mk2.UserButton;
 import titanicsend.lx.DirectorAPCminiMk2;
@@ -165,7 +165,6 @@ public class TEApp extends LXStudio {
 
     private final ColorPaletteManager paletteManagerA;
     private final ColorPaletteManager paletteManagerB;
-    private final TELaserTask laserTask;
     private final CrutchOSC crutchOSC;
     private DevSwitch devSwitch;
     private final Director director;
@@ -217,10 +216,6 @@ public class TEApp extends LXStudio {
       // lx.engine.registerComponent("autopilot", this.autopilotJKB = new AutopilotExample(lx));
       // initializeAutopilotLibraryJKB();
 
-      // create our loop task for outputting data to lasers
-      this.laserTask = new TELaserTask(lx);
-      lx.engine.addLoopTask(this.laserTask);
-
       // Load metadata about unused controls per-pattern into a singleton that patterns will
       // reference later
       MissingControlsManager.get();
@@ -241,6 +236,7 @@ public class TEApp extends LXStudio {
 
       // Register child plugin components
       AudioStemsPlugin.registerComponents(lx);
+      BeyondPlugin.registerComponents(lx);
 
       // Patterns/effects that currently conform to art direction standards
       lx.registry.addPattern(EdgeProgressions.class);
@@ -496,7 +492,7 @@ public class TEApp extends LXStudio {
       //      GPOutput gpOutput = new GPOutput(lx, this.gpBroadcaster);
       //      lx.addOutput(gpOutput);
 
-      TEOscMessage.applyTEOscOutputSettings(lx);
+      // TEOscMessage.applyTEOscOutputSettings(lx);
 
       // Developer/Production Switch
       // Must be after everything else has initialized.
@@ -775,17 +771,18 @@ public class TEApp extends LXStudio {
       // Import latest gamepad controllers db
       gamepadEngine.updateGamepadMappings();
 
-      lx.engine.addTask(
-          () -> {
-            setOscDestinationForIpads();
-            // openDelayedFile(lx);
-            // Replace old saved destination IPs from project files
-            // setOscDestinationForIpads();
-          });
+      /* lx.engine.addTask(
+      () -> {
+        setOscDestinationForIpads();
+        // openDelayedFile(lx);
+        // Replace old saved destination IPs from project files
+        // setOscDestinationForIpads();
+      }); */
 
       this.superMod.onUIReady(lx, ui);
     }
 
+    @Deprecated
     public void setOscDestinationForIpads() {
       try {
         this.lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
@@ -830,6 +827,7 @@ public class TEApp extends LXStudio {
       this.lx.removeProjectListener(this);
 
       this.devSwitch.dispose();
+      this.director.dispose();
       this.dmxEngine.dispose();
       this.crutchOSC.dispose();
       this.glEngine.dispose();

--- a/te-app/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
+++ b/te-app/src/main/java/titanicsend/app/autopilot/TEOscMessage.java
@@ -153,10 +153,11 @@ public class TEOscMessage {
     return TEPhrase.resolvePhrase(phraseTypeString);
   }
 
+  @Deprecated
   public static void applyTEOscOutputSettings(LX lx) {
-    lx.engine.osc.transmitActive.setValue(true);
-    lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
-    lx.engine.osc.transmitPort.setValue(PangolinHost.PORT);
+    // lx.engine.osc.transmitActive.setValue(true);
+    // lx.engine.osc.transmitHost.setValue(PangolinHost.HOSTNAME);
+    // lx.engine.osc.transmitPort.setValue(PangolinHost.PORT);
   }
 
   /**
@@ -165,6 +166,7 @@ public class TEOscMessage {
    * @param address String
    * @param value int
    */
+  @Deprecated
   public static void sendOscToPangolin(LX lx, String address, int value, boolean verbose) {
     if (verbose)
       TE.log(

--- a/te-app/src/main/java/titanicsend/app/dev/UIDevSwitch.java
+++ b/te-app/src/main/java/titanicsend/app/dev/UIDevSwitch.java
@@ -42,16 +42,19 @@ public class UIDevSwitch extends UICollapsibleSection implements UIControls {
 
     addHorizontalBreak(ui, this);
 
-    for (DetailParameter p : devSwitch.detailParameters) {
-      addRow(this, ROW_HEIGHT, p.label, newControl(p.parameter));
+    for (DetailParameter dp : devSwitch.detailParameters) {
+      addRow(this, ROW_HEIGHT, dp.label, newControl(dp));
     }
   }
 
-  public UI2dComponent newControl(LXParameter p) {
+  public UI2dComponent newControl(DetailParameter dp) {
     UI2dComponent control = null;
+    LXParameter p = dp.parameter;
     if (p instanceof BooleanParameter) {
       control =
-          new UIButton(0, 0, (BooleanParameter) p).setActiveLabel("On").setInactiveLabel("Off");
+          new UIButton(0, 0, (BooleanParameter) p)
+              .setActiveLabel(dp.activeLabel)
+              .setInactiveLabel(dp.inactiveLabel);
     } else if (p instanceof BoundedParameter) {
       control = new UIDoubleBox(0, 0, (BoundedParameter) p);
     } else if (p instanceof DiscreteParameter) {

--- a/te-app/src/main/java/titanicsend/app/director/Director.java
+++ b/te-app/src/main/java/titanicsend/app/director/Director.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import titanicsend.lasercontrol.TELaserTask;
 
 public class Director extends LXComponent
     implements LX.Listener, LXOscComponent, LX.ProjectListener {
@@ -30,17 +31,21 @@ public class Director extends LXComponent
 
   private final CompoundParameter beaconsFader;
 
+  public final TELaserTask laserTask;
+
   public Director(LX lx) {
     super(lx, "director");
     current = this;
 
     lx.engine.registerComponent("director", this);
 
+    // LaserTask is a child to ensure proper initialization order and to access the fader parameter
+    lx.engine.registerComponent("lasers", this.laserTask = new TELaserTask(lx));
+
     addFilter(new TagFilter("te", "TE", "te"));
     addFilter(new TagFilter("panels", "Panels", "panel"));
     addFilter(new TagFilter("edges", "Edges", "edge"));
     addFilter(new TagFilter("foh", "FOH", "mothership"));
-    addFilter(new Filter("lasers", "Lasers"));
 
     Filter beaconsFilter = new DmxFilter("beacons", "Beacons", "beacon");
     addFilter(beaconsFilter);
@@ -50,7 +55,6 @@ public class Director extends LXComponent
 
     lx.addListener(this);
     onModelChanged(lx.getModel());
-
     lx.addProjectListener(this);
   }
 
@@ -107,6 +111,7 @@ public class Director extends LXComponent
 
   @Override
   public void dispose() {
+    this.laserTask.dispose();
     lx.removeListener(this);
     super.dispose();
   }

--- a/te-app/src/main/java/titanicsend/app/director/UIDirector.java
+++ b/te-app/src/main/java/titanicsend/app/director/UIDirector.java
@@ -1,22 +1,28 @@
 package titanicsend.app.director;
 
+import heronarts.glx.ui.UI2dComponent;
 import heronarts.glx.ui.UI2dContainer;
 import heronarts.glx.ui.component.UICollapsibleSection;
 import heronarts.glx.ui.component.UILabel;
 import heronarts.glx.ui.component.UISlider;
 import heronarts.glx.ui.vg.VGraphics;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIControls;
+import titanicsend.lasercontrol.TELaserTask;
+import titanicsend.lasercontrol.UITELaserTask;
 
 public class UIDirector extends UICollapsibleSection implements UIControls {
 
-  private static final float VERTICAL_SPACING = 4;
+  private static final float VERTICAL_SPACING = 2;
   private static final float FADER_WIDTH = 20;
   private static final float FADER_HEIGHT = 45;
   private static final int COLUMNS = 8;
 
   private final float columnWidth;
+
+  private final LXParameterListener laserBrightnessListener;
 
   public UIDirector(UI ui, Director director, float w) {
     super(ui, 0, 0, w, 30);
@@ -41,8 +47,38 @@ public class UIDirector extends UICollapsibleSection implements UIControls {
       }
     }
 
-    addFader(ui, row, director.master, column, labelUp);
+    // Lasers fader
+    UISlider laserFader = addFader(ui, row, TELaserTask.get().brightness, column++, labelUp);
+    labelUp = !labelUp;
+
+    // Set laser fader background color to gray when not sending, like channel faders
+    TELaserTask.get()
+        .brightness
+        .addListener(
+            this.laserBrightnessListener =
+                (p) -> {
+                  if (TELaserTask.get().sendBrightness.isOn()) {
+                    laserFader.resetFillColor();
+                    laserFader.redraw(); // TODO: why is this not refreshing the slider background?
+                  } else {
+                    laserFader.setFillColor(ui.theme.controlDisabledValueColor);
+                    laserFader.redraw();
+                  }
+                },
+            true);
+
+    // Master fader
+    addFader(ui, row, director.master, column++, labelUp);
     this.addChildren(row);
+
+    addChildren(
+        // Horizontal break
+        new UI2dComponent(2, 0, getContentWidth() - 4, 1) {}.setBackgroundColor(
+                ui.theme.paneInsetColor)
+            .setMargin(0, 0, 2, 0),
+
+        // Laser sync options
+        new UITELaserTask(ui, getContentWidth()));
   }
 
   private UI2dContainer addRow() {
@@ -50,23 +86,25 @@ public class UIDirector extends UICollapsibleSection implements UIControls {
         .setLayout(UI2dContainer.Layout.NONE);
   }
 
-  private void addFader(
+  private UISlider addFader(
       UI ui,
       UI2dContainer uiDevice,
       LXListenableNormalizedParameter parameter,
       int column,
       boolean labelUp) {
 
-    new UISlider(
-            UISlider.Direction.VERTICAL,
-            (column * this.columnWidth) + ((this.columnWidth - FADER_WIDTH) / 2),
-            0,
-            FADER_WIDTH,
-            FADER_HEIGHT,
-            parameter)
-        .setShowLabel(false)
-        .setWidth(20)
-        .addToContainer(uiDevice);
+    UISlider fader =
+        (UISlider)
+            new UISlider(
+                    UISlider.Direction.VERTICAL,
+                    (column * this.columnWidth) + ((this.columnWidth - FADER_WIDTH) / 2),
+                    0,
+                    FADER_WIDTH,
+                    FADER_HEIGHT,
+                    parameter)
+                .setShowLabel(false)
+                .setWidth(20)
+                .addToContainer(uiDevice);
 
     new UILabel(this.columnWidth * 2, parameter.getLabel())
         .setFont(ui.theme.getControlFont())
@@ -74,5 +112,13 @@ public class UIDirector extends UICollapsibleSection implements UIControls {
         .setX((column - 0.5f) * this.columnWidth)
         .setY(FADER_HEIGHT + (labelUp ? 4 : 16))
         .addToContainer(uiDevice);
+
+    return fader;
+  }
+
+  @Override
+  public void dispose() {
+    TELaserTask.get().brightness.removeListener(this.laserBrightnessListener);
+    super.dispose();
   }
 }

--- a/te-app/src/main/java/titanicsend/lasercontrol/PangolinHost.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/PangolinHost.java
@@ -3,6 +3,6 @@ package titanicsend.lasercontrol;
 /** Information to be able to send OSC messages to Pangolin host. */
 public class PangolinHost {
   // TODO(will) change this to a config file later
-  public static final String HOSTNAME = "10.1.3.1";
-  public static final int PORT = 7890;
+  public static final String HOSTNAME = "10.4.0.1";
+  public static final int PORT = 8000;
 }

--- a/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -2,16 +2,20 @@ package titanicsend.lasercontrol;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXComponent;
-import heronarts.lx.LXLoopTask;
-import heronarts.lx.color.LXDynamicColor;
 import heronarts.lx.parameter.BooleanParameter;
-import heronarts.lx.parameter.BooleanParameter.Mode;
-import titanicsend.app.autopilot.TEOscMessage;
-import titanicsend.color.TEColorType;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.parameter.TriggerParameter;
+import studio.jkb.beyond.BeyondPlugin;
+import studio.jkb.beyond.BeyondVariable;
+import studio.jkb.beyond.parameter.BeyondBpmSync;
+import studio.jkb.beyond.parameter.BeyondColorSync;
+import studio.jkb.beyond.parameter.BeyondCompoundParameter;
+import titanicsend.color.TEColorParameter;
+import titanicsend.color.TEGradientSource;
 
-public class TELaserTask extends LXComponent implements LXLoopTask {
+public class TELaserTask extends LXComponent {
 
-  public static final boolean DEFAULT_ENABLE_IN_PRODUCTION = false;
+  public static final boolean DEFAULT_ENABLE_IN_PRODUCTION = true;
 
   private static TELaserTask current;
 
@@ -19,28 +23,70 @@ public class TELaserTask extends LXComponent implements LXLoopTask {
     return current;
   }
 
-  public final BooleanParameter enabled =
-      new BooleanParameter("Lasers", DEFAULT_ENABLE_IN_PRODUCTION).setMode(Mode.TOGGLE);
+  public final BooleanParameter sendBrightness =
+      new BooleanParameter("SendBrightness", DEFAULT_ENABLE_IN_PRODUCTION)
+          .setDescription("Send the laser fader to Pangolin Beyond master brightness with OSC");
+
+  public final BooleanParameter sendColor =
+      new BooleanParameter("SendColor", DEFAULT_ENABLE_IN_PRODUCTION)
+          .setDescription("Send the laser color to Pangolin Beyond with OSC");
+
+  public final BooleanParameter sendTempo =
+      new BooleanParameter("SendTempo", DEFAULT_ENABLE_IN_PRODUCTION)
+          .setDescription("Send beats and BPM to Pangolin Beyond with OSC");
+
+  public final TEColorParameter color;
+
+  public final BeyondCompoundParameter brightness;
+  private final BeyondColorSync colorSync;
+  private final BeyondBpmSync bpm;
+
+  public final TriggerParameter setUpOsc =
+      new TriggerParameter("Set Up Now", this::runSetup)
+          .setDescription("Add an OSC output for Beyond with the appropriate filter");
 
   public TELaserTask(LX lx) {
     super(lx);
     current = this;
 
-    addParameter("enabled", this.enabled);
+    addParameter("sendBrightness", this.sendBrightness);
+    addParameter("sendColor", this.sendColor);
+    addParameter("sendTempo", this.sendTempo);
+
+    this.color = new TEColorParameter(TEGradientSource.get(), "Lasers");
+
+    this.brightness = new BeyondCompoundParameter(lx, BeyondVariable.BRIGHTNESS, "Lasers");
+    this.colorSync = new BeyondColorSync(lx, this.color);
+    this.bpm = new BeyondBpmSync(lx);
+
+    this.brightness.setOutputEnabled(this.sendBrightness.isOn());
+    this.colorSync.setOutputEnabled(this.sendColor.isOn());
+    this.bpm.setOutputEnabled(this.sendTempo.isOn());
   }
 
   @Override
-  public void loop(double deltaMs) {
-    if (this.enabled.isOn() && this.lx.engine.output.enabled.isOn()) {
-      // get the swatch color
-      int primaryIndex = TEColorType.PRIMARY.swatchIndex();
-      LXDynamicColor primary = this.lx.engine.palette.swatch.getColor(primaryIndex);
-
-      // convert to a 0 - 360 format for Pangolin
-      int hue = (int) (primary.getHue());
-
-      // send the OSC message
-      TEOscMessage.sendOscToPangolin(lx, TEOscMessage.makePaletteHueAddress(), hue, false);
+  public void onParameterChanged(LXParameter p) {
+    if (p == this.sendBrightness) {
+      this.brightness.setOutputEnabled(this.sendBrightness.isOn());
+    } else if (p == this.sendColor) {
+      this.colorSync.setOutputEnabled(this.sendColor.isOn());
+    } else if (p == this.sendTempo) {
+      this.bpm.setOutputEnabled(this.sendTempo.isOn());
     }
+  }
+
+  private void runSetup() {
+    BeyondPlugin.confirmOscOutput(this.lx, PangolinHost.HOSTNAME, PangolinHost.PORT);
+  }
+
+  @Override
+  public void dispose() {
+    this.brightness.dispose();
+    this.colorSync.dispose();
+    this.bpm.dispose();
+
+    this.color.dispose();
+
+    super.dispose();
   }
 }

--- a/te-app/src/main/java/titanicsend/lasercontrol/UITELaserTask.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/UITELaserTask.java
@@ -1,0 +1,69 @@
+package titanicsend.lasercontrol;
+
+import heronarts.glx.ui.UI;
+import heronarts.glx.ui.UI2dContainer;
+import heronarts.glx.ui.component.UIButton;
+import heronarts.glx.ui.component.UIKnob;
+import heronarts.glx.ui.component.UILabel;
+import heronarts.glx.ui.vg.VGraphics;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.device.UIControls;
+import titanicsend.ui.UITEColorControl;
+
+public class UITELaserTask extends UI2dContainer implements UIControls {
+
+  private static final int CHECKBOX_LABEL_WIDTH = 60;
+
+  public UITELaserTask(LXStudio.UI ui, float w) {
+    super(0, 0, w, 0);
+    setLayout(Layout.HORIZONTAL, 4);
+
+    TELaserTask laserTask = TELaserTask.get();
+
+    UI2dContainer checkboxes =
+        newVerticalContainer(
+            CHECKBOX_LABEL_WIDTH + 14,
+            0,
+            newCheckbox(ui, laserTask.sendBrightness, "Brightness"),
+            newCheckbox(ui, laserTask.sendColor, "Color"),
+            newCheckbox(ui, laserTask.sendTempo, "BPM"));
+    float h = checkboxes.getHeight();
+
+    addChildren(
+        newVerticalContainer(
+            47,
+            0,
+            new UILabel(0, (h - 20) / 2, 45, 12, "Laser")
+                .setTextAlignment(VGraphics.Align.LEFT, VGraphics.Align.MIDDLE)
+                .setFont(ui.theme.getLabelFont())
+                .setMargin(7, 0, 0, 0),
+            new UILabel(0, (h - 20) / 2, 45, 12, "Sync")
+                .setTextAlignment(VGraphics.Align.LEFT, VGraphics.Align.MIDDLE)
+                .setFont(ui.theme.getLabelFont())),
+        checkboxes,
+        new UITEColorControl(0, (h - UIKnob.HEIGHT) / 2, laserTask.color));
+
+    setContentHeight(h);
+  }
+
+  private UI2dContainer newCheckbox(LXStudio.UI ui, BooleanParameter p, String label) {
+    return newHorizontalContainer(
+        14,
+        4,
+        new UIButton.Toggle(p),
+        new UILabel(CHECKBOX_LABEL_WIDTH, label)
+            .setTextAlignment(VGraphics.Align.LEFT, VGraphics.Align.MIDDLE)
+            .setFont(ui.theme.getControlFont()));
+  }
+
+  @Override
+  protected void drawBorder(UI ui, VGraphics vg) {
+    super.drawBorder(ui, vg);
+    vg.beginPath();
+    vg.strokeColor(ui.theme.controlTextColor);
+    vg.line(48, 0, 30, 20);
+    vg.line(30, 20, 48, 40);
+    vg.stroke();
+  }
+}


### PR DESCRIPTION
Adds a plugin for sending parameters to Beyond and some TE-specific plumbing to make things very simple.

The Director pane now has laser sync options at the bottom:
<img width="222" height="186" alt="image" src="https://github.com/user-attachments/assets/7bf98526-4f66-4558-bbde-980fbe2d3638" />

It includes a TEColorParameter so the laser colors can be varied within the TE gradient.  I'll circle back at some point and make the color's Offset parameter mappable from a midi knob.

To enable, click the new "Set Up Now" link in MODEL > Control Panel (previously DevSwitch).
<img width="217" height="101" alt="image" src="https://github.com/user-attachments/assets/2cd536ea-3e3f-4eaa-bf11-3e187c2f2446" />
... that will add an OSC output with the proper filter ("/b") for Beyond:
<img width="536" height="308" alt="image" src="https://github.com/user-attachments/assets/b1b96266-42cb-4c23-8578-5c9a5c564c69" />

BPM is working but I've not yet added the beats.  Hopefully will follow up on that soon.

Plugin source code is here: https://github.com/jkbelcher/Beyond