### PR TITLE
UILabels: add edges and vertices

### DIFF
--- a/te-app/src/main/java/titanicsend/app/TEUIControls.java
+++ b/te-app/src/main/java/titanicsend/app/TEUIControls.java
@@ -30,6 +30,7 @@ public class TEUIControls extends UICollapsibleSection {
     controlRow(ui, controlWidth, visual.lasersVisible);
     controlRow(ui, controlWidth, visual.laserBoxSize);
     controlRow(ui, controlWidth, visual.panelLabelsVisible);
+    controlRow(ui, controlWidth, visual.edgeLabelsVisible);
     controlRow(ui, controlWidth, visual.vertexLabelsVisible);
 
     setContentHeight(Math.max(0, y - 4));

--- a/te-app/src/main/java/titanicsend/app/TEVirtualOverlays.java
+++ b/te-app/src/main/java/titanicsend/app/TEVirtualOverlays.java
@@ -19,6 +19,11 @@ public class TEVirtualOverlays extends LXComponent {
           .setDescription("Toggle whether vertex labels are visible")
           .setValue(false);
 
+  public final BooleanParameter edgeLabelsVisible =
+      new BooleanParameter("Edge Labels")
+          .setDescription("Toggle whether edge labels are visible")
+          .setValue(false);
+
   public final BooleanParameter panelLabelsVisible =
       new BooleanParameter("Panel Labels")
           .setDescription("Toggle whether panel labels are visible")
@@ -79,6 +84,7 @@ public class TEVirtualOverlays extends LXComponent {
 
     addParameter("vertexSpheresVisible", this.speakersVisible);
     addParameter("vertexLabelsVisible", this.vertexLabelsVisible);
+    addParameter("edgeLabelsVisible", this.edgeLabelsVisible);
     addParameter("panelLabelsVisible", this.panelLabelsVisible);
     addParameter("unknownPanelsVisible", this.unknownPanelsVisible);
     addParameter("opaqueBackPanelsVisible", this.opaqueBackPanelsVisible);

--- a/te-app/src/main/java/titanicsend/model/TEEdgeModel.java
+++ b/te-app/src/main/java/titanicsend/model/TEEdgeModel.java
@@ -1,7 +1,10 @@
 package titanicsend.model;
 
+import static titanicsend.model.TEPanelModel.calculateCentroid;
+
 import heronarts.lx.model.LXModel;
 import heronarts.lx.model.LXPoint;
+import heronarts.lx.transform.LXVector;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -45,10 +48,36 @@ public class TEEdgeModel extends TEModel {
 
   // Connections
   public final TEVertex v0, v1;
+  public final LXVector centroid;
   public final Set<TEPanelModel> connectedPanels = new HashSet<TEPanelModel>();
 
   /** This edge and any other that's a reflection about the XY or YZ planes */
   public final List<TEEdgeModel> symmetryGroup = new ArrayList<TEEdgeModel>();
+
+  /** Dynamic model constructor (2024+) */
+  public TEEdgeModel(LXModel model, TEVertex v0, TEVertex v1) {
+    super(TE_MODEL_TYPE, model);
+
+    this.v0 = v0;
+    this.v1 = v1;
+
+    setId(this.model.meta(META_ID));
+
+    this.size = this.model.points.length;
+    this.points = this.model.points;
+    this.centroid = calculateCentroid(this.points);
+    this.edgePoints = new Point[this.points.length];
+    for (int i = 0; i < this.points.length; i++) {
+      this.edgePoints[i] = new Point(this.points[i], i, fraction(i, this.size));
+    }
+    // register vertices
+    int id0 = Integer.parseInt(this.model.meta("v0"));
+    int id1 = Integer.parseInt(this.model.meta("v1"));
+    LXVector p0 = new LXVector(this.points[0]);
+    LXVector p1 = new LXVector(this.points[this.points.length - 1]);
+    TEVertex.registerVertex(id0, p0);
+    TEVertex.registerVertex(id1, p1);
+  }
 
   /** Static model constructor (2022-23) */
   public TEEdgeModel(TEVertex v0, TEVertex v1, int numPixels, boolean dark, String... tags) {
@@ -61,8 +90,9 @@ public class TEEdgeModel extends TEModel {
 
     this.size = this.model.size;
     this.points = this.model.points;
+    this.centroid = calculateCentroid(this.points);
     // Allocate an array of the LXPoint wrapper, TEEdgeModel.Point
-    this.edgePoints = new Point[this.model.points.length];
+    this.edgePoints = new Point[this.points.length];
     for (int i = 0; i < this.points.length; i++) {
       // Now that Point can't extend LXPoint we ended up calculating the fraction twice.
       this.edgePoints[i] = new Point(this.points[i], i, fraction(i, this.size));
@@ -89,23 +119,6 @@ public class TEEdgeModel extends TEModel {
       return (float) (i) / (numPixels - 1);
     } else {
       return .5f;
-    }
-  }
-
-  /** Dynamic model constructor (2024+) */
-  public TEEdgeModel(LXModel model, TEVertex v0, TEVertex v1) {
-    super(TE_MODEL_TYPE, model);
-
-    this.v0 = v0;
-    this.v1 = v1;
-
-    setId(this.model.meta(META_ID));
-
-    this.size = this.model.points.length;
-    this.points = this.model.points;
-    this.edgePoints = new Point[this.points.length];
-    for (int i = 0; i < this.points.length; i++) {
-      this.edgePoints[i] = new Point(this.points[i], i, fraction(i, this.size));
     }
   }
 

--- a/te-app/src/main/java/titanicsend/model/TEPanelModel.java
+++ b/te-app/src/main/java/titanicsend/model/TEPanelModel.java
@@ -261,9 +261,17 @@ public class TEPanelModel extends TEModel {
     this.edge0id = this.model.meta(META_EDGE1);
     this.edge1id = this.model.meta(META_EDGE2);
     this.edge2id = this.model.meta(META_EDGE3);
+
+    // register vertices
+    int idA = Integer.parseInt(this.model.meta("v0"));
+    int idB = Integer.parseInt(this.model.meta("v1"));
+    int idC = Integer.parseInt(this.model.meta("v2"));
+    TEVertex.registerVertex(idA, vA);
+    TEVertex.registerVertex(idB, vB);
+    TEVertex.registerVertex(idC, vC);
   }
 
-  private static LXVector calculateCentroid(LXPoint[] points) {
+  public static LXVector calculateCentroid(LXPoint[] points) {
     LXVector centroid = new LXVector(0, 0, 0);
     if (points.length > 0) {
       for (LXPoint p : points) {

--- a/te-app/src/main/java/titanicsend/model/TEVertex.java
+++ b/te-app/src/main/java/titanicsend/model/TEVertex.java
@@ -8,6 +8,10 @@ import titanicsend.util.TEMath;
 
 public class TEVertex extends LXVector {
 
+  private static Map<Integer, LXVector> mutableVertexLookup = new HashMap<>();
+  public static Map<Integer, LXVector> vertexLookup =
+      Collections.unmodifiableMap(mutableVertexLookup);
+
   public final int id;
   private final Set<TEEdgeModel> mutableEdges = new HashSet<TEEdgeModel>();
   public final Set<TEEdgeModel> edges = Collections.unmodifiableSet(this.mutableEdges);
@@ -74,5 +78,11 @@ public class TEVertex extends LXVector {
 
   public void nudgeToward(LXVector other, float distance) {
     lerp(other, distance);
+  }
+
+  public static void registerVertex(Integer id, LXVector coord) {
+    if (!mutableVertexLookup.containsKey(id)) {
+      mutableVertexLookup.put(id, coord);
+    }
   }
 }

--- a/te-app/src/main/java/titanicsend/model/TEWholeModelDynamic.java
+++ b/te-app/src/main/java/titanicsend/model/TEWholeModelDynamic.java
@@ -299,6 +299,7 @@ public class TEWholeModelDynamic implements TEWholeModel, LX.Listener {
       this.mutableVertexes.add(vertex);
       this.vertexesById.put(v, vertex);
     }
+    System.out.println("Vertex " + v + ": " + vertex);
     return vertex;
   }
 

--- a/te-app/src/main/java/titanicsend/ui/UIModelLabels.java
+++ b/te-app/src/main/java/titanicsend/ui/UIModelLabels.java
@@ -22,10 +22,12 @@ import heronarts.glx.ui.UI;
 import heronarts.glx.ui.UI3dComponent;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.studio.TEApp;
+import heronarts.lx.transform.LXVector;
 import java.util.ArrayList;
 import java.util.List;
 import org.joml.Vector3f;
 import titanicsend.app.TEVirtualOverlays;
+import titanicsend.model.TEEdgeModel;
 import titanicsend.model.TEPanelModel;
 import titanicsend.model.TEVertex;
 import titanicsend.ui.text3d.Label;
@@ -36,6 +38,7 @@ public class UIModelLabels extends UI3dComponent {
   private final GLX glx;
   private TextManager3d textManager = null;
   private final List<Label> panelLabels = new ArrayList<Label>();
+  private final List<Label> edgeLabels = new ArrayList<Label>();
   private final List<Label> vertexLabels = new ArrayList<Label>();
 
   // initialization that should be done once, when the UI is ready
@@ -69,16 +72,22 @@ public class UIModelLabels extends UI3dComponent {
       panelLabels.add(textManager.labelMaker(p.getId(), position, rotation));
     }
 
-    /*
-    // TODO: Vertex labeling disabled 'till we actually have vertex data
+    textManager.setFontScale(fontScale * 0.5f);
+    textManager.setFontColor(LXColor.GREEN);
+    textManager.setFontBackground(LXColor.rgba(64, 64, 0, 150));
+    for (TEEdgeModel e : TEApp.wholeModel.getEdges()) {
+      getEdgeCoordinates(e, position, rotation, labelOffset);
+      edgeLabels.add(textManager.labelMaker(e.getId(), position, rotation));
+    }
+
     textManager.setFontScale(fontScale * 1.333f);
     textManager.setFontColor(LXColor.GREEN);
     textManager.setFontBackground(LXColor.rgba(0, 64, 64, 200));
-    for (TEVertex v : TEApp.wholeModel.getVertexes()) {
+    for (Integer vertexId : TEVertex.vertexLookup.keySet()) {
+      LXVector v = TEVertex.vertexLookup.get(vertexId);
       getVertexCoordinates(v, position, rotation, labelOffset);
-      vertexLabels.add(textManager.labelMaker(String.valueOf(v.id), position, rotation));
+      vertexLabels.add(textManager.labelMaker(String.valueOf(vertexId), position, rotation));
     }
-    */
   }
 
   /**
@@ -139,8 +148,49 @@ public class UIModelLabels extends UI3dComponent {
     getLabelCoordinates(panelCenter, position, rotation, offset, onCarEnd);
   }
 
+  public void getEdgeCoordinates(
+      TEEdgeModel edge, Vector3f position, Vector3f rotation, float offset) {
+    // TODO: fix
+    boolean onCarEnd = false; // edge.getId().startsWith("F") || edge.getId().startsWith("A");
+
+    getLabelCoordinates(
+        new Vector3f(edge.centroid.x, edge.centroid.y, edge.centroid.z),
+        position,
+        rotation,
+        offset,
+        onCarEnd);
+
+    // TODO: try to get the labels rotated alongside the edges...
+    //    int id0 = Integer.parseInt(edge.model.meta("v0"));
+    //    int id1 = Integer.parseInt(edge.model.meta("v1"));
+    //    LXVector v0 = TEVertex.vertexLookup.get(id0);
+    //    LXVector v1 = TEVertex.vertexLookup.get(id1);
+    //    if (v0 == null) {
+    //      return;
+    //    } else if (v1 == null) {
+    //      return;
+    //    }
+    //
+    //    LXVector direction = v0.sub(v1).normalize();
+    //    // Angle with YZ plane (complement of angle with X axis)
+    //    // This is how much the line deviates from being parallel to the YZ plane
+    //    float angleWithYZ = (float) Math.acos(Math.abs(direction.x));
+    //
+    //    // Angle with XZ plane (complement of angle with Y axis)
+    //    // This is how much the line deviates from being parallel to the XZ plane
+    //    float angleWithXZ = (float) Math.acos(Math.abs(direction.y));
+    //
+    //    // Angle with XY plane (complement of angle with Z axis)
+    //    // This is how much the line deviates from being parallel to the XY plane
+    //    float angleWithXY = (float) Math.acos(Math.abs(direction.z));
+    //
+    //    position.x = angleWithYZ;
+    //    position.y = angleWithXZ;
+    //    position.z = angleWithXY;
+  }
+
   public void getVertexCoordinates(
-      TEVertex vertex, Vector3f position, Vector3f rotation, float offset) {
+      LXVector vertex, Vector3f position, Vector3f rotation, float offset) {
     Vector3f panelCenter = new Vector3f(vertex.x, vertex.y, vertex.z);
 
     getLabelCoordinates(panelCenter, position, rotation, offset, false);
@@ -158,13 +208,13 @@ public class UIModelLabels extends UI3dComponent {
       textManager.draw(view, panelLabels);
     }
 
-    /*
-    // TODO - fill in vertex locations for dynamic model.  It currently has
-    // TODO - labels, but no data, so we only show these labels for the static model.
-    if (this.virtualOverlays.vertexLabelsVisible.isOn() && this.isStatic) {
+    if (this.virtualOverlays.edgeLabelsVisible.isOn()) {
+      textManager.draw(view, edgeLabels);
+    }
+
+    if (this.virtualOverlays.vertexLabelsVisible.isOn()) {
       textManager.draw(view, vertexLabels);
     }
-    */
   }
 
   @Override


### PR DESCRIPTION
Bit of a hack to get this working - "registered" the vertices from within `TEEdgeModel` and `TEPanelModel`, using their metadata to identify the vertices then save them in a global lookup. Maybe the global lookup should live on `TEWholeModel` instead?

Just wanted to get a POC of this working in case it makes life easier for folks testing edges at the warehouse, I know Andy mentioned this would be helpful but I didn't want to add it to anyone else's plate.

<img width="1507" height="949" alt="image" src="https://github.com/user-attachments/assets/39b2098c-adc1-4504-87e0-47ea24bb6ff7" />

<img width="1508" height="948" alt="Screen Shot 2025-08-03 at 10 46 44 PM" src="https://github.com/user-attachments/assets/6c8e9e91-69ad-41b8-8a79-a4b5b7735932" />
