### PR TITLE
fix(audio-stems): te-app import using parent pom version

### DIFF
--- a/audio-stems/pom.xml
+++ b/audio-stems/pom.xml
@@ -11,7 +11,6 @@
 	</parent>
 
 	<artifactId>audio-stems</artifactId>
-	<version>0.1.0-SNAPSHOT</version>
 	<name>Audio Stems Plugin</name>
 	<description>A Chromatik plugin that receives audio stem information over OSC and makes it available for real-time
 		display and mapping.

--- a/te-app/pom.xml
+++ b/te-app/pom.xml
@@ -104,7 +104,7 @@
 		<dependency>
 			<groupId>com.titanicsend</groupId>
 			<artifactId>audio-stems</artifactId>
-			<version>0.1.0-SNAPSHOT</version>
+			<version>${project.parent.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Noticed some IDE/maven weirdness because te-app wasn't actually importing audio-stems plugin from within the monorepo, it was stuck on an old version