### PR TITLE
NDIOutShader incremental improvements

### DIFF
--- a/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
+++ b/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
@@ -114,11 +114,8 @@ public class NDIOutShader extends GLShader implements GLShader.UniformSource {
     // Render frame
     drawElements();
 
-    // Bind the current PBO
-    this.ppPBOs.render.bind();
-
-    // Read pixels into current PBO
-    this.gl4.glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, 0);
+    // Start async read of framebuffer into PBO
+    this.ppPBOs.render.startRead();
 
     if (firstFrame) {
       // Skip the first frame, PBO is empty
@@ -126,18 +123,12 @@ public class NDIOutShader extends GLShader implements GLShader.UniformSource {
     } else {
 
       // Map the other PBO for reading (from previous frame)
-      this.ppPBOs.copy.bind();
-      this.imageBuffer = this.gl4.glMapBuffer(GL4.GL_PIXEL_PACK_BUFFER, GL4.GL_READ_ONLY);
+      this.imageBuffer = this.ppPBOs.copy.getData();
 
       if (this.imageBuffer != null) {
-        this.imageBuffer.rewind(); // Needed?
-
         // Send NDI frame
         this.ndiFrame.setData(this.imageBuffer);
         this.ndiSender.sendVideoFrame(this.ndiFrame);
-
-        // Unmap the PBO
-        this.gl4.glUnmapBuffer(GL4.GL_PIXEL_PACK_BUFFER);
       }
     }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -945,7 +945,6 @@ public abstract class GLShader {
 
       if (buffer != null) {
         // Anything here? rewind? copy to other buffer?
-
         gl4.glUnmapBuffer(GL4.GL_PIXEL_PACK_BUFFER);
       }
 
@@ -998,6 +997,82 @@ public abstract class GLShader {
     public void dispose() {
       this.render.dispose();
       this.copy.dispose();
+    }
+  }
+
+  protected class TripleFBO {
+    private final FBO[] fbo = new FBO[3];
+    private int a = 0;
+    private int b = 1;
+    private int c = 2;
+
+    public TripleFBO() {
+      for (int i = 0; i < fbo.length; i++) {
+        fbo[i] = new FBO();
+      }
+    }
+
+    public FBO a() {
+      return fbo[a];
+    }
+
+    public FBO b() {
+      return fbo[b];
+    }
+
+    public FBO c() {
+      return fbo[c];
+    }
+
+    public void swap() {
+      int temp = a;
+      a = c;
+      c = b;
+      b = temp;
+    }
+
+    public void dispose() {
+      for (FBO p : fbo) {
+        p.dispose();
+      }
+    }
+  }
+
+  protected class TriplePBO {
+    private final PBO[] pbo = new PBO[3];
+    private int a = 0;
+    private int b = 1;
+    private int c = 2;
+
+    public TriplePBO() {
+      for (int i = 0; i < pbo.length; i++) {
+        pbo[i] = new PBO();
+      }
+    }
+
+    public PBO a() {
+      return pbo[a];
+    }
+
+    public PBO b() {
+      return pbo[b];
+    }
+
+    public PBO c() {
+      return pbo[c];
+    }
+
+    public void swap() {
+      int temp = a;
+      a = c;
+      c = b;
+      b = temp;
+    }
+
+    public void dispose() {
+      for (PBO p : pbo) {
+        p.dispose();
+      }
     }
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
@@ -214,10 +214,8 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
 
     // JKB note: Retrofit of CPU compatibility for the GPU branch:
     if (this.lx.engine.renderMode.cpu && this.cpuBuffer != null) {
-      // Bind the current PBO
-      this.ppPBOs.render.bind();
-
-      gl4.glReadPixels(0, 0, this.width, this.height, GL_BGRA, GL_UNSIGNED_BYTE, 0);
+      // Start async read of framebuffer into PBO
+      this.ppPBOs.render.startRead();
 
       if (firstFrame) {
         // Skip the first frame, PBO is empty
@@ -225,13 +223,10 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
       } else {
 
         // Map the other PBO for reading (from previous frame)
-        this.ppPBOs.copy.bind();
-
-        this.imageBuffer = this.gl4.glMapBuffer(GL4.GL_PIXEL_PACK_BUFFER, GL4.GL_READ_ONLY);
+        this.imageBuffer = this.ppPBOs.copy.getData();
 
         if (this.imageBuffer != null) {
           // Copy data from PBO to cpu buffer
-          this.imageBuffer.rewind();
           IntBuffer src = this.imageBuffer.asIntBuffer();
           // Clamp
           int count = Math.min(src.remaining(), this.cpuBuffer.length);

--- a/te-app/src/main/java/titanicsend/pattern/glengine/mixer/BusShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/mixer/BusShader.java
@@ -100,11 +100,8 @@ public class BusShader extends GLShader implements GLShader.UniformSource {
     // Render frame
     drawElements();
 
-    // Bind the current PBO
-    this.ppPBOs.render.bind();
-
-    // Read pixels into current PBO
-    this.gl4.glReadPixels(0, 0, width, height, GL_BGRA, GL_UNSIGNED_BYTE, 0);
+    // Start async read of framebuffer into PBO
+    this.ppPBOs.render.startRead();
 
     if (firstFrame) {
       // Skip the first frame, PBO is empty
@@ -112,8 +109,7 @@ public class BusShader extends GLShader implements GLShader.UniformSource {
     } else {
 
       // Map the other PBO for reading (from previous frame)
-      this.ppPBOs.copy.bind();
-      ByteBuffer pboData = this.gl4.glMapBuffer(GL4.GL_PIXEL_PACK_BUFFER, GL4.GL_READ_ONLY);
+      ByteBuffer pboData = this.ppPBOs.copy.getData();
 
       if (pboData != null) {
         // Copy data from PBO to main array


### PR DESCRIPTION
Slight improvement by using a triple buffer on the NDI output.

While sending NDI out at 1920x1200 @ 60fps, this is sometimes able to hover at 45% CPU.  Other times it is higher or lower but sometimes still pins at 100%.