### PR TITLE
GPU Shader Effects

### DIFF
--- a/te-app/resources/shaders/explode_effect.fs
+++ b/te-app/resources/shaders/explode_effect.fs
@@ -3,6 +3,9 @@
 #define TE_EFFECTSHADER
 #define TE_NOPOSTPROCESSING
 
+// Texture from the preceding pattern or effect
+uniform sampler2D iDst;
+
 uniform float basis;
 uniform float size;
 
@@ -33,5 +36,5 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 displacement = (-0.5 + random2(quv)) * basis;
     //fragColor = (basis <= 0.001) ? texelFetch(iBackbuffer, ivec2(gl_FragCoord.xy), 0) :
     //    texelFetch(iMappedBuffer, ivec2((uv + displacement) * 639), 0);
-    fragColor = texelFetch(iMappedBuffer, ivec2((uv + displacement) * 639), 0);
+    fragColor = texelFetch(iDst, ivec2((uv + displacement) * 639), 0);
 }

--- a/te-app/resources/shaders/ndi_out_effect.fs
+++ b/te-app/resources/shaders/ndi_out_effect.fs
@@ -1,0 +1,28 @@
+#version 410
+
+out vec4 fragColor;
+
+// Incoming frame texture
+uniform sampler2D iDst;
+
+// Normalized model coordinates
+uniform sampler2D lxModelCoords;
+
+//uniform vec2 iResolution;
+
+void main() {
+//    vec2 coords = texelFetch(lxModelCoords, ivec2(gl_FragCoord.xy), 0).xy;
+//
+//    if (isnan(coords.r)) {
+//        fragColor = vec4(0.0);
+//        return;
+//    }
+
+    // Scale the coordinates to the resolution specified by Chromatik
+    // (which can be changed via the --resolution command line option)
+//    coords *= iResolution;
+
+    vec4 color = texelFetch(iDst, ivec2(gl_FragCoord.xy), 0);
+
+    fragColor = color;
+}

--- a/te-app/resources/shaders/sustain_effect.fs
+++ b/te-app/resources/shaders/sustain_effect.fs
@@ -1,0 +1,25 @@
+// This is an effect, therefore does not use common controls
+#define TE_EFFECTSHADER
+// Bypass TE post-processing color and alpha adjustments
+#define TE_NOPOSTPROCESSING
+
+// Texture from the preceding pattern or effect
+uniform sampler2D iDst;
+
+// Amount of sustain 0-1
+uniform float iSustain;
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    ivec2 pixel = ivec2(gl_FragCoord.xy);
+    vec4 color = texelFetch(iDst, pixel, 0);
+    vec4 prev = texelFetch(iBackbuffer, pixel, 0);
+
+    // Calculate an amount to decay in this frame
+    float decay = pow((1.0 - clamp(iSustain, 0.0, 1.0)), 5.);
+
+    // Apply decay to backbuffer color
+    vec4 faded = clamp(prev - decay, 0.0, 1.0);
+
+    // Jump to current frame color values if they are higher
+    fragColor = max(faded, color);
+}

--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -339,6 +339,7 @@ public class TEApp extends LXStudio {
       lx.registry.addEffect(DirectorEffect.class);
       lx.registry.addEffect(SimplifyEffect.class);
       lx.registry.addEffect(SustainEffect.class);
+      lx.registry.addEffect(titanicsend.effect.NDIOutShaderEffect.class);
 
       // DMX effects
       lx.registry.addEffect(BeaconStrobeEffect.class);

--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -56,6 +56,7 @@ import titanicsend.dmx.pattern.*;
 import titanicsend.effect.GlobalPatternControl;
 import titanicsend.effect.RandomStrobeEffect;
 import titanicsend.effect.SimplifyEffect;
+import titanicsend.effect.SustainEffect;
 import titanicsend.gamepad.GamepadEngine;
 import titanicsend.lasercontrol.PangolinHost;
 import titanicsend.lasercontrol.TELaserTask;
@@ -337,6 +338,7 @@ public class TEApp extends LXStudio {
       // Effects
       lx.registry.addEffect(DirectorEffect.class);
       lx.registry.addEffect(SimplifyEffect.class);
+      lx.registry.addEffect(SustainEffect.class);
 
       // DMX effects
       lx.registry.addEffect(BeaconStrobeEffect.class);

--- a/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
@@ -145,12 +145,10 @@ public class ExplodeEffect extends GLShaderEffect {
     addParameter("manualTrigger", this.manualTrigger);
     addParameter("trigger", this.trigger);
 
-    // add the first shader, passing in the effect's backbuffer
     addShader(
         GLShader.config(lx)
             .withFilename("explode_effect.fs")
-            .withUniformSource(this::setUniforms)
-            .withLegacyBackBuffer(getImageBuffer()));
+            .withUniformSource(this::setUniforms));
   }
 
   private void setUniforms(GLShader shader) {

--- a/te-app/src/main/java/titanicsend/effect/NDIOutRawEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/NDIOutRawEffect.java
@@ -30,10 +30,6 @@ public class NDIOutRawEffect extends TEEffect {
 
   @Override
   protected void run(double deltaMs, double enabledAmount) {
-    if (!isInitialized) {
-      return;
-    }
-
     // TODO - make frame size adapt automatically to the size of the
     // TODO - current model.
     // Make sure we don't overrun the frame buffer if the model is too large

--- a/te-app/src/main/java/titanicsend/effect/NDIOutShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/NDIOutShaderEffect.java
@@ -1,0 +1,59 @@
+package titanicsend.effect;
+
+import heronarts.lx.GpuDevice;
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.model.LXModel;
+import titanicsend.ndi.NDIOutShader;
+
+@LXCategory("Titanics End")
+public class NDIOutShaderEffect extends TEEffect implements GpuDevice {
+
+  final NDIOutShader shader;
+
+  private boolean modelChanged = true;
+
+  public NDIOutShaderEffect(LX lx) {
+    super(lx);
+
+    this.shader = new NDIOutShader(lx);
+  }
+
+  public void setDst(int iDst) {
+    this.shader.setDst(iDst);
+  }
+
+  @Override
+  protected void run(double deltaMs, double enabledAmount) {
+    // Update the model coords texture only when changed (and the first run)
+    if (this.modelChanged) {
+      this.modelChanged = false;
+      LXModel m = getModel();
+      this.shader.setModelCoordinates(m);
+    }
+
+    this.shader.run();
+  }
+
+  public int getRenderTexture() {
+    return this.shader.getRenderTexture();
+  }
+
+  @Override
+  protected void onEnable() {
+    super.onEnable();
+    this.shader.onActive();
+  }
+
+  @Override
+  protected void onDisable() {
+    this.shader.onInactive();
+    super.onDisable();
+  }
+
+  @Override
+  public void dispose() {
+    this.shader.dispose();
+    super.dispose();
+  }
+}

--- a/te-app/src/main/java/titanicsend/effect/SustainEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SustainEffect.java
@@ -1,0 +1,31 @@
+package titanicsend.effect;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.parameter.CompoundParameter;
+import titanicsend.pattern.glengine.GLShader;
+import titanicsend.pattern.glengine.GLShaderEffect;
+
+@LXCategory("Titanics End")
+public class SustainEffect extends GLShaderEffect {
+
+  public final CompoundParameter sustain =
+    new CompoundParameter("Sustain", 0)
+      .setUnits(CompoundParameter.Units.PERCENT_NORMALIZED)
+      .setDescription("Amount of sustain to apply");
+
+
+  public SustainEffect(LX lx) {
+    super(lx);
+
+    addParameter("sustain", this.sustain);
+
+    addShader(GLShader.config(lx)
+      .withFilename("sustain_effect.fs")
+      .withUniformSource(this::setUniforms));
+  }
+
+  private void setUniforms(GLShader s) {
+    s.setUniform("iSustain", sustain.getValuef());
+  }
+}

--- a/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
+++ b/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
@@ -1,0 +1,191 @@
+package titanicsend.ndi;
+
+import com.jogamp.opengl.GL4;
+import heronarts.lx.LX;
+import heronarts.lx.model.LXModel;
+import me.walkerknapp.devolay.DevolayFrameFourCCType;
+import me.walkerknapp.devolay.DevolaySender;
+import me.walkerknapp.devolay.DevolayVideoFrame;
+import titanicsend.pattern.glengine.GLShader;
+import titanicsend.pattern.glengine.TEShader;
+import titanicsend.pattern.yoffa.shader_engine.Uniform;
+import titanicsend.pattern.yoffa.shader_engine.UniformNames;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.jogamp.opengl.GL.GL_BGRA;
+import static com.jogamp.opengl.GL.GL_MAP_INVALIDATE_BUFFER_BIT;
+import static com.jogamp.opengl.GL.GL_UNSIGNED_BYTE;
+
+public class NDIOutShader extends GLShader implements GLShader.UniformSource {
+
+  private static final int UNINITIALIZED = -1;
+
+  // Framebuffer object (FBO) for rendering
+  private GLShader.FBO fbo;
+
+  // Pixel Pack Buffers (PBOs) for ping-pong output
+  private GLShader.PingPongPBO ppPBOs;
+
+  private DevolaySender ndiSender;
+  private DevolayVideoFrame ndiFrame;
+  protected ByteBuffer imageBuffer;
+
+  private int modelCoordsTextureHandle = UNINITIALIZED;
+
+  // Variables that will be passed to uniforms
+  // Incoming texture handle
+  private int iDst = -1;
+
+  private static class NdiOutUniforms {
+    private Uniform.Sampler2D iDst;
+    private Uniform.Sampler2D lxModelCoords;
+  }
+
+  private final NdiOutUniforms uniforms = new NdiOutUniforms();
+  private boolean initializedUniforms = false;
+
+  public NDIOutShader(LX lx) {
+    super(config(lx).withFilename("ndi_out_effect.fs"));
+
+    addUniformSource(this);
+  }
+
+  @Override
+  protected boolean useTEPreProcess() {
+    return false;
+  }
+
+  @Override
+  protected void allocateShaderBuffers() {
+    super.allocateShaderBuffers();
+
+    // FBO (framebuffer and texture) for rendering
+    this.fbo = new GLShader.FBO();
+
+    // Pixel Pack Buffers (PBOs) for ping-pong output
+    this.ppPBOs = new GLShader.PingPongPBO();
+
+    this.imageBuffer = TEShader.allocateBackBuffer();
+  }
+
+  /** Set input texture handle */
+  public void setDst(int iDst) {
+    this.iDst = iDst;
+  }
+
+  private void initializeUniforms() {
+    this.uniforms.lxModelCoords = getUniformSampler2D(UniformNames.LX_MODEL_COORDS);
+    this.uniforms.iDst = getUniformSampler2D("iDst");
+    initializeNdiSender();
+  }
+
+  private void initializeNdiSender() {
+    ndiSender = new DevolaySender("TitanicsEnd");
+    ndiFrame = new DevolayVideoFrame();
+    ndiFrame.setResolution(width, height);
+    ndiFrame.setFourCCType(DevolayFrameFourCCType.RGBA);
+    ndiFrame.setData(this.imageBuffer);
+    ndiFrame.setFrameRate(60, 1);
+    ndiFrame.setAspectRatio(1);
+  }
+
+  @Override
+  public void setUniforms(GLShader s) {
+    // Use Uniform objects to track locations and values
+    if (!initializedUniforms) {
+      this.initializedUniforms = true;
+      initializeUniforms();
+    }
+
+    // Stage uniform values for updating
+    this.uniforms.lxModelCoords.setValue(this.modelCoordsTextureHandle);
+    this.uniforms.iDst.setValue(this.iDst);
+  }
+
+  boolean firstFrame = true;
+
+  @Override
+  protected void render() {
+    // Bind vertex array object
+    bindVAO();
+
+    // Bind framebuffer object (FBO).
+    this.fbo.bind();
+
+    // Render frame
+    drawElements();
+
+    // Bind the current PBO
+    this.ppPBOs.render.bind();
+
+    // Read pixels into current PBO
+    this.gl4.glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, 0);
+
+    if (firstFrame) {
+      // Skip the first frame, PBO is empty
+      firstFrame = false;
+    } else {
+
+      // Map the other PBO for reading (from previous frame)
+      this.ppPBOs.copy.bind();
+      this.imageBuffer = this.gl4.glMapBuffer(GL4.GL_PIXEL_PACK_BUFFER, GL4.GL_READ_ONLY);
+
+      if (this.imageBuffer != null) {
+        this.imageBuffer.rewind(); // Needed?
+
+        // Send NDI frame
+        this.ndiFrame.setData(this.imageBuffer);
+        this.ndiSender.sendVideoFrame(this.ndiFrame);
+
+        // Unmap the PBO
+        this.gl4.glUnmapBuffer(GL4.GL_PIXEL_PACK_BUFFER);
+      }
+    }
+
+    // Unbind the PBO
+    this.gl4.glBindBuffer(GL4.GL_PIXEL_PACK_BUFFER, 0);
+
+    // Switch to the next PBO for the next frame
+    this.ppPBOs.swap();
+
+    // No need to unbind VAO.
+    // Also not unbinding the FBO here, as other shader render passes will change it.
+    // And GLMixer will unbind the last FBO at the end of postMix().
+  }
+
+  @Override
+  public void unbindTextures() {
+    this.uniforms.lxModelCoords.unbind();
+    this.uniforms.iDst.unbind();
+  }
+
+  public int getRenderTexture() {
+    return this.iDst;
+  }
+
+  // Staging Uniforms: LX Model
+
+  /**
+   * Copy LXPoints' normalized coordinates into textures for use by shaders. Must be called by the
+   * parent pattern or effect at least once before the first frame is rendered. And should be called
+   * by the pattern's frametime run() function if the model has changed since the last frame.
+   *
+   * @param model Current LXModel of the calling context, which is a LXView or the global model
+   */
+  public void setModelCoordinates(LXModel model) {
+    this.modelCoordsTextureHandle = this.glEngine.textureCache.getCoordinatesTexture(model);
+  }
+
+  @Override
+  public void dispose() {
+    if (isInitialized()) {
+      this.fbo.dispose();
+      this.ppPBOs.dispose();
+      this.ndiSender.close();
+    }
+    super.dispose();
+  }
+}

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -42,6 +42,7 @@ import titanicsend.pattern.yoffa.shader_engine.FragmentShader;
 import titanicsend.pattern.yoffa.shader_engine.ShaderAttribute;
 import titanicsend.pattern.yoffa.shader_engine.ShaderProgram;
 import titanicsend.pattern.yoffa.shader_engine.Uniform;
+import titanicsend.pattern.yoffa.shader_engine.UniformNames;
 import titanicsend.pattern.yoffa.shader_engine.UniformType;
 
 /** Shader program components that are currently common across shader classes. */
@@ -208,6 +209,10 @@ public abstract class GLShader {
     this.indexBuffer = Buffers.newDirectIntBuffer(INDICES.length);
     this.vertexBuffer.put(VERTICES);
     this.indexBuffer.put(INDICES);
+
+    // Reserved texture units
+    this.uniformTextureUnits.put(UniformNames.BACK_BUFFER, TEXTURE_UNIT_BACKBUFFER);
+    this.uniformTextureUnits.put(UniformNames.LX_MODEL_COORDS, TEXTURE_UNIT_COORDS);
   }
 
   // Buffers

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -60,6 +60,9 @@ public abstract class GLShader {
   public interface UniformSource {
     /** Called once per frame. Set uniforms on the shader here. */
     void setUniforms(GLShader s);
+
+    /** Called once per frame after render(). Unbind any Sampler2D uniforms. */
+    default void unbindTextures() {}
   }
 
   // Vertices for default geometry - a rectangle that covers the entire canvas
@@ -348,6 +351,8 @@ public abstract class GLShader {
     // hand the complete uniform list to OpenGL
     updateUniforms();
     render();
+    unbindTextures();
+    activateDefaultTextureUnit();
   }
 
   /** Activate this shader for rendering in the current context */
@@ -372,6 +377,12 @@ public abstract class GLShader {
 
   /** Child classes should run GL draw commands here */
   protected abstract void render();
+
+  private void unbindTextures() {
+    for (UniformSource uniformSource : this.uniformSources) {
+      uniformSource.unbindTextures();
+    }
+  }
 
   /** Activates texture unit 0. */
   protected void activateDefaultTextureUnit() {
@@ -815,9 +826,13 @@ public abstract class GLShader {
     }
 
     public void bind() {
+      bind(false);
+    }
+
+    public void bind(boolean zeroAlpha) {
       gl4.glBindFramebuffer(GL_FRAMEBUFFER, this.fboHandles[0]);
       gl4.glViewport(0, 0, width, height);
-      gl4.glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+      gl4.glClearColor(0.0f, 0.0f, 0.0f, zeroAlpha ? 0f : 1.0f);
       gl4.glClear(GL_COLOR_BUFFER_BIT);
     }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -4,6 +4,7 @@ import heronarts.lx.GpuDevice;
 import heronarts.lx.LX;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXModel;
+
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,6 +12,9 @@ import java.util.List;
 import titanicsend.color.TEColorType;
 import titanicsend.effect.TEEffect;
 import titanicsend.pattern.jon.VariableSpeedTimer;
+import titanicsend.pattern.yoffa.shader_engine.Uniform;
+
+import static titanicsend.pattern.glengine.GLShaderPattern.NO_TEXTURE;
 
 /**
  * Wrapper class for OpenGL shaders. Simplifies handling of context and native memory management,
@@ -19,10 +23,6 @@ import titanicsend.pattern.jon.VariableSpeedTimer;
 public class GLShaderEffect extends TEEffect implements GpuDevice {
 
   private final VariableSpeedTimer iTime = new VariableSpeedTimer();
-  protected ByteBuffer imageBuffer;
-  protected ByteBuffer mappedBuffer;
-  protected final int mappedBufferWidth = GLEngine.getMappedBufferWidth();
-  protected final int mappedBufferHeight = GLEngine.getMappedBufferHeight();
 
   // list of shaders to run
   private final List<TEShader> mutableShaders = new ArrayList<>();
@@ -30,16 +30,28 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
 
   private boolean modelChanged = true;
 
+  // Input texture handle that is the output from the pattern or preceding effect
+  public int iDst = -1;
+  // If there are multiple shaders in one effect, the iDst texture of each will be the output
+  // of the previous shader
+  private int currentShaderDst = -1;
+
+  private static class TEEffectUniforms {
+    private Uniform.Sampler2D iDst;
+    private Uniform.Float1 level; // Is this universal for LXEffects?
+
+    private Uniform.Float1 iTime;
+    private Uniform.Float3 iColorRGB;
+    private Uniform.Float3 iColorHSB;
+    private Uniform.Float3 iColor2RGB;
+    private Uniform.Float3 iColor2HSB;
+  }
+
+  private final TEEffectUniforms uniforms = new TEEffectUniforms();
+  private boolean initializedUniforms = false;
+
   public GLShaderEffect(LX lx) {
     super(lx);
-
-    imageBuffer = TEShader.allocateBackBuffer();
-    mappedBuffer = TEShader.allocateMappedBuffer(mappedBufferWidth, mappedBufferHeight);
-    // zero mappedBuffer
-    mappedBuffer.rewind();
-    for (int i = 0; i < mappedBuffer.capacity(); i++) {
-      mappedBuffer.put(i, (byte) 0);
-    }
   }
 
   protected TEShader addShader(GLShader.Config config) {
@@ -48,50 +60,12 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
     return shader;
   }
 
-  protected ByteBuffer getImageBuffer() {
-    return imageBuffer;
+  protected TEShader addShader(String shaderFilename) {
+    return addShader(GLShader.config(lx).withFilename(shaderFilename));
   }
 
   public double getTime() {
     return iTime.getTime();
-  }
-
-  @Override
-  protected void onModelChanged(LXModel model) {
-    super.onModelChanged(model);
-    this.modelChanged = true;
-  }
-
-  protected void run(double deltaMs, double enabledAmount) {
-    LXModel m = getModel();
-    iTime.tick();
-
-    // Update the model coords texture only when changed (and the first run)
-    if (this.modelChanged) {
-      this.modelChanged = false;
-      for (TEShader shader : this.shaders) {
-        shader.setModelCoordinates(m);
-      }
-    }
-
-    // set up rectangular texture buffers for effects that need them
-    ShaderPainter.mapToBufferDirect(m.points, imageBuffer, colors);
-    ShaderPainter.mapFromLinearBuffer(
-        m.points, mappedBufferWidth, mappedBufferHeight, mappedBuffer, colors);
-
-    // run the chain of shaders, except for the last one,
-    // copying the output of each to the next shader's input texture
-    TEShader shader = null;
-    int n = this.shaders.size();
-    for (int i = 0; i < n; i++) {
-      shader = this.shaders.get(i);
-      shader.run();
-    }
-
-    // paint the final shader output to the car.
-    if (shader != null) {
-      ShaderPainter.mapToPointsDirect(m.points, imageBuffer, getColors());
-    }
   }
 
   protected int getColor1() {
@@ -102,27 +76,103 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
     return lx.engine.palette.getSwatchColor(TEColorType.SECONDARY.swatchIndex()).getColor();
   }
 
+  @Override
+  protected void onModelChanged(LXModel model) {
+    super.onModelChanged(model);
+    this.modelChanged = true;
+  }
+
+  public void setDst(int iDst) {
+    this.iDst = iDst;
+  }
+
+  protected void run(double deltaMs, double enabledAmount) {
+    // Safety check: bail if the effect contains no shaders
+    if (this.shaders.isEmpty()) {
+      return;
+    }
+
+    iTime.tick();
+
+    // Update the model coords texture only when changed (and the first run)
+    if (this.modelChanged) {
+      this.modelChanged = false;
+      LXModel m = getModel();
+      for (TEShader shader : this.shaders) {
+        shader.setModelCoordinates(m);
+      }
+    }
+
+    // Set the CPU buffer for any non-last shader to be null. These will be chained.
+    for (int i = 0; i < (this.shaders.size() - 1); i++) {
+      this.shaders.get(i).setCpuBuffer(null);
+    }
+    // Set the CPU buffer for the last shader, if using CPU mixer
+    this.shaders
+      .getLast()
+      .setCpuBuffer(this.lx.engine.renderMode.cpu ? this.colors : null);
+
+    // Run the chain of shaders,
+    // mapping the output texture of each to the next shader's input texture
+    this.currentShaderDst = this.iDst;
+    for (TEShader shader : this.shaders) {
+      shader.run();
+      this.currentShaderDst = shader.getRenderTexture();
+    }
+  }
+
+  /**
+   * Retrieve the render(output) texture handle for the effect.
+   *
+   * @return The output texture handle of the last shader, or NO_TEXTURE if no shaders exist
+   */
+  public int getRenderTexture() {
+    if (!this.shaders.isEmpty()) {
+      return this.shaders.getLast().getRenderTexture();
+    } else {
+      return NO_TEXTURE;
+    }
+  }
+
+  private void initializeUniforms(GLShader s) {
+    // Keep direct references to each Uniform, saves hashmap lookup.
+    this.uniforms.iDst = s.getUniformSampler2D("iDst");
+    this.uniforms.iTime = s.getUniformFloat1("iTime");
+    this.uniforms.iColorRGB = s.getUniformFloat3("iColorRGB");
+    this.uniforms.iColorHSB = s.getUniformFloat3("iColorHSB");
+    this.uniforms.iColor2RGB = s.getUniformFloat3("iColor2RGB");
+    this.uniforms.iColor2HSB = s.getUniformFloat3("iColor2HSB");
+  }
+
   // send a subset of the controls we use with patterns
   private void setUniforms(GLShader s) {
-    s.setUniform("iTime", (float) getTime());
+    if (!this.initializedUniforms) {
+      this.initializedUniforms = true;
+      initializeUniforms(s);
+    }
+
+    // Shaders are run in sequence.  Pass the current iDst value, which may be the output of the previous shader
+    this.uniforms.iDst.setValue(this.currentShaderDst);
+
+    this.uniforms.iTime.setValue((float) getTime());
 
     // get current primary and secondary colors
     // TODO - we're just grabbing swatch colors here.  Do we need to worry about modulation?
     int col = getColor1();
-    s.setUniform(
-        "iColorRGB",
+    this.uniforms.iColorRGB.setValue(
         (float) (0xff & LXColor.red(col)) / 255f,
         (float) (0xff & LXColor.green(col)) / 255f,
         (float) (0xff & LXColor.blue(col)) / 255f);
-    s.setUniform("iColorHSB", LXColor.h(col) / 360f, LXColor.s(col) / 100f, LXColor.b(col) / 100f);
+    this.uniforms.iColorHSB.setValue(
+      LXColor.h(col) / 360f, LXColor.s(col) / 100f, LXColor.b(col) / 100f);
 
     col = getColor2();
-    s.setUniform(
-        "iColor2RGB",
-        (float) (0xff & LXColor.red(col)) / 255f,
-        (float) (0xff & LXColor.green(col)) / 255f,
-        (float) (0xff & LXColor.blue(col)) / 255f);
-    s.setUniform("iColor2HSB", LXColor.h(col) / 360f, LXColor.s(col) / 100f, LXColor.b(col) / 100f);
+    this.uniforms.iColor2RGB.setValue(
+      (float) (0xff & LXColor.red(col)) / 255f,
+      (float) (0xff & LXColor.green(col)) / 255f,
+      (float) (0xff & LXColor.blue(col)) / 255f);
+    this.uniforms.iColor2HSB.setValue(
+      LXColor.h(col) / 360f, LXColor.s(col) / 100f, LXColor.b(col) / 100f);
   }
 
   @Override

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -55,14 +55,8 @@ public class GLShaderPattern extends TEPerformancePattern implements GpuDevice {
     this(lx, TEShaderView.ALL_POINTS);
   }
 
-  protected ByteBuffer imageBuffer;
-
   public GLShaderPattern(LX lx, TEShaderView view) {
     super(lx, view);
-
-    if (this.lx.engine.renderMode.cpu) {
-      imageBuffer = TEShader.allocateBackBuffer();
-    }
   }
 
   protected TEShader addShader(GLShader.Config config) {
@@ -103,7 +97,7 @@ public class GLShaderPattern extends TEPerformancePattern implements GpuDevice {
     }
     // Set the CPU buffer for the last shader, if using CPU mixer
     this.shaders
-        .get(this.shaders.size() - 1)
+        .getLast()
         .setCpuBuffer(this.lx.engine.renderMode.cpu ? this.colors : null);
 
     // Run the chain of shaders,

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
@@ -15,7 +15,7 @@ import titanicsend.pattern.yoffa.shader_engine.*;
  * Shader class for TE patterns and effects. Adds image file textures and uniforms for TE common
  * controls.
  */
-public class TEShader extends GLShader {
+public class TEShader extends GLShader implements GLShader.UniformSource {
 
   private static final int UNINITIALIZED = -1;
 
@@ -54,11 +54,13 @@ public class TEShader extends GLShader {
   private final TEShaderUniforms uniforms = new TEShaderUniforms();
   private boolean initializedUniforms = false;
 
+  boolean clearBackbuffer = false;
+
   public TEShader(GLShader.Config config) {
     super(config);
 
     // Uniform callback for TE common controls
-    addUniformSource(this::setUniforms);
+    addUniformSource(this);
   }
 
   // Setup
@@ -123,6 +125,12 @@ public class TEShader extends GLShader {
 
   // Run loop
 
+  @Override
+  public void onActive() {
+    this.clearBackbuffer = true;
+    super.onActive();
+  }
+
   private void initializeUniforms() {
     this.uniforms.audio = getUniformInt1(UniformNames.AUDIO_CHANNEL);
     this.uniforms.lxModelCoords = getUniformInt1(UniformNames.LX_MODEL_COORDS);
@@ -130,7 +138,8 @@ public class TEShader extends GLShader {
     this.uniforms.mappedBuffer = getUniformInt1(UniformNames.MAPPED_BUFFER);
   }
 
-  private void setUniforms(GLShader s) {
+  @Override
+  public void setUniforms(GLShader s) {
     // Use Uniform objects to track locations and values
     if (!initializedUniforms) {
       this.initializedUniforms = true;
@@ -163,6 +172,8 @@ public class TEShader extends GLShader {
 
     // Use older FBO as backbuffer
     int backBufferHandle = this.ppFBOs.copy.getTextureHandle();
+
+
     bindTextureUnit(TEXTURE_UNIT_BACKBUFFER, backBufferHandle);
     this.uniforms.backBuffer.setValue(TEXTURE_UNIT_BACKBUFFER);
 
@@ -189,6 +200,12 @@ public class TEShader extends GLShader {
   protected void render() {
     // Bind vertex array object
     bindVAO();
+
+    // Clear backbuffer on first frame (TODO: do this on disable)
+    if (this.clearBackbuffer) {
+      this.clearBackbuffer = false;
+      this.ppFBOs.copy.bind(true);
+    }
 
     // Bind framebuffer object (FBO)
     this.ppFBOs.render.bind();
@@ -234,17 +251,19 @@ public class TEShader extends GLShader {
       this.ppPBOs.swap();
     }
 
+    // No need to unbind VAO.
+    // Also not unbinding the FBO here, as other shader render passes will change it.
+    // And GLMixer will unbind the last FBO at the end of postMix().
+  }
+
+  @Override
+  public void unbindTextures() {
     // Unbind textures (except for audio, which stays bound for all patterns)
     unbindTextureUnit(TEXTURE_UNIT_COORDS);
     unbindTextureUnit(TEXTURE_UNIT_BACKBUFFER);
     for (TextureInfo ti : this.textures) {
       unbindTextureUnit(ti.unit);
     }
-    activateDefaultTextureUnit();
-
-    // No need to unbind VAO.
-    // Also not unbinding the FBO here, as other shader render passes will change it.
-    // And GLMixer will unbind the last FBO at the end of postMix().
   }
 
   /** Called by GLMixer to retrieve the current render texture handle */

--- a/te-app/src/main/java/titanicsend/pattern/glengine/mixer/BlendShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/mixer/BlendShader.java
@@ -3,14 +3,10 @@ package titanicsend.pattern.glengine.mixer;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.yoffa.shader_engine.Uniform;
 
-public class BlendShader extends GLShader {
+public class BlendShader extends GLShader implements GLShader.UniformSource {
 
   // Framebuffer object (FBO) for rendering
   private FBO fbo;
-
-  // Input texture units
-  private int textureUnitDst;
-  private int textureUnitSrc;
 
   // Input texture handles (src = blending from, dst = blending into)
   public int iDst = -1;
@@ -20,8 +16,8 @@ public class BlendShader extends GLShader {
   private float level = 0f;
 
   private static class BlendUniforms {
-    private Uniform.Int1 iDst;
-    private Uniform.Int1 iSrc;
+    private Uniform.Sampler2D iDst;
+    private Uniform.Sampler2D iSrc;
     private Uniform.Float1 level;
   }
 
@@ -32,7 +28,7 @@ public class BlendShader extends GLShader {
   public BlendShader(GLShader.Config config) {
     super(config);
 
-    addUniformSource(this::setUniforms);
+    addUniformSource(this);
   }
 
   @Override
@@ -43,10 +39,6 @@ public class BlendShader extends GLShader {
   @Override
   protected void allocateShaderBuffers() {
     super.allocateShaderBuffers();
-
-    // Use the first two "rotating" texture unit slots, avoiding our few reserved units
-    this.textureUnitSrc = getNextTextureUnit();
-    this.textureUnitDst = getNextTextureUnit();
 
     // FBO (framebuffer and texture) for rendering
     this.fbo = new FBO();
@@ -65,26 +57,24 @@ public class BlendShader extends GLShader {
   }
 
   private void initializeUniforms() {
-    this.uniforms.iDst = getUniformInt1("iDst");
-    this.uniforms.iSrc = getUniformInt1("iSrc");
+    // These will take the first two "rotating" texture unit slots, avoiding our few reserved units
+    this.uniforms.iDst = getUniformSampler2D("iDst");
+    this.uniforms.iSrc = getUniformSampler2D("iSrc");
     this.uniforms.level = getUniformFloat1("level");
   }
 
   /** Stage new uniform values that need to be sent to the shader */
-  private void setUniforms(GLShader s) {
+  @Override
+  public void setUniforms(GLShader s) {
     // Use Uniform objects to track locations and values
     if (!initializedUniforms) {
       this.initializedUniforms = true;
       initializeUniforms();
     }
 
-    // Bind input textures to texture units
-    bindTextureUnit(this.textureUnitDst, this.iDst);
-    bindTextureUnit(this.textureUnitSrc, this.iSrc);
-
     // Stage uniform values for updating
-    this.uniforms.iDst.setValue(this.textureUnitDst);
-    this.uniforms.iSrc.setValue(this.textureUnitSrc);
+    this.uniforms.iDst.setValue(this.iDst);
+    this.uniforms.iSrc.setValue(this.iSrc);
     this.uniforms.level.setValue(this.level);
   }
 
@@ -99,14 +89,15 @@ public class BlendShader extends GLShader {
     // Render frame to FBO
     drawElements();
 
-    // Unbind textures
-    unbindTextureUnit(this.textureUnitDst);
-    unbindTextureUnit(this.textureUnitSrc);
-    activateDefaultTextureUnit();
-
     // No need to unbind VAO.
     // Also not unbinding the FBO here, as other shader render passes will change it.
     // And GLMixer will unbind the last FBO at the end of postMix().
+  }
+
+  @Override
+  public void unbindTextures() {
+    this.uniforms.iDst.unbind();
+    this.uniforms.iSrc.unbind();
   }
 
   /** Retrieve the output texture handle */

--- a/te-app/src/main/java/titanicsend/pattern/glengine/mixer/GLMixer.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/mixer/GLMixer.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import titanicsend.effect.NDIOutShaderEffect;
 import titanicsend.pattern.glengine.GLEngine;
 import titanicsend.pattern.glengine.GLShaderEffect;
 import titanicsend.pattern.glengine.GLShaderPattern;
@@ -251,6 +253,11 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
             effect.setModel(effect.getModelView());
             effect.loop(deltaMs);
             dst = glShaderEffect.getRenderTexture();
+          } else if (effect instanceof NDIOutShaderEffect ndiOutShaderEffect) {
+            ndiOutShaderEffect.setDst(dst);
+            effect.setModel(effect.getModelView());
+            effect.loop(deltaMs);
+            // Do not modify dst. Output texture is for NDI sending, not for us.
           } else {
             // Java effect in GPU mode
             // Currently gets looped for processing but the output is not used

--- a/te-app/src/main/java/titanicsend/pattern/glengine/mixer/GLMixer.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/mixer/GLMixer.java
@@ -13,6 +13,7 @@ import static titanicsend.pattern.glengine.GLShaderPattern.NO_TEXTURE;
 
 import com.jogamp.opengl.GL4;
 import heronarts.lx.LX;
+import heronarts.lx.ModelBuffer;
 import heronarts.lx.blend.LXBlend;
 import heronarts.lx.blend.MultiplyBlend;
 import heronarts.lx.effect.LXEffect;
@@ -44,7 +45,11 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
 
   private boolean initialized = false;
 
+  // Default starting texture for buses
   private int blackBackground = UNINITIALIZED;
+
+  // Dummy CPU buffer for Java effects in GPU mode
+  private final ModelBuffer dummyBuffer;
 
   // Wrapper classes around LX channels
   private final GLMasterBus glMasterBus;
@@ -54,6 +59,8 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
   public GLMixer(LX lx, GLEngine glEngine) {
     this.lx = lx;
     this.glEngine = glEngine;
+
+    this.dummyBuffer = new ModelBuffer(lx);
 
     this.glMasterBus = new GLMasterBus(lx.engine.mixer.masterBus);
 
@@ -117,6 +124,9 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
       throw new IllegalStateException("GLMixer was not initialized");
     }
 
+    // TODO: pass deltaMs from LXMixerEngine.loop()
+    double deltaMs = 16;
+
     // Patterns have been looped
 
     // Perform GPU mixing
@@ -125,7 +135,7 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
     this.glMasterBus.setMain(main);
 
     // Recursive run the buses
-    this.glMasterBus.blend(this.blackBackground);
+    this.glMasterBus.blend(deltaMs, this.blackBackground);
 
     // Unbind framebuffer, the next GL commands might be out of GLEngine scope...
     this.gl4.glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -203,7 +213,7 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
     }
 
     /** Blend down the bus onto the dst texture, returning the output texture handle */
-    final int blend(int dst) {
+    final int blend(double deltaMs, int dst) {
       // Fast-out if no blending or effect looping
       if (!isActive()) {
         return dst;
@@ -212,10 +222,10 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
       // Future expansion note: run geometry-manipulation effects here, *then* loop patterns.
 
       // Composite contents (If this is a group, subchannels. Or if this is a channel, patterns.)
-      int src = blendContents();
+      int src = blendContents(deltaMs);
 
       // Run Effects
-      src = loopEffects(src, bus.effects);
+      src = loopEffects(deltaMs, src, bus.effects);
 
       // Blend the bus texture onto the dst texture
       return finalBlend(dst, src);
@@ -228,16 +238,25 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
     protected abstract boolean isActive();
 
     /** Blend the bus contents (either channels or patterns), but do not yet run effects. */
-    protected abstract int blendContents();
+    protected abstract int blendContents(double deltaMs);
 
-    protected final int loopEffects(int dst, List<LXEffect> effects) {
+    protected final int loopEffects(double deltaMs, int dst, List<LXEffect> effects) {
       for (LXEffect effect : effects) {
-        if (effect instanceof GLShaderEffect glShaderEffect) {
-          /*
-                    glShaderEffect.setInput(dst);
-                    glShaderEffect.run();
-                    dst = glShaderEffect.getRenderTexture();
-          */
+        // TODO: loop effect for damping even if disabled
+        if (effect.isEnabled()) {
+          effect.setBuffer(dummyBuffer);
+          if (effect instanceof GLShaderEffect glShaderEffect) {
+            // Shader effect in GPU mode
+            glShaderEffect.setDst(dst);
+            effect.setModel(effect.getModelView());
+            effect.loop(deltaMs);
+            dst = glShaderEffect.getRenderTexture();
+          } else {
+            // Java effect in GPU mode
+            // Currently gets looped for processing but the output is not used
+            effect.setModel(effect.getModelView());
+            effect.loop(deltaMs);
+          }
         }
       }
       return dst;
@@ -267,13 +286,13 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
     }
 
     @Override
-    protected int blendContents() {
+    protected int blendContents(double deltaMs) {
       int dst = blackBackground;
       // Blend all channels in the mixer
       for (LXAbstractChannel channel : lx.engine.mixer.channels) {
         if (!channel.isInGroup()) {
           GLAbstractChannel glChannel = channelMap.get(channel);
-          dst = glChannel.blend(dst);
+          dst = glChannel.blend(deltaMs, dst);
         }
       }
       return dst;
@@ -381,12 +400,12 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
     }
 
     @Override
-    protected int blendContents() {
+    protected int blendContents(double deltaMs) {
       int dst = blackBackground;
       // Blend all channels in the group
       for (LXAbstractChannel channel : this.group.channels) {
         GLAbstractChannel glChannel = channelMap.get(channel);
-        dst = glChannel.blend(dst);
+        dst = glChannel.blend(deltaMs, dst);
       }
       return dst;
     }
@@ -413,7 +432,7 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
 
     // Get output of active pattern or patterns within a channel. Do not apply channel-level effects
     @Override
-    protected int blendContents() {
+    protected int blendContents(double deltaMs) {
       // Fast-out if no patterns
       if (this.channel.patterns.isEmpty()) {
         return blackBackground;
@@ -423,9 +442,9 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
       if (this.channel.isComposite()) {
         return compositePatterns();
       } else if (this.channel.isInTransition()) {
-        return transition();
+        return transition(deltaMs);
       } else {
-        return getPatternTexture(this.channel.getActivePattern());
+        return getPatternTexture(deltaMs, this.channel.getActivePattern());
       }
     }
 
@@ -440,11 +459,11 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
       return blackBackground;
     }
 
-    private int transition() {
+    private int transition(double deltaMs) {
       // Get both patterns and blend them using the transition blend
       float transitionProgress = (float) this.channel.getTransitionProgress();
-      int activeTexture = getPatternTexture(this.channel.getActivePattern());
-      int nextTexture = getPatternTexture(this.channel.getNextPattern());
+      int activeTexture = getPatternTexture(deltaMs, this.channel.getActivePattern());
+      int nextTexture = getPatternTexture(deltaMs, this.channel.getNextPattern());
       this.transitionShader.setSrc(nextTexture);
       this.transitionShader.setDst(activeTexture);
       this.transitionShader.setLevel(transitionProgress);
@@ -452,7 +471,7 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
       return this.transitionShader.getRenderTexture();
     }
 
-    private int getPatternTexture(LXPattern pattern) {
+    private int getPatternTexture(double deltaMs, LXPattern pattern) {
       int patternTexture = blackBackground;
 
       // Get output texture from pattern, if any
@@ -465,7 +484,7 @@ public class GLMixer implements LXMixerEngine.Listener, LXMixerEngine.PostMixer 
 
       // Loop pattern-level effects
       if (pattern != null) {
-        patternTexture = loopEffects(patternTexture, pattern.effects);
+        patternTexture = loopEffects(deltaMs, patternTexture, pattern.effects);
       }
 
       return patternTexture;

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/Uniform.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/Uniform.java
@@ -1,6 +1,7 @@
 package titanicsend.pattern.yoffa.shader_engine;
 
 import static com.jogamp.opengl.GL.GL_TEXTURE0;
+import static com.jogamp.opengl.GL.GL_TEXTURE_2D;
 
 import com.jogamp.opengl.GL4;
 import com.jogamp.opengl.util.texture.Texture;
@@ -580,10 +581,21 @@ public abstract class Uniform {
     }
 
     private final int textureUnit;
+
+    private boolean isObject = false;
     private Texture texture = null;
+    private int textureHandle = -1;
 
     public Sampler2D setValue(Texture texture) {
       this.texture = texture;
+      this.isObject = true;
+      this.modified = true;
+      return this;
+    }
+
+    public Sampler2D setValue(int textureHandle) {
+      this.textureHandle = textureHandle;
+      this.isObject = false;
       this.modified = true;
       return this;
     }
@@ -591,8 +603,17 @@ public abstract class Uniform {
     @Override
     public void update() {
       gl4.glActiveTexture(GL_TEXTURE0 + this.textureUnit);
-      this.texture.bind(gl4);
+      if (this.isObject) {
+        this.texture.bind(gl4);
+      } else {
+        gl4.glBindTexture(GL_TEXTURE_2D, this.textureHandle);
+      }
       gl4.glUniform1i(this.location, this.textureUnit);
+    }
+
+    public void unbind() {
+      gl4.glActiveTexture(GL_TEXTURE0 + this.textureUnit);
+      gl4.glBindTexture(GL_TEXTURE_2D, 0);
     }
   }
 }


### PR DESCRIPTION
Key updates for effects in GPU mode and plumbing for NDI Out shader.

Adds:

- Improved unbinding of textures
- Shader effects
- Example shader effect: Sustain
- A NDI Out shader effect in GPU mode, works but still uses heavy CPU
