### PR TITLE
fix(SimplifyEffect): add check before this.getModelView()

### DIFF
--- a/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
@@ -177,7 +177,9 @@ public class SimplifyEffect extends LXEffect
     // Candidate models are calculated from View groups + depth parameter
     final int depth = this.depth.getValuei();
     this.models.clear();
-    extractModels(this.models, this.getModelView(), depth);
+    if (this.getParent() != null) {
+      extractModels(this.models, this.getModelView(), depth);
+    }
   }
 
   @Override
@@ -229,7 +231,6 @@ public class SimplifyEffect extends LXEffect
       for (LXModel child : fromModel.children) {
         extractModels(toList, child, depth - 1);
       }
-      return;
     } else {
       toList.add(fromModel);
     }


### PR DESCRIPTION
When `SimplifyEffect` was calling `getModelView()` (right after being added to a channel), we were seeing an exception get thrown. Specifically here

```java
  // In LXDeviceComponent:

  public final LXModel getModelView() {
    LXViewDefinition view = this.view.getObject();
    if (view != null) {
      return view.getModelView();
    }
    return switch (getParent()) {  // <--- Exception thrown here
      case LXMasterBus master -> lx.model;
      case LXAbstractChannel bus -> bus.getModelView();
      case LXPattern pattern -> pattern.getModelView();
      default -> getModel();
    };
  }
```

It seems like maybe upstream LX should do a null check on that `getParent()` call, just to be safe?

I'm not totally sure where in the lifecycle that parent gets set on an LXEffect - maybe there's a better way for this effect to decide when to first refresh its models.

It seems to me like there are other places that `refreshModels` gets called. If `depth` defaults to `0` (no visual impact), and turning up the depth invokes a param listener that will call `refreshModels`, I think this is safe. Works for me when I tested locally.