### PR TITLE
tweak(defaults): ExplodeEffects start in Manual Trigger mode (not sync)

### DIFF
--- a/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
@@ -39,10 +39,10 @@ public class ExplodeEffect extends GLShaderEffect {
       new BoundedParameter("Slope", 5, 1, 15).setDescription("Steepness of effect/time curve");
 
   public final BooleanParameter tempoSync =
-      new BooleanParameter("Sync", true).setDescription("Sync the effect to the engine tempo");
+      new BooleanParameter("Sync", false).setDescription("Sync the effect to the engine tempo");
 
   public final BooleanParameter manualTrigger =
-      new BooleanParameter("Manual", false)
+      new BooleanParameter("Manual", true)
           .setDescription("Enable manual triggering w/trigger button");
 
   public final EnumParameter<Tempo.Division> tempoDivision =


### PR DESCRIPTION
Small preference tweak: since we use Explode as an effect, I'm always slightly surprised when it doesn't trigger the first time I click it (but when i ramp up the depth in preparation to trigger it, it starts exploding based on tempo before I expected it to).

I'd prefer it starts in manual trigger mode, and operators can switch to sync mode on purpose