### PR TITLE
Show feedback dialog to user after clicking Set Up Now on laser OSC

### DIFF
--- a/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -1,7 +1,9 @@
 package titanicsend.lasercontrol;
 
+import heronarts.glx.GLX;
 import heronarts.lx.LX;
 import heronarts.lx.LXComponent;
+import heronarts.lx.osc.LXOscConnection;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.TriggerParameter;
@@ -76,7 +78,14 @@ public class TELaserTask extends LXComponent {
   }
 
   private void runSetup() {
-    BeyondPlugin.confirmOscOutput(this.lx, PangolinHost.HOSTNAME, PangolinHost.PORT);
+    // Confirm the OSC output for lasers (with correct filter) exists, or create a new one if not
+    LXOscConnection.Output output =
+        BeyondPlugin.confirmOscOutput(this.lx, PangolinHost.HOSTNAME, PangolinHost.PORT);
+
+    // If someone clicked the button, let's make sure the output is turned on
+    output.active.setValue(true);
+
+    ((GLX) this.lx).ui.showContextDialogMessage("OSC output for lasers is ready to use!");
   }
 
   @Override


### PR DESCRIPTION
Giving *some* feedback to avoid confusion.  Clicking this button:
<img width="171" height="27" alt="image" src="https://github.com/user-attachments/assets/694b3525-bb5f-43b9-a3b1-dfcf13679233" />

...shows this dialog:
<img width="270" height="100" alt="image" src="https://github.com/user-attachments/assets/53219899-d228-403c-adeb-1fab619b2b0e" />
