### PR TITLE
GlobalEffectsManager (no UI yet), and making some effects implement TEPerformanceEffect

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -46,6 +46,7 @@ import titanicsend.app.dev.UIDevSwitch;
 import titanicsend.app.director.Director;
 import titanicsend.app.director.DirectorEffect;
 import titanicsend.app.director.UIDirector;
+import titanicsend.app.effectmgr.GlobalEffectManager;
 import titanicsend.audio.AudioStemModulator;
 import titanicsend.audio.AudioStems;
 import titanicsend.audio.AudioStemsPlugin;
@@ -173,6 +174,7 @@ public class TEApp extends LXStudio {
     private DevSwitch devSwitch;
     private final Director director;
     private final PresetEngine presetEngine;
+    private final GlobalEffectManager effectManager;
 
     // objects that manage UI displayed in 3D views
     private UI3DManager ui3dManager;
@@ -201,6 +203,7 @@ public class TEApp extends LXStudio {
       gamepadEngine = new GamepadEngine(lx);
       this.presetEngine = new PresetEngine(lx);
       this.presetEngine.openFile(lx.getMediaFile("Presets/UserPresets/BM24.userPresets"));
+      this.effectManager = new GlobalEffectManager(lx);
 
       // Super Modulator midi controller
       this.superMod = new SuperMod(lx);

--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -1,0 +1,123 @@
+package titanicsend.app.effectmgr;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.LXComponent;
+import heronarts.lx.LXComponentName;
+import heronarts.lx.effect.LXEffect;
+import heronarts.lx.mixer.LXBus;
+import heronarts.lx.osc.LXOscComponent;
+import titanicsend.audio.LOG;
+import titanicsend.effect.TEPerformanceEffect;
+
+@LXCategory(LXCategory.OTHER)
+@LXComponentName("Effect Manager")
+public class GlobalEffectManager extends LXComponent
+    implements LXOscComponent, LXBus.Listener, LX.ProjectListener {
+
+//  LXEffect effect1;
+//  final BooleanParameter effect1Registered =
+//      new BooleanParameter("E2 Registered", false).setDescription("");
+//
+//  public final TriggerParameter effect1Trigger =
+//      new TriggerParameter("E1 Trigger", this::triggerEffect1)
+//          .setDescription("Push the managed swatch to the global active swatch");
+//
+//  public LXListenableNormalizedParameter effect1Param = null;
+
+  private static GlobalEffectManager instance;
+
+  public static GlobalEffectManager get() {
+    return instance;
+  }
+
+  private final List<TEPerformanceEffect> registeredEffects = new ArrayList<>();
+
+  public GlobalEffectManager(LX lx) {
+    super(lx, "effectmgr");
+
+    // When we first open the Project, we need to load up all effects from Master Bus
+    this.lx.addProjectListener(this);
+    // When effects are added / removed / moved on Master Bus, we gotta listen and update
+    this.lx.engine.mixer.masterBus.addListener(this);
+  }
+
+  @Override
+  public void effectAdded(LXBus channel, LXEffect effect) {
+    if (effect instanceof TEPerformanceEffect) {
+      attemptToRegister((TEPerformanceEffect) effect);
+      LOG.log("TEPerformanceEffect added: " + effect.getLabel());
+    }
+  }
+
+  @Override
+  public void effectRemoved(LXBus channel, LXEffect effect) {
+    if (effect instanceof TEPerformanceEffect && registeredEffects.contains((TEPerformanceEffect) effect)) {
+      registeredEffects.remove(effect);
+      LOG.log("TEPerformanceEffect removed: " + effect.getLabel());
+    }
+  }
+
+  @Override
+  public void effectMoved(LXBus channel, LXEffect effect) {
+    LOG.log("TEPerformanceEffect moved: " + effect.getLabel());
+  }
+
+  private void attemptToRegister(TEPerformanceEffect effect) {
+    LOG.log(
+        "Effect[ProjectChanged - TEPerformanceEffect]: '"
+            + effect.getLabel()
+            + "', enabled: "
+            + effect.enabled.isOn());
+    if (registeredEffects.contains(effect)) {
+      // already exists
+      return;
+    }
+
+    registeredEffects.add(effect);
+  }
+
+  @Override
+  public void projectChanged(File file, LX.ProjectListener.Change change) {
+    // TODO: is it enough to have the bus listener above / do I also need this proj listener?
+
+//    // Auto-create Director Effect
+//    if (change == LX.ProjectListener.Change.OPEN) {
+//      // Does effect already exist?
+//      for (LXEffect effect : this.lx.engine.mixer.masterBus.effects) {
+//        if (effect instanceof TEPerformanceEffect) {
+//          attemptToRegister((TEPerformanceEffect) effect);
+//        }
+//      }
+//    }
+  }
+
+//  public void registerEffect1(LXEffect effect, LXListenableNormalizedParameter param) {
+//    this.effect1 = effect;
+//    this.effect1Registered.setValue(true);
+//    this.effect1Param = param;
+//  }
+//
+//  public void disposeEffect1(LXEffect effect) {
+//    if (this.effect1 != effect) {
+//      // for prototyping, I've hardcoded "effect1". Really, this will end up as
+//      // an array or list, so we'll find the effect in that list and dispose it.
+//      return;
+//    }
+//  }
+//
+//  public void triggerEffect1() {
+//    // TODO
+//  }
+
+  @Override
+  public void dispose() {
+    this.lx.removeProjectListener(this);
+    this.lx.engine.mixer.masterBus.removeListener(this);
+    super.dispose();
+  }
+}

--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -7,28 +7,38 @@ import heronarts.lx.LXComponentName;
 import heronarts.lx.effect.LXEffect;
 import heronarts.lx.mixer.LXBus;
 import heronarts.lx.osc.LXOscComponent;
-import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import titanicsend.audio.LOG;
-import titanicsend.effect.TEPerformanceEffect;
+import titanicsend.effect.*;
 
 @LXCategory(LXCategory.OTHER)
 @LXComponentName("Effect Manager")
-public class GlobalEffectManager extends LXComponent
-    implements LXOscComponent, LXBus.Listener, LX.ProjectListener {
+public class GlobalEffectManager extends LXComponent implements LXOscComponent, LXBus.Listener {
+
+  public static final int NUM_EFFECT_SLOTS = 8;
+  public static final List<Class<? extends TEPerformanceEffect>> EFFECT_SLOTS =
+      List.of(
+          RandomStrobeEffect.class,
+          ExplodeEffect.class,
+          SimplifyEffect.class,
+          SustainEffect.class,
+          null,
+          null,
+          null,
+          null);
 
   private static GlobalEffectManager instance;
 
-  private final List<TEPerformanceEffect> registeredEffects = new ArrayList<>();
+  private final List<TEPerformanceEffect> mutableSlots = new ArrayList<>(NUM_EFFECT_SLOTS);
+  public final List<TEPerformanceEffect> slots = Collections.unmodifiableList(this.mutableSlots);
 
   public GlobalEffectManager(LX lx) {
-    super(lx, "effectmgr");
+    super(lx, "effectManager");
     GlobalEffectManager.instance = this;
 
-    // When we first open the Project, we need to load up all effects from Master Bus
-    this.lx.addProjectListener(this);
-    // When effects are added / removed / moved on Master Bus, we gotta listen and update
+    // When effects are added / removed / moved on Master Bus, listen and update
     this.lx.engine.mixer.masterBus.addListener(this);
   }
 
@@ -38,57 +48,37 @@ public class GlobalEffectManager extends LXComponent
 
   @Override
   public void effectAdded(LXBus channel, LXEffect effect) {
-    if (isPerformanceEffect(effect)) {
-      attemptToRegister(effect);
-      LOG.log("TEPerformanceEffect added: " + effect.getLabel());
+    if (isPerformanceEffect(effect) && !mutableSlots.contains((TEPerformanceEffect) effect)) {
+      int slotIndex = EFFECT_SLOTS.indexOf(effect.getClass());
+      if (slotIndex >= 0) {
+        mutableSlots.set(slotIndex, (TEPerformanceEffect) effect);
+        LOG.log("TEPerformanceEffect added to slot " + slotIndex + ": " + effect.getLabel());
+      }
     }
   }
 
   @Override
   public void effectRemoved(LXBus channel, LXEffect effect) {
-    if (isPerformanceEffect(effect) && registeredEffects.contains((TEPerformanceEffect) effect)) {
-      registeredEffects.remove(effect);
-      LOG.log("TEPerformanceEffect removed: " + effect.getLabel());
+    if (isPerformanceEffect(effect) && mutableSlots.contains((TEPerformanceEffect) effect)) {
+      int slotIndex = EFFECT_SLOTS.indexOf(effect.getClass());
+      if (slotIndex >= 0) {
+        mutableSlots.set(slotIndex, null);
+        LOG.log("TEPerformanceEffect removed: " + effect.getLabel());
+      }
     }
   }
 
   @Override
-  public void effectMoved(LXBus channel, LXEffect effect) {
-    LOG.log("TEPerformanceEffect moved: " + effect.getLabel());
-  }
-
-  private void attemptToRegister(LXEffect effect) {
-    LOG.log(
-        "Effect[ProjectChanged - TEPerformanceEffect]: '"
-            + effect.getLabel()
-            + "', enabled: "
-            + effect.enabled.isOn());
-    if (!isPerformanceEffect(effect)) {
-      LOG.log("NOT A PERFORMANCE EFFECT");
-      return;
-    }
-    TEPerformanceEffect performanceEffect = (TEPerformanceEffect) effect;
-    if (registeredEffects.contains(performanceEffect)) {
-      registeredEffects.add(performanceEffect);
-    }
-  }
+  public void effectMoved(LXBus channel, LXEffect effect) {}
 
   private static boolean isPerformanceEffect(LXEffect effect) {
-    if (TEPerformanceEffect.class.isAssignableFrom(effect.getClass())) {
-      return true;
-    } else {
-      return false;
-    }
-  }
-
-  @Override
-  public void projectChanged(File file, LX.ProjectListener.Change change) {
-    // TODO: is it enough to have the bus listener above / do I also need this proj listener?
+    return effect instanceof TEPerformanceEffect;
+    // NOTE(look): alternative approach if instanceof is not working
+    // System.out.println(TEPerformanceEffect.class.isAssignableFrom(effect.getClass());
   }
 
   @Override
   public void dispose() {
-    this.lx.removeProjectListener(this);
     this.lx.engine.mixer.masterBus.removeListener(this);
     super.dispose();
   }

--- a/te-app/src/main/java/titanicsend/app/effectmgr/UIGlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/UIGlobalEffectManager.java
@@ -1,0 +1,23 @@
+package titanicsend.app.effectmgr;
+
+import heronarts.glx.ui.UI;
+import heronarts.glx.ui.UI2dContainer;
+import heronarts.glx.ui.component.UICollapsibleSection;
+import heronarts.lx.studio.LXStudio;
+import heronarts.lx.studio.ui.device.UIControls;
+
+public class UIGlobalEffectManager extends UICollapsibleSection implements UIControls {
+
+  private final GlobalEffectManager effectManager;
+
+  public UIGlobalEffectManager(UI ui, GlobalEffectManager effectManager, float w) {
+    super(ui, w, 60);
+    this.effectManager = effectManager;
+  }
+
+  public static void addToPane(
+      LXStudio.UI ui, UI2dContainer pane, GlobalEffectManager effectManager, int index) {
+    new UIGlobalEffectManager(ui, effectManager, pane.getContentWidth())
+        .addToContainer(pane, index);
+  }
+}

--- a/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
@@ -169,6 +169,21 @@ public class ExplodeEffect extends GLShaderEffect {
     super.run(deltaMs, enabledAmount);
   }
 
+//  @Override
+//  public LXListenableNormalizedParameter primaryParam() {
+//    return this.speed;
+//  }
+//
+//  @Override
+//  public LXListenableNormalizedParameter secondaryParam() {
+//    return this.depth;
+//  }
+//
+//  @Override
+//  public void trigger() {
+//    this.manualTrigger.toggle();
+//  }
+
   @Override
   public void dispose() {
     trigger.removeListener(triggerListener);

--- a/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
@@ -169,20 +169,20 @@ public class ExplodeEffect extends GLShaderEffect {
     super.run(deltaMs, enabledAmount);
   }
 
-//  @Override
-//  public LXListenableNormalizedParameter primaryParam() {
-//    return this.speed;
-//  }
-//
-//  @Override
-//  public LXListenableNormalizedParameter secondaryParam() {
-//    return this.depth;
-//  }
-//
-//  @Override
-//  public void trigger() {
-//    this.manualTrigger.toggle();
-//  }
+  //  @Override
+  //  public LXListenableNormalizedParameter primaryParam() {
+  //    return this.speed;
+  //  }
+  //
+  //  @Override
+  //  public LXListenableNormalizedParameter secondaryParam() {
+  //    return this.depth;
+  //  }
+  //
+  //  @Override
+  //  public void trigger() {
+  //    this.manualTrigger.toggle();
+  //  }
 
   @Override
   public void dispose() {

--- a/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/ExplodeEffect.java
@@ -11,7 +11,7 @@ import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderEffect;
 
 @LXCategory("Titanics End")
-public class ExplodeEffect extends GLShaderEffect {
+public class ExplodeEffect extends GLShaderEffect implements TEPerformanceEffect {
   double effectDepth;
   private double lastBasis;
   private boolean triggerRequested = false;
@@ -169,20 +169,20 @@ public class ExplodeEffect extends GLShaderEffect {
     super.run(deltaMs, enabledAmount);
   }
 
-  //  @Override
-  //  public LXListenableNormalizedParameter primaryParam() {
-  //    return this.speed;
-  //  }
-  //
-  //  @Override
-  //  public LXListenableNormalizedParameter secondaryParam() {
-  //    return this.depth;
-  //  }
-  //
-  //  @Override
-  //  public void trigger() {
-  //    this.manualTrigger.toggle();
-  //  }
+  @Override
+  public LXListenableNormalizedParameter primaryParam() {
+    return this.speed;
+  }
+
+  @Override
+  public LXListenableNormalizedParameter secondaryParam() {
+    return this.depth;
+  }
+
+  @Override
+  public void trigger() {
+    this.manualTrigger.toggle();
+  }
 
   @Override
   public void dispose() {

--- a/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
@@ -26,20 +26,14 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.model.LXPoint;
 import heronarts.lx.modulator.LXWaveshape;
 import heronarts.lx.modulator.SawLFO;
-import heronarts.lx.parameter.BooleanParameter;
-import heronarts.lx.parameter.BoundedParameter;
-import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
-import heronarts.lx.parameter.FunctionalParameter;
-import heronarts.lx.parameter.LXParameter;
-import heronarts.lx.parameter.ObjectParameter;
+import heronarts.lx.parameter.*;
 import heronarts.lx.utils.LXUtils;
 import java.util.ArrayList;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.model.TEPanelModel;
 
 @LXCategory("Titanics End")
-public class RandomStrobeEffect extends TEEffect {
+public class RandomStrobeEffect extends TEEffect implements TEPerformanceEffect {
 
   private class Element {
     protected double offset;
@@ -158,21 +152,20 @@ public class RandomStrobeEffect extends TEEffect {
     }
   }
 
-//  @Override
-//  public LXListenableNormalizedParameter primaryParam() {
-//    return this.speed;
-//  }
-//
-//  @Override
-//  public LXListenableNormalizedParameter secondaryParam() {
-//    return this.depth;
-//  }
-//
-//  @Override
-//  public void trigger() {
-//    // TODO
-//    //    this.manualTrigger.toggle();
-//  }
+  @Override
+  public LXListenableNormalizedParameter primaryParam() {
+    return this.speed;
+  }
+
+  @Override
+  public LXListenableNormalizedParameter secondaryParam() {
+    return this.depth;
+  }
+
+  @Override
+  public void trigger() {
+    // TODO
+  }
 
   @Override
   protected void onEnable() {

--- a/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
@@ -158,6 +158,22 @@ public class RandomStrobeEffect extends TEEffect {
     }
   }
 
+//  @Override
+//  public LXListenableNormalizedParameter primaryParam() {
+//    return this.speed;
+//  }
+//
+//  @Override
+//  public LXListenableNormalizedParameter secondaryParam() {
+//    return this.depth;
+//  }
+//
+//  @Override
+//  public void trigger() {
+//    // TODO
+//    //    this.manualTrigger.toggle();
+//  }
+
   @Override
   protected void onEnable() {
     this.basis.setBasis(0).start();

--- a/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
@@ -162,6 +162,21 @@ public class SimplifyEffect extends LXEffect
   }
 
   @Override
+  public LXListenableNormalizedParameter primaryParam() {
+    return this.amount;
+  }
+
+  @Override
+  public LXListenableNormalizedParameter secondaryParam() {
+    return this.depth;
+  }
+
+  @Override
+  public void trigger() {
+    // this.manualTrigger.toggle();
+  }
+
+  @Override
   public void onParameterChanged(LXParameter p) {
     if (p == this.view || p == this.depth) {
       refreshModels();

--- a/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
@@ -7,10 +7,7 @@ import heronarts.lx.color.LXColor;
 import heronarts.lx.effect.LXEffect;
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
-import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.EnumParameter;
-import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.parameter.*;
 import heronarts.lx.parameter.LXParameter.Units;
 import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIDevice;
@@ -28,7 +25,7 @@ import java.util.List;
 @LXCategory("Model")
 @LXComponentName("Simplify")
 public class SimplifyEffect extends LXEffect
-    implements heronarts.lx.LX.Listener, UIDeviceControls<SimplifyEffect> {
+    implements TEPerformanceEffect, heronarts.lx.LX.Listener, UIDeviceControls<SimplifyEffect> {
 
   public enum BlendMode {
     HSB("HSB") {

--- a/te-app/src/main/java/titanicsend/effect/SustainEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SustainEffect.java
@@ -8,7 +8,7 @@ import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderEffect;
 
 @LXCategory("Titanics End")
-public class SustainEffect extends GLShaderEffect {
+public class SustainEffect extends GLShaderEffect implements TEPerformanceEffect {
 
   public final CompoundParameter sustain =
       new CompoundParameter("Sustain", 0)
@@ -25,17 +25,17 @@ public class SustainEffect extends GLShaderEffect {
   }
 
   @Override
-  protected LXListenableNormalizedParameter primaryParam() {
+  public LXListenableNormalizedParameter primaryParam() {
     return sustain;
   }
 
   @Override
-  protected LXListenableNormalizedParameter secondaryParam() {
+  public LXListenableNormalizedParameter secondaryParam() {
     return null;
   }
 
   @Override
-  protected void trigger() {
+  public void trigger() {
     // TODO
   }
 

--- a/te-app/src/main/java/titanicsend/effect/SustainEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SustainEffect.java
@@ -3,6 +3,7 @@ package titanicsend.effect;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderEffect;
 
@@ -21,6 +22,21 @@ public class SustainEffect extends GLShaderEffect {
 
     addShader(
         GLShader.config(lx).withFilename("sustain_effect.fs").withUniformSource(this::setUniforms));
+  }
+
+  @Override
+  protected LXListenableNormalizedParameter primaryParam() {
+    return sustain;
+  }
+
+  @Override
+  protected LXListenableNormalizedParameter secondaryParam() {
+    return null;
+  }
+
+  @Override
+  protected void trigger() {
+    // TODO
   }
 
   private void setUniforms(GLShader s) {

--- a/te-app/src/main/java/titanicsend/effect/TEPerformanceEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/TEPerformanceEffect.java
@@ -1,0 +1,38 @@
+package titanicsend.effect;
+
+import heronarts.lx.LX;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
+
+/** Effects for which we want easy trigger access on a dedicated MIDI controller. */
+public abstract class TEPerformanceEffect extends TEEffect {
+
+  public TEPerformanceEffect(LX lx) {
+    super(lx);
+  }
+
+  // Knobs to expose
+  protected abstract LXListenableNormalizedParameter primaryParam();
+
+  protected abstract LXListenableNormalizedParameter secondaryParam();
+
+  // Behavior when triggered
+  protected abstract void trigger();
+
+  // Idea: use these to annotate certain effects if they're only safe for GPU/CPU
+  /*
+  default boolean gpuMixerCompatible() {
+    return true;
+  }
+
+  default boolean cpuMixerCompatible() {
+    return true;
+  }
+  */
+
+  // Idea: for anything TE-model specific (e.g. BassLighting)
+  /*
+  default boolean teModelOnly() {
+    return false;
+  }
+  */
+}

--- a/te-app/src/main/java/titanicsend/effect/TEPerformanceEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/TEPerformanceEffect.java
@@ -1,38 +1,15 @@
 package titanicsend.effect;
 
-import heronarts.lx.LX;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
 
 /** Effects for which we want easy trigger access on a dedicated MIDI controller. */
-public abstract class TEPerformanceEffect extends TEEffect {
-
-  public TEPerformanceEffect(LX lx) {
-    super(lx);
-  }
+public interface TEPerformanceEffect {
 
   // Knobs to expose
-  protected abstract LXListenableNormalizedParameter primaryParam();
+  LXListenableNormalizedParameter primaryParam();
 
-  protected abstract LXListenableNormalizedParameter secondaryParam();
+  LXListenableNormalizedParameter secondaryParam();
 
   // Behavior when triggered
-  protected abstract void trigger();
-
-  // Idea: use these to annotate certain effects if they're only safe for GPU/CPU
-  /*
-  default boolean gpuMixerCompatible() {
-    return true;
-  }
-
-  default boolean cpuMixerCompatible() {
-    return true;
-  }
-  */
-
-  // Idea: for anything TE-model specific (e.g. BassLighting)
-  /*
-  default boolean teModelOnly() {
-    return false;
-  }
-  */
+  void trigger();
 }


### PR DESCRIPTION
`GlobalEffectsManager` (better name welcome, this is WIP)

## Proposed UI

- UI widget showing the top 8 effects that a VJ would want to use during a show
- order of those effects should **be hardcoded in the GlobalEffectsManager** ~mirror the order in which they're added to the master effects bus~
- Making this shortlist of effects easily visible:
  - UI widget in performance pane
  - Corresponding MIDI driver 

## Proposed Trigger/Toggle Behavior 

After playing with CDJ's once, I really like how their effects work:
- when available in the current project but **disabled**, the effect's toggle button is lit up (so it's easy to see in the dark)
- when **enabled**, the toggle button is blinking (on MIDI device and in UI)

When enabled, you can dial up the intensity, and then you click the effect button once for it to immediately disable (rather than needing to quickly spin a knob back to zero, with little room for error / looking terrible if it's a micron above zero).

## Proposed Design

Each relevant "performance effect" can **implement `TEPerformanceEffect` interface to define:
- one or two parameters which would be useful to communicate at a glance what the effect will do
- what "trigger" means for it.
  - For most effects, it might be as simple as `effect.enable()`, so `trigger()` has a default implementation in the interface and is not required by implementors (but they still have a hook to define any custom behavior)

`GlobalEffectsManager` has a hardcoded List of `Class<? extends TEPerformanceEffect>`, with a length corresponding to the number of available slots. Similar to `TEPerformancePattern`/`TECommonControls`, if an effect isn't present we'll have its slot empty, so we can maintain muscle memory for which effects live where on the MIDI controller.