### PR TITLE
Laser color hue/sat uses Beyond OSC ch 15 and 16

### DIFF
--- a/te-app/src/main/java/titanicsend/color/TEColorParameter.java
+++ b/te-app/src/main/java/titanicsend/color/TEColorParameter.java
@@ -289,6 +289,32 @@ public class TEColorParameter extends ColorParameter implements GradientUtils.Gr
     }
   }
 
+  public float calcHuef() {
+    switch (this.colorSource.getEnum()) {
+      case NORMAL:
+        return LXColor.h(getGradientColorFixed(getOffsetf(), TEGradient.NORMAL));
+      case DARK:
+        // Workaround: Hue will dip to 0(red) if we sample a black part of the Dark gradient.
+        // But the correct hue is visible in the Normal gradient, so we'll just use that.
+        return LXColor.h(getGradientColorFixed(getOffsetf(), TEGradient.NORMAL));
+      case STATIC:
+      default:
+        return this.hue.getValuef();
+    }
+  }
+
+  public float calcSaturationf() {
+    switch (this.colorSource.getEnum()) {
+      case NORMAL:
+        return LXColor.s(getGradientColorFixed(getOffsetf(), TEGradient.NORMAL));
+      case DARK:
+        return LXColor.s(getGradientColorFixed(getOffsetf(), TEGradient.DARK));
+      case STATIC:
+      default:
+        return this.saturation.getValuef();
+    }
+  }
+
   @Override
   public void dispose() {
     this.offset.removeListener(offsetListener);

--- a/te-app/src/main/java/titanicsend/lasercontrol/TEBeyondColorSync.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TEBeyondColorSync.java
@@ -3,7 +3,6 @@ package titanicsend.lasercontrol;
 import heronarts.lx.LX;
 import heronarts.lx.LXLoopTask;
 import heronarts.lx.color.ColorParameter;
-import heronarts.lx.color.LXColor;
 import studio.jkb.beyond.parameter.BeyondCompoundParameter;
 import titanicsend.color.TEColorParameter;
 
@@ -42,16 +41,12 @@ public class TEBeyondColorSync implements LXLoopTask {
     this.lx = lx;
     this.colorParameter = colorParameter;
 
-    this.hue = new BeyondCompoundParameter(lx, "Hue",
-      HUE_OSC_BEYOND_PATH,
-      HUE_VALUE_DEFAULT,
-      HUE_VALUE_0,
-      HUE_VALUE_1);
-    this.saturation = new BeyondCompoundParameter(lx, "Saturation",
-      SAT_OSC_BEYOND_PATH,
-      SAT_VALUE_DEFAULT,
-      SAT_VALUE_0,
-      SAT_VALUE_1);
+    this.hue =
+        new BeyondCompoundParameter(
+            lx, "Hue", HUE_OSC_BEYOND_PATH, HUE_VALUE_DEFAULT, HUE_VALUE_0, HUE_VALUE_1);
+    this.saturation =
+        new BeyondCompoundParameter(
+            lx, "Saturation", SAT_OSC_BEYOND_PATH, SAT_VALUE_DEFAULT, SAT_VALUE_0, SAT_VALUE_1);
 
     this.lx.engine.addLoopTask(this);
   }

--- a/te-app/src/main/java/titanicsend/lasercontrol/TEBeyondColorSync.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TEBeyondColorSync.java
@@ -1,0 +1,90 @@
+package titanicsend.lasercontrol;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXLoopTask;
+import heronarts.lx.color.ColorParameter;
+import heronarts.lx.color.LXColor;
+import studio.jkb.beyond.parameter.BeyondCompoundParameter;
+import titanicsend.color.TEColorParameter;
+
+/**
+ * Wraps a color parameter and sends Hue Shift + Saturation to Beyond in a TE-specific manner
+ * detailed by Jeff in a handwritten document on a late August night early in the 21st century.
+ */
+public class TEBeyondColorSync implements LXLoopTask {
+
+  private static final String HUE_OSC_BEYOND_PATH = "/b/Channels/15/Value";
+  private static final float HUE_VALUE_DEFAULT = 0;
+  private static final float HUE_VALUE_0 = 0;
+  private static final float HUE_VALUE_1 = 1;
+
+  private static final String SAT_OSC_BEYOND_PATH = "/b/Channels/16/Value";
+  private static final float SAT_VALUE_DEFAULT = 1;
+  private static final float SAT_VALUE_0 = 1;
+  private static final float SAT_VALUE_1 = 0;
+
+  // Scale values to convert TE color parameter values to normalized
+  private static final float LX_HUE_RANGE = 360f;
+  private static final float LX_SATURATION_RANGE = 100f;
+
+  private final LX lx;
+
+  private final BeyondCompoundParameter hue;
+  private final BeyondCompoundParameter saturation;
+
+  private TEColorParameter colorParameter = null;
+
+  public TEBeyondColorSync(LX lx) {
+    this(lx, null);
+  }
+
+  public TEBeyondColorSync(LX lx, TEColorParameter colorParameter) {
+    this.lx = lx;
+    this.colorParameter = colorParameter;
+
+    this.hue = new BeyondCompoundParameter(lx, "Hue",
+      HUE_OSC_BEYOND_PATH,
+      HUE_VALUE_DEFAULT,
+      HUE_VALUE_0,
+      HUE_VALUE_1);
+    this.saturation = new BeyondCompoundParameter(lx, "Saturation",
+      SAT_OSC_BEYOND_PATH,
+      SAT_VALUE_DEFAULT,
+      SAT_VALUE_0,
+      SAT_VALUE_1);
+
+    this.lx.engine.addLoopTask(this);
+  }
+
+  public TEBeyondColorSync setColorParameter(TEColorParameter colorParameter) {
+    this.colorParameter = colorParameter;
+    return this;
+  }
+
+  public ColorParameter getColorParameter() {
+    return this.colorParameter;
+  }
+
+  public TEBeyondColorSync setOutputEnabled(boolean outputEnabled) {
+    this.hue.setOutputEnabled(outputEnabled);
+    this.saturation.setOutputEnabled(outputEnabled);
+    return this;
+  }
+
+  @Override
+  public void loop(double deltaMs) {
+    if (this.colorParameter == null) {
+      return;
+    }
+
+    float h = this.colorParameter.calcHuef();
+    float s = this.colorParameter.calcSaturationf();
+
+    this.hue.setNormalized(h / LX_HUE_RANGE);
+    this.saturation.setNormalized(s / LX_SATURATION_RANGE);
+  }
+
+  public void dispose() {
+    this.lx.engine.removeLoopTask(this);
+  }
+}

--- a/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -38,7 +38,7 @@ public class TELaserTask extends LXComponent {
   public final TEColorParameter color;
 
   public final BeyondCompoundParameter brightness;
-  private final BeyondColorSync colorSync;
+  private final TEBeyondColorSync colorSync;
   private final BeyondBpmSync bpm;
 
   public final TriggerParameter setUpOsc =
@@ -56,7 +56,7 @@ public class TELaserTask extends LXComponent {
     this.color = new TEColorParameter(TEGradientSource.get(), "Lasers");
 
     this.brightness = new BeyondCompoundParameter(lx, BeyondVariable.BRIGHTNESS, "Lasers");
-    this.colorSync = new BeyondColorSync(lx, this.color);
+    this.colorSync = new TEBeyondColorSync(lx, this.color);
     this.bpm = new BeyondBpmSync(lx);
 
     this.brightness.setOutputEnabled(this.sendBrightness.isOn());

--- a/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
+++ b/te-app/src/main/java/titanicsend/lasercontrol/TELaserTask.java
@@ -8,7 +8,6 @@ import heronarts.lx.parameter.TriggerParameter;
 import studio.jkb.beyond.BeyondPlugin;
 import studio.jkb.beyond.BeyondVariable;
 import studio.jkb.beyond.parameter.BeyondBpmSync;
-import studio.jkb.beyond.parameter.BeyondColorSync;
 import studio.jkb.beyond.parameter.BeyondCompoundParameter;
 import titanicsend.color.TEColorParameter;
 import titanicsend.color.TEGradientSource;


### PR DESCRIPTION
As requested!

I left some obvious `static final` values at the top of `TEBeyondColorSync` in case you need to modify the OSC path or min/max values.