### PR TITLE
tweak(defaults): DotVortex panic button should still have speed=0.5, not 0

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -284,7 +284,7 @@ public class ShaderPanelsPatternConfig {
 
     @Override
     protected void createShader() {
-      controls.setRange(TEControlTag.SPEED, 0, -4, 4).setValue(TEControlTag.SPEED, 0.5);
+      controls.setRange(TEControlTag.SPEED, 0.5, -4, 4);
 
       controls.setRange(TEControlTag.SIZE, 1.3, 6., 0.75); // vortex size
       controls.setRange(TEControlTag.SPIN, 0, -0.5, 0.5); // rotate about x


### PR DESCRIPTION
Small hiccup i noticed during VJ training: Clicking "Panic" button on dot vortex caused pattern to stop completely (even though when it's added to channel, the default is 0.5).

https://github.com/user-attachments/assets/7e280237-03c1-4760-9d2c-c83d86a8667e

