### PR TITLE
Shader Updates, Round 1

### DIFF
--- a/.run/Titanic's End GPU.run.xml
+++ b/.run/Titanic's End GPU.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="--resolution 1920x1200" />
-    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true -Dgpu" />
+    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true -Dgpu" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Titanic's End GPU.run.xml
+++ b/.run/Titanic's End GPU.run.xml
@@ -3,7 +3,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="--resolution 1920x1200" />
-    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true -Dgpu" />
+    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true -Dgpu" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/te-app/resources/pattern/missingControls.json
+++ b/te-app/resources/pattern/missingControls.json
@@ -138,13 +138,7 @@
       "XorceryDiamonds"
     ],
     "uses_palette": true,
-    "missing_control_tags": [
-      "SIZE",
-      "QUANTITY",
-      "WOW1",
-      "WOW2",
-      "WOWTRIGGER"
-    ]
+    "missing_control_tags": []
   },
   {
     "shader_name": "audio_test.fs",
@@ -381,13 +375,7 @@
       "FourStar"
     ],
     "uses_palette": true,
-    "missing_control_tags": [
-      "SIZE",
-      "QUANTITY",
-      "WOW1",
-      "WOW2",
-      "WOWTRIGGER"
-    ]
+    "missing_control_tags": []
   },
   {
     "shader_name": "synth_waves.fs",

--- a/te-app/resources/shaders/circuitry.fs
+++ b/te-app/resources/shaders/circuitry.fs
@@ -7,8 +7,8 @@
 #pragma name "Circuitry"
 #pragma TEControl.SIZE.Range(2.0,10.0,0.1)
 #pragma TEControl.QUANTITY.Range(4.0,3.0,6.0)
+#pragma TEControl.WOW1.Range(0.0,0.0,0.25)
 #pragma TEControl.WOW2.Disable
-#pragma TEControl.WOW1.Disable
 #pragma TEControl.WOWTRIGGER.Disable
 #pragma TEControl.LEVELREACTIVITY.Disable
 #pragma TEControl.FREQREACTIVITY.Disable
@@ -34,7 +34,7 @@ float fractal(vec2 p) {
 
     for (float i = 0.; i < iQuantity; i++) {
         p = abs(p);
-        // adjust viewing region in x and y to get the most "interesting"
+        // adjust viewing region
         // part.
         p = p/clamp(p.x*p.y,0.15,5.) - vec2(1.525,1.5);
 
@@ -82,5 +82,5 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     }
     c = c/2.;
 
-    fragColor = vec4(mix(iColorRGB,iColor2RGB,minIteration/floor(iQuantity)),c);
+    fragColor = vec4(getGradientColor(minIteration/floor(iQuantity - 1.0)),max(iWow1,c));
 }

--- a/te-app/resources/shaders/radial_simplex.fs
+++ b/te-app/resources/shaders/radial_simplex.fs
@@ -7,8 +7,9 @@
 // https://github.com/ashima/webgl-noise
 //
 
-const float PI = 3.1415924;
-const float TAU = PI * 2.0;
+#include <include/constants.fs>
+#include <include/colorspace.fs>
+
 const float QUARTER_WAVE = PI / 2.0;
 
 vec3 mod289(vec3 x) {
@@ -167,12 +168,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
         }
     }
 
-    // bump up the gain a little, and adjust gamma
-    noise *= 1.15 * (1. - beat * levelReact);
-    noise = noise * noise;
+    // bump up the gain a little, add beat reactivity
+    noise = clamp(abs(noise) * 1.15 * (1. - beat * levelReact), 0.0, 1.0);
 
-    // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = noise * mix(iColorRGB, mix(iColorRGB, iColor2RGB, wave(noise)), iWow2);
+    // Wow2 controls the mix of gradient vs foreground.
+    vec3 col = noise * mix(iColorRGB, getGradientColor(noise), 1.0 - iWow2);
 
-    fragColor = vec4(col, 1.0);
+    fragColor = vec4(col, 0.995);
 }

--- a/te-app/resources/shaders/rhythm_static.fs
+++ b/te-app/resources/shaders/rhythm_static.fs
@@ -1,5 +1,5 @@
-#define PI 3.14159265359
-#define TAU (2.0 * PI)
+#include <include/constants.fs>
+#include <include/colorspace.fs>
 #define LAYERS 3
 
 // build 2D rotation matrix
@@ -30,10 +30,15 @@ vec2 randomVec2(ivec2 seed) {
 
 // build a nice animated composite static field from multiple layers of noise
 void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    // center, rotate and restore original position
+    vec2 uv = fragCoord - (iResolution.xy * 0.5);
+    uv *= rotate(iRotationAngle);
+    uv += iResolution.xy * 0.5;
+
     // we keep the numbers large b/c our fast hash function/prng works
     // with integers, and we need enough space to keep precision and
     // avoid collisions.
-    vec2 uv = fragCoord + vec2(1000000, 1000000.0);
+    uv += vec2(1000000, 1000000.0);
 
     //float bassEffect = bassRatio * levelReact;
     //float trebleEffect = trebleRatio * frequencyReact;
@@ -42,15 +47,18 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
 
     // Size control manages overall scale - from dots to HUGE blocks.
     int startingPower = 1 + int(iScale) + int(clamp(2.*bassEffect, 0. ,4.));
-    //float startingPower = 1. + iScale + clamp(2.*bassEffect, 0. ,4.);
     float sum = 0.0;
 
     // subdivide the field into layers of randomly colored powers-of-two sized blocks
+
+    // random rotation vector for each layer.  Declared outside the loop so
+    // we can use it for final color too.
+    vec2 rVec;
     for(int layer = 0; layer < LAYERS; layer++) {
         float power = float(startingPower) + float(layer);
         float scale = pow(2.0, power);
         ivec2 iuv = ivec2(uv / scale);
-        vec2 rVec = randomVec2(iuv);
+        rVec = randomVec2(iuv);
 
         float timeFactor = 8.0;
         if (iWowTrigger) {
@@ -65,11 +73,11 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
         sum += (layer == LAYERS - 1) ? 2.0 * value : value;
     }
 
-    // interpolate color from current palette
-    vec3 color = mix(iColor2RGB,iColorRGB,sum);
+    // interpolate random color from current palette
+    vec3 color = getGradientColor(fract(rVec.x + rVec.y));
 
     // threshold values by iQuantity, gamma adjust, and flash the whole thing to the beat
     // with depth controlled by WOW1.
     sum *= 1.25 * step(1.0-(iQuantity*(1.+trebleEffect)), sum) * (1.0 - (beat * iWow1));
-    fragColor = vec4(sum * color, 1.0);
+    fragColor = vec4(color, sum);
 }

--- a/te-app/resources/shaders/simplex_posterized.fs
+++ b/te-app/resources/shaders/simplex_posterized.fs
@@ -10,6 +10,9 @@
 // override the default x/y offset control behavior
 #define TE_NOTRANSLATE
 
+#include <include/constants.fs>
+#include <include/colorspace.fs>
+
 vec3 mod289(vec3 x) {
     return x - floor(x * (1.0 / 289.0)) * 289.0;
 }
@@ -153,8 +156,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     noise = mix(1.15 * field, noise, iWow1);
     float gradient = mix(noise,mod((noise * levels),2.0),iWow1);
 
-    // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = noise * mix(iColorRGB, mix(iColorRGB, iColor2RGB,gradient), iWow2);
+    // Wow2 controls the mix of gradient vs foreground.
+    vec3 col = noise * mix(iColorRGB, getGradientColor(noise * noise), 1.0 - iWow2);
 
     fragColor = vec4(col, 1.0);
 }

--- a/te-app/resources/shaders/space_explosion.fs
+++ b/te-app/resources/shaders/space_explosion.fs
@@ -1,103 +1,332 @@
-//fork of https://www.shadertoy.com/view/7ddBzr
+// space_explosion v2:  The Volumetric Version
+// adapted for TE from:
+// https://www.shadertoy.com/view/Xd3GWn
+// NOTE: I love how parameterized this is.
 
-/*
- * "Hyperspace explosion" by Ben Wheatley - 2018
- * License MIT License
- * Contact: github.com/BenWheatley
- */
 
-// constants
-const int MIN_OCTAVE = 3;
-const int MAX_OCTAVE = 8;
-const float PI = 3.14159265359;
-const float centerToCorner = sqrt((0.5*0.5) + (0.5*0.5));
-const float tangentScale = PI / (2.0*centerToCorner);
-const float thetaToPerlinScale = 2.0 / PI;
-const float TAU = PI * 2.0;
-const float QUARTER_WAVE = PI / 2.0;
+#include <include/constants.fs>
+#include <include/colorspace.fs>
 
-float wave(float n) {
-    return 0.5 + 0.5 * sin(-QUARTER_WAVE + TAU * fract(n));
+#define CAM_ROTATION_SPEED 11.7
+#define CAM_TILT .20
+#define CAM_DIST 2.8
+#define MAX_MULT_EXPLOSIONS 15
+
+// the bounding sphere of the entire explosion. We use this to reduce the number of rays we need
+// to march through the explosion's density field.  If a ray lies outside the sphere, we know it isn't
+// going to be in the explosion, and we can skip it.
+const float expRadius = 1.75;
+const int mult_explosions = MAX_MULT_EXPLOSIONS;	// how many explosion sub-spheres to draw
+const int steps = 64;				// max ray marching steps
+const float delay_range = 0.15;		// maximum delay for explosion start up.
+
+float explosion_seed = 0.618;       // seed for explosion noise.
+float downscale = 1.25;				// how much smaller (than expRadius) one explosion ball should be. bigger value = smaller. 1.0 = no scale down.
+float grain = 3.0;					// increase for more detailed explosions
+float speed = 0.5;					// animation speed (time stretch). nice = 0.5, default = 0.4
+float ballness = 1.0;				// lower values makes explosion look more like a cloud. higher values more like a ball.
+float growth = 2.2;					// initial growth to explosion ball. lower values makes explosion grow faster
+float fade = 1.6;					// greater values make fade go faster but later. Greater values leave more smoke at the end.
+float thinout_smooth = 0.7;			// thinning out of the outer bounding sphere. 1.0 = none, 0.0 = lots
+float density = 1.35;				// higher values increase contrast
+vec2 brightness = vec2(3.0, 2.2);	// x = constant offset, y = time-dependent factor
+vec2 brightrad = vec2(1.3, 1.0);	// adds some variation to the radius of the brightness falloff.
+float contrast = 1.0;				// final color contrast. higher values make ligher contrast. default = 1.0
+float rolling_init_damp = 0.20;		// rolling animation initial damping. 0.0 = no damping. nice = 0.2, default = 0.15
+float rolling_speed = 0.6;			// rolling animation speed (static over time). default = 1.0
+float variation_seed = 0.618;		// influences position variation of the different explosion balls
+float delay_seed = 0.0;				// influences the start delay variation of the different explosion balls
+float ball_spread = 1.0;			// how much to spread ball starting positions from the up vector.
+
+// Everything you need to know about the explosion's component spheres
+struct Ball {
+    vec3 offset;
+    vec3 dir;
+    float delay;
+};
+
+Ball balls[MAX_MULT_EXPLOSIONS];
+
+float tmax = 1.0 + delay_range;
+float getTime() {
+    return fract(iTime * speed / tmax) * tmax;
 }
 
-float cosineInterpolate(float a, float b, float x) {
-    float ft = x * PI;
-    float f = (1.0 - cos(ft)) * 0.5;
-
-    return a*(1.0-f) + b*f;
+// hash and noise functions from shadertoy
+float hash( float n ) {
+    return fract(cos(n)*41415.92653);
 }
 
-float seededRandom(float seed) {
-    int x = int(seed);
-    x = x << 13 ^ x;
-    x = (x * (x * x * 15731 + 789221) + 1376312589);
-    x = x & 0x7fffffff;
-    return float(x)/1073741824.0;
+vec2 hash2( float n ) {
+    return fract(sin(vec2(n,n+1.0))*vec2(13.5453123,31.1459123));
 }
 
-// The magic constants are essentially arbitary:
-// they define the scale of the largest component of the Perlin noise
-float perlinNoise(float perlinTheta, float r, float time) {
-    float sum = 0.0;
-    for (int octave=MIN_OCTAVE; octave<MAX_OCTAVE; ++octave) {
-        float sf = pow(2.0, float(octave));
-        float sf8 = sf*64.0; // I can't remember where this variable name came from
+vec3 hash3( float n ) {
+    return fract(sin(vec3(n,n+1.0,n+2.0))*vec3(13.5453123,31.1459123,37.3490423));
+}
 
-        float new_theta = sf*perlinTheta;
-        float new_r = sf*r + time; // Add current time to this to get an animated effect
+float hash13(vec3 p3) {
+    p3  = fract(p3 * vec3(.1031,.11369,.13787));
+    p3 += dot(p3, p3.yzx + 19.19);
+    return fract((p3.x + p3.y) * p3.z);
+}
 
-        float new_theta_floor = floor(new_theta);
-        float new_r_floor = floor(new_r);
-        float fraction_r = new_r - new_r_floor;
-        float fraction_theta = new_theta - new_theta_floor;
+float noise( in vec3 x ) {
+    vec3 f = fract(x);
+    vec3 p = x - f;
+    f = f*f*(3.0-2.0*f);
 
-        float t1 = seededRandom( new_theta_floor	+	sf8 *  new_r_floor      );
-        float t2 = seededRandom( new_theta_floor	+	sf8 * (new_r_floor+1.0) );
+    float n = p.x + p.y*157.0 + 113.0*p.z;
+    return mix(mix(mix( hash(n+  0.0), hash(n+  1.0),f.x),
+    mix( hash(n+157.0), hash(n+158.0),f.x),f.y),
+    mix(mix( hash(n+113.0), hash(n+114.0),f.x),
+    mix( hash(n+270.0), hash(n+271.0),f.x),f.y),f.z);
+}
 
-        new_theta_floor += 1.0;
-        float maxVal = sf*2.0;
-        if (new_theta_floor >= maxVal) {
-            new_theta_floor -= maxVal; // So that interpolation with angle 0-360° doesn't do weird things with angles > 360°
+float fbm( vec3 p, vec3 dir ) {
+    float f;
+    vec3 q = p - dir; f  = 0.50000*noise( q );
+    q = q*2.02 - dir; f += 0.25000*noise( q );
+    q = q*2.03 - dir; f += 0.12500*noise( q );
+    q = q*2.01 - dir; f += 0.06250*noise( q );
+    q = q*2.02 - dir; f += 0.03125*noise( q );
+    return f;
+}
+
+// Get gradient color from the palette based on field density
+vec4 applyColor( float density, float radius, float bright ) {
+    // TODO: give the option for fire colored fire as well.
+    vec4 result = vec4(bright * getGradientColor(density) * density * min( (radius+0.5)*0.588, 1.0 ) ,density);
+
+    return result;
+}
+
+// map 3d position to density
+float densityFn( in vec3 p, in float r, float t, in vec3 dir, float seed ) {
+    float den = ballness + (growth+ballness)*log(t)*r;
+    den -= (2.5+ballness)*pow(t,fade)/r;
+    if ( den <= -3. ) return -1.;
+
+    // offset noise based on seed
+    // plus a time based offset for the rolling effect (together with the space inversion below)
+    float s = seed-(rolling_speed/(sin(min(t*3.,1.57))+rolling_init_damp));
+    dir *= s;
+
+    // invert space
+    p = -grain*p/(dot(p,p)*downscale);
+
+    // participating media
+    float f = fbm( p, dir );
+
+    // add in noise with scale factor
+    den += 4.0*f;
+    return den;
+}
+
+// rad = radius of complete explosion (range 0 to 1)
+// r = radius of the explosion ball that contributes the highest density
+// rawDens = non-clamped density at the current marching location on the current ray
+// foffset = factor for offset how much the offsetting should be applied. best to pass a time-based value.
+void computeDensity( in vec3 pos, out float rad, out float r, out float rawDens, in float t, in float foffset, out vec4 col, in float bright )
+{
+    float radiusFromExpCenter = length(pos);
+    rad = radiusFromExpCenter / expRadius;
+
+    r = 0.0;
+    rawDens = 0.0;
+    col = vec4(0.0);
+
+    for ( int k = 0; k < mult_explosions; ++k ) {
+        float t0 = t - balls[k].delay;
+        if ( t0 < 0.0 || t0 > 1.0 ) continue;
+
+        vec3 p = pos - balls[k].offset * foffset;
+        float radiusFromExpCenter0 = length(p);
+
+        float r0 = downscale* radiusFromExpCenter0 / expRadius;
+        if( r0 > 1.0 ) continue;
+
+        float rawDens0 = densityFn( p, r0, t0, balls[k].dir, explosion_seed + 33.7*float(k) ) * density;
+
+        // thin out the volume at the far extends of the bounding sphere to avoid
+        // clipping with the bounding sphere
+        rawDens0 *= 1.-smoothstep(thinout_smooth,1.,r0);
+
+        float dens = clamp( rawDens0, 0.0, 1.0 );
+        vec4 col0 = applyColor(dens, r0*(brightrad.x+brightrad.y*rawDens0), bright);	// also adds some variation to the radius
+
+        // scale density to the range 0 to 1
+        col0.a *= (col0.a + .4) * (1. - r0*r0);
+        col0.rgb *= col0.a;
+        col += col0;
+
+        rawDens = max(rawDens, rawDens0);
+    }
+}
+
+// use alpha to blend in contribution at current point
+void addColor( in vec4 col, inout vec4 sum ) {
+    sum = sum + col*(1.0 - sum.a);
+    sum.a+=0.15*col.a;
+}
+
+vec4 raymarch( in vec3 rayo, in vec3 rayd, in vec2 expInter, in float t, out float d ) {
+    vec4 sum = vec4( 0.0 );
+    float step = 1.5 / float(steps);
+    vec3 pos = rayo + rayd * (expInter.x);	// no dither
+
+    float march_pos = expInter.x;
+    d = 4000.0;
+
+    // t goes from 0 to 1 + mult delay. that is 0 to 1 is for one explosion ball. the delay for time distribution of the multiple explosion balls.
+    // t_norm is 0 to 1 for the whole animation (incl mult delay).
+    float t_norm = t / tmax;
+    float smooth_t = sin(t_norm*2.1);	//sin(t*2.);
+
+    //float bright = 6.1;
+    float t1 = 1.0 - t_norm;	// we use t_norm instead of t so that final color is reached at end of whole animation and not already at end of first explosion ball.
+
+    float bright = brightness.x + brightness.y * t1*t1;
+
+    for( int i=0; i<steps; i++ ) {
+        if( sum.a >= 0.98 ) { d = march_pos; break; }
+        if ( march_pos >= expInter.y ) break;
+
+        float rad, r, rawDens;
+        vec4 col;
+        computeDensity( pos, rad, r, rawDens, t, smooth_t, col, bright );
+
+        if ( rawDens <= 0.0 )
+        {
+            float s = step * 2.0;
+            pos += rayd * s;
+            march_pos += s;
+            continue;
         }
 
-        float t3 = seededRandom( new_theta_floor	+	sf8 *  new_r_floor      );
-        float t4 = seededRandom( new_theta_floor	+	sf8 * (new_r_floor+1.0) );
+        addColor( col, sum );
 
-        float i1 = cosineInterpolate(t1, t2, fraction_r);
-        float i2 = cosineInterpolate(t3, t4, fraction_r);
-
-        sum += cosineInterpolate(i1, i2, fraction_theta)/sf;
+        // take larger steps through low densities.
+        // something like using the density function as a SDF.
+        float stepMult = 1.0 + (1.-clamp(rawDens+col.a,0.,1.));
+        // step along ray
+        pos += rayd * step * stepMult;
+        march_pos += step * stepMult;
     }
-    return sum;
+
+    return clamp( sum, 0.0, 1.0 );
 }
 
-// main
-void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
-    vec2 uv = fragCoord.xy / iResolution.xy;
+// iq's sphere intersection for a sphere centered at (0,0,0)
+vec2 iSphere(in vec3 ro, in vec3 rd, in float rad) {
+    float b = dot(ro, rd);
+    float c = dot(ro, ro) - rad * rad;
+    float h = b*b - c;
 
-    float dx = 0.5 - uv.x;
-    float dy = 0.5 - uv.y;
-    dy *= iResolution.y / iResolution.x;
-
-    float perlinTheta = (-iRotationAngle + PI+atan(dy, -dx))/PI;
-    float r = sqrt((dx*dx) + (dy*dy));
-    r = centerToCorner - r;
-
-    float perlin = perlinNoise(perlinTheta, r, iTime);
-
-    float timeMod = mod(-iTime, 1.5);
-    float scale = 2.0*(timeMod - r);
-    float glowRing = cos(pow(1.0-scale, 0.1));
-    glowRing -= 0.5;
-    glowRing *= 2.0;
-    if (scale>1.0) {
-        scale = 0.0;
+    if (h < 0.0) {
+        return vec2(-1.0);
     }
 
-    // calculate and gamma correct brightness
-    float c = glowRing + (scale*perlin*2.0);
+    // this should really be sqrt(h), but we just need a rough estimate - we're
+    // distorting the heck out of spheres anyway.
+    h *= 0.5;
+    return vec2(-b-h, -b+h);
+}
 
-    // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = c * mix(iColorRGB, mix(iColorRGB, iColor2RGB, wave(c * 2.0)), iWow2);
-    fragColor = vec4(col, 1.);
+vec3 computePixelRay( in vec2 p, out vec3 cameraPos ) {
+    // camera orbits around explosion at fairly high speed to give it a
+    // rolling effect.
+
+    float camRadius = CAM_DIST;
+    float a = iTime*CAM_ROTATION_SPEED;
+    float b = CAM_TILT * sin(a * .014);
+
+    float phi = b * PI;
+    float camRadiusProjectedDown = camRadius * cos(phi);
+    float theta = -(a-iResolution.x)/80.;
+    float xoff = camRadiusProjectedDown * cos(theta);
+    float zoff = camRadiusProjectedDown * sin(theta);
+    float yoff = camRadius * sin(phi);
+    cameraPos = vec3(xoff,yoff,zoff);
+
+    // camera target
+    vec3 target = vec3(0.);
+
+    // camera frame
+    vec3 fo = normalize(target-cameraPos);
+    vec3 ri = normalize(vec3(fo.z, 0., -fo.x ));
+    vec3 up = normalize(cross(fo,ri));
+
+    // multiplier to emulate a fov control
+    float fov = .5;
+
+    // ray direction
+    return normalize(fo + fov*p.x*ri + fov*p.y*up);
+}
+
+void setup() {
+    // first ball always centered
+    balls[0] = Ball(
+      vec3(0.),
+      vec3(0.,.7,0.),
+      0.0
+    );
+
+    float pseed = variation_seed;
+    float tseed = delay_seed;
+    float maxdelay = 0.0;
+    for ( int k = 1; k < mult_explosions; ++k ) {
+        float pseed = variation_seed + 3. * float(k-1);
+        float tseed = delay_seed + 3. * float(k-1);
+        vec2 phi = hash2(pseed) * vec2(2.*PI, PI*ball_spread);
+        vec2 tilted = vec2( sin(phi.y), cos(phi.y) );
+        vec3 rotated = vec3( tilted.x * cos(phi.x), tilted.y, tilted.x * sin(phi.x) );
+        balls[k].offset = 0.7 * rotated;
+        balls[k].dir = normalize( balls[k].offset );
+        balls[k].delay = delay_range * hash(tseed);
+        pseed += 3.;
+        tseed += 3.;
+        maxdelay = max(maxdelay, balls[k].delay);
+    }
+
+    if ( maxdelay > 0.0 ) {
+        // Now stretch the ball explosion delays to the maximum allowed range.
+        // So that the last ball starts with a delay of exactly delay_range and thus we do not waste any final time with just empty space.
+        for ( int k = 0; k < mult_explosions; ++k )
+        balls[k].delay *= delay_range / maxdelay;
+    }
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    float t = getTime();
+
+    setup();
+
+    // get aspect corrected normalized pixel coordinate
+    vec2 q = (fragCoord.xy / iResolution.xy);
+    vec2 p = -1.0 + 2.0*q;
+    p *= iScale;
+
+    // move down a bit to center explosion on car
+    p.y += 0.3;
+
+    // set up camera for ray marching
+    vec3 rayDir, cameraPos;
+    rayDir = computePixelRay( p, cameraPos );
+
+    // starting color is black
+    vec4 col = vec4(0.);
+
+    // does pixel ray intersect with the explosion's bounding sphere?
+    vec2 boundingSphereInter = iSphere( cameraPos, rayDir, expRadius );
+    if( boundingSphereInter.x > 0. ) {
+        // if so, we raymarch through the explosion to get field density
+        float d = 4000.0;
+        col = raymarch( cameraPos, rayDir, boundingSphereInter, t, d );
+    }
+
+    // adjust color contrast and brightness
+    col.xyz = col.xyz*col.xyz*(1.0+contrast*(1.0-col.xyz));
+    col.a = 0.995;
+    fragColor = col;
 }

--- a/te-app/resources/shaders/space_explosionfx.fs
+++ b/te-app/resources/shaders/space_explosionfx.fs
@@ -1,104 +1,331 @@
-//fork of https://www.shadertoy.com/view/7ddBzr
+// space_explosion v2:  The Volumetric Version
+// adapted for TE from:
+// https://www.shadertoy.com/view/Xd3GWn
+// NOTE: I love how parameterized this is.
+uniform float explosionSeed;
 
-/*
- * "Hyperspace explosion" by Ben Wheatley - 2018
- * License MIT License
- * Contact: github.com/BenWheatley
- */
+#include <include/constants.fs>
+#include <include/colorspace.fs>
 
-// constants
-const int MIN_OCTAVE = 3;
-const int MAX_OCTAVE = 8;
-const float PI = 3.14159265359;
-const float centerToCorner = sqrt((0.5*0.5) + (0.5*0.5));
-const float tangentScale = PI / (2.0*centerToCorner);
-const float thetaToPerlinScale = 2.0 / PI;
-const float TAU = PI * 2.0;
-const float QUARTER_WAVE = PI / 2.0;
+#define CAM_ROTATION_SPEED 11.7
+#define CAM_TILT .20
+#define CAM_DIST 2.8
+#define MAX_MULT_EXPLOSIONS 15
 
-float wave(float n) {
-    return 0.5 + 0.5 * sin(-QUARTER_WAVE + TAU * fract(n));
+// the bounding sphere of the entire explosion. We use this to reduce the number of rays we need
+// to march through the explosion's density field.  If a ray lies outside the sphere, we know it isn't
+// going to be in the explosion, and we can skip it.
+const float expRadius = 1.75;
+const int mult_explosions = MAX_MULT_EXPLOSIONS;	// how many explosion sub-spheres to draw
+const int steps = 64;				// max ray marching steps
+const float delay_range = 0.25;		// maximum delay for explosion start up.
+
+float downscale = 1.25;				// how much smaller (than expRadius) one sphere should be. bigger value = smaller. 1.0 = no scale down.
+float grain = 3.0;					// increase for more detailed explosions
+float speed = 1.0;					// animation speed (time stretch). nice = 0.5, default = 0.4
+float ballness = 1.0;				// lower values makes explosion look more like a cloud. higher values more like a ball.
+float growth = 2.0;					// initial growth to explosion ball. lower values makes explosion grow faster
+float fade = 1.6;					// greater values make fade go faster but later. Greater values leave more smoke at the end.
+float thinout_smooth = 0.7;			// thinning out of the outer bounding sphere. 1.0 = none, 0.0 = lots
+float density = 1.35;				// higher values increase contrast
+vec2 brightness = vec2(3.0, 2.2);	// x = constant offset, y = time-dependent factor
+vec2 brightrad = vec2(1.3, 1.0);	// adds some variation to the radius of the brightness falloff.
+float contrast = 1.0;				// final color contrast. higher values make ligher contrast. default = 1.0
+float rolling_init_damp = 0.20;		// rolling animation initial damping. 0.0 = no damping. nice = 0.2, default = 0.15
+float rolling_speed = 0.6;			// rolling animation speed (static over time). default = 1.0
+float variation_seed = explosionSeed + 0.618;	// influences position variation of spheres
+float delay_seed = explosionSeed * 1.618;		// influences the start delay variation of the different spheres
+float ball_spread = 1.0;			// how much to spread ball starting positions from the up vector.
+
+// Everything you need to know about the explosion's component spheres
+struct Sphere {
+    vec3 offset;
+    vec3 dir;
+    float delay;
+};
+
+Sphere balls[MAX_MULT_EXPLOSIONS];
+
+float tmax = 1.0 + delay_range;
+float getTime() {
+    return fract(iTime * speed / tmax) * tmax;
 }
 
-float cosineInterpolate(float a, float b, float x) {
-    float ft = x * PI;
-    float f = (1.0 - cos(ft)) * 0.5;
-
-    return a*(1.0-f) + b*f;
+// hash and noise functions from shadertoy
+float hash( float n ) {
+    return fract(cos(n)*41415.92653);
 }
 
-float seededRandom(float seed) {
-    int x = int(seed);
-    x = x << 13 ^ x;
-    x = (x * (x * x * 15731 + 789221) + 1376312589);
-    x = x & 0x7fffffff;
-    return float(x)/1073741824.0;
+vec2 hash2( float n ) {
+    return fract(sin(vec2(n,n+1.0))*vec2(13.5453123,31.1459123));
 }
 
-// The magic constants are essentially arbitary:
-// they define the scale of the largest component of the Perlin noise
-float perlinNoise(float perlinTheta, float r, float time) {
-    float sum = 0.0;
-    for (int octave=MIN_OCTAVE; octave<MAX_OCTAVE; ++octave) {
-        float sf = pow(2.0, float(octave));
-        float sf8 = sf*64.0; // I can't remember where this variable name came from
+vec3 hash3( float n ) {
+    return fract(sin(vec3(n,n+1.0,n+2.0))*vec3(13.5453123,31.1459123,37.3490423));
+}
 
-        float new_theta = sf*perlinTheta;
-        float new_r = sf*r + time; // Add current time to this to get an animated effect
+float hash13(vec3 p3) {
+    p3  = fract(p3 * vec3(.1031,.11369,.13787));
+    p3 += dot(p3, p3.yzx + 19.19);
+    return fract((p3.x + p3.y) * p3.z);
+}
 
-        float new_theta_floor = floor(new_theta);
-        float new_r_floor = floor(new_r);
-        float fraction_r = new_r - new_r_floor;
-        float fraction_theta = new_theta - new_theta_floor;
+float noise( in vec3 x ) {
+    vec3 f = fract(x);
+    vec3 p = x - f;
+    f = f*f*(3.0-2.0*f);
 
-        float t1 = seededRandom( new_theta_floor	+	sf8 *  new_r_floor      );
-        float t2 = seededRandom( new_theta_floor	+	sf8 * (new_r_floor+1.0) );
+    float n = p.x + p.y*157.0 + 113.0*p.z;
+    return mix(mix(mix( hash(n+  0.0), hash(n+  1.0),f.x),
+    mix( hash(n+157.0), hash(n+158.0),f.x),f.y),
+    mix(mix( hash(n+113.0), hash(n+114.0),f.x),
+    mix( hash(n+270.0), hash(n+271.0),f.x),f.y),f.z);
+}
 
-        new_theta_floor += 1.0;
-        float maxVal = sf*2.0;
-        if (new_theta_floor >= maxVal) {
-            new_theta_floor -= maxVal; // So that interpolation with angle 0-360° doesn't do weird things with angles > 360°
+float fbm( vec3 p, vec3 dir ) {
+    float f;
+    vec3 q = p - dir; f  = 0.50000*noise( q );
+    q = q*2.02 - dir; f += 0.25000*noise( q );
+    q = q*2.03 - dir; f += 0.12500*noise( q );
+    q = q*2.01 - dir; f += 0.06250*noise( q );
+    q = q*2.02 - dir; f += 0.03125*noise( q );
+    return f;
+}
+
+// Get gradient color from the palette based on field density
+vec4 applyColor( float density, float radius, float bright ) {
+    // TODO: give the option for fire colored fire as well.
+    vec4 result = vec4(bright * getGradientColor(density) * density * min( (radius+0.5)*0.588, 1.0 ) ,density);
+
+    return result;
+}
+
+// map 3d position to density
+float densityFn( in vec3 p, in float r, float t, in vec3 dir, float seed ) {
+    float den = ballness + (growth+ballness)*log(t)*r;
+    den -= (2.5+ballness)*pow(t,fade)/r;
+    if ( den <= -3. ) return -1.;
+
+    // offset noise based on seed
+    // plus a time based offset for the rolling effect (together with the space inversion below)
+    float s = seed-(rolling_speed/(sin(min(t*3.,1.57))+rolling_init_damp));
+    dir *= s;
+
+    // invert space
+    p = -grain*p/(dot(p,p)*downscale);
+
+    // participating media
+    float f = fbm( p, dir );
+
+    // add in noise with scale factor
+    den += 4.0*f;
+    return den;
+}
+
+// rad = radius of complete explosion (range 0 to 1)
+// r = radius of the explosion ball that contributes the highest density
+// rawDens = non-clamped density at the current marching location on the current ray
+// foffset = factor for offset how much the offsetting should be applied. best to pass a time-based value.
+void computeDensity( in vec3 pos, out float rad, out float r, out float rawDens, in float t, in float foffset, out vec4 col, in float bright )
+{
+    float radiusFromExpCenter = length(pos);
+    rad = radiusFromExpCenter / expRadius;
+
+    r = 0.0;
+    rawDens = 0.0;
+    col = vec4(0.0);
+
+    for ( int k = 0; k < mult_explosions; ++k ) {
+        float t0 = t - balls[k].delay;
+        if ( t0 < 0.0 || t0 > 1.0 ) continue;
+
+        vec3 p = pos - balls[k].offset * foffset;
+        float radiusFromExpCenter0 = length(p);
+
+        float r0 = downscale* radiusFromExpCenter0 / expRadius;
+        if( r0 > 1.0 ) continue;
+
+        float rawDens0 = densityFn( p, r0, t0, balls[k].dir, explosionSeed + 33.7*float(k) ) * density;
+
+        // thin out the volume at the far extends of the bounding sphere to avoid
+        // clipping with the bounding sphere
+        rawDens0 *= 1.-smoothstep(thinout_smooth,1.,r0);
+
+        float dens = clamp( rawDens0, 0.0, 1.0 );
+        vec4 col0 = applyColor(dens, r0*(brightrad.x+brightrad.y*rawDens0), bright);	// also adds some variation to the radius
+
+        // scale density to the range 0 to 1
+        col0.a *= (col0.a + .4) * (1. - r0*r0);
+        col0.rgb *= col0.a;
+        col += col0;
+
+        rawDens = max(rawDens, rawDens0);
+    }
+}
+
+// use alpha to blend in contribution at current point
+void addColor( in vec4 col, inout vec4 sum ) {
+    sum = sum + col*(1.0 - sum.a);
+    sum.a+=0.15*col.a;
+}
+
+vec4 raymarch( in vec3 rayo, in vec3 rayd, in vec2 expInter, in float t, out float d ) {
+    vec4 sum = vec4( 0.0 );
+    float step = 1.5 / float(steps);
+    vec3 pos = rayo + rayd * (expInter.x);	// no dither
+
+    float march_pos = expInter.x;
+    d = 4000.0;
+
+    // t goes from 0 to 1 + mult delay. that is 0 to 1 is for one explosion ball. the delay for time distribution of the multiple explosion balls.
+    // t_norm is 0 to 1 for the whole animation (incl mult delay).
+    float t_norm = t / tmax;
+    float smooth_t = sin(t_norm*2.1);	//sin(t*2.);
+
+    //float bright = 6.1;
+    float t1 = 1.0 - t_norm;	// we use t_norm instead of t so that final color is reached at end of whole animation and not already at end of first explosion ball.
+
+    float bright = brightness.x + brightness.y * t1*t1;
+
+    for( int i=0; i<steps; i++ ) {
+        if( sum.a >= 0.98 ) { d = march_pos; break; }
+        if ( march_pos >= expInter.y ) break;
+
+        float rad, r, rawDens;
+        vec4 col;
+        computeDensity( pos, rad, r, rawDens, t, smooth_t, col, bright );
+
+        if ( rawDens <= 0.0 )
+        {
+            float s = step * 2.0;
+            pos += rayd * s;
+            march_pos += s;
+            continue;
         }
 
-        float t3 = seededRandom( new_theta_floor	+	sf8 *  new_r_floor      );
-        float t4 = seededRandom( new_theta_floor	+	sf8 * (new_r_floor+1.0) );
+        addColor( col, sum );
 
-        float i1 = cosineInterpolate(t1, t2, fraction_r);
-        float i2 = cosineInterpolate(t3, t4, fraction_r);
-
-        sum += cosineInterpolate(i1, i2, fraction_theta)/sf;
+        // take larger steps through low densities.
+        // something like using the density function as a SDF.
+        float stepMult = 1.0 + (1.-clamp(rawDens+col.a,0.,1.));
+        // step along ray
+        pos += rayd * step * stepMult;
+        march_pos += step * stepMult;
     }
-    return sum;
+
+    return clamp( sum, 0.0, 1.0 );
 }
 
-// main
-void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
-    vec2 uv = fragCoord.xy / iResolution.xy;
+// iq's sphere intersection for a sphere centered at (0,0,0)
+vec2 iSphere(in vec3 ro, in vec3 rd, in float rad) {
+    float b = dot(ro, rd);
+    float c = dot(ro, ro) - rad * rad;
+    float h = b*b - c;
 
-    float dx = 0.5 - uv.x;
-    float dy = 0.5 - uv.y;
-    dy *= iResolution.y / iResolution.x;
-
-    float perlinTheta = (-iRotationAngle + PI+atan(dy, -dx))/PI;
-    float r = sqrt((dx*dx) + (dy*dy));
-    r = centerToCorner - r;
-
-    float perlin = perlinNoise(perlinTheta, r, iTime);
-
-    float timeMod = mod(-iTime, 1.0);
-    float run = (iWowTrigger == true) ? 2.0 : 0.0;
-    float scale = run * (timeMod-r);
-    float glowRing = cos(pow(1.0-scale, 0.1));
-    glowRing -= 0.5;
-    glowRing *= run;
-    if (scale>1.0) {
-        scale = 0.0;
+    if (h < 0.0) {
+        return vec2(-1.0);
     }
 
-    // calculate and gamma correct brightness
-    float c = glowRing + (scale*perlin*2.0);
+    // this should really be sqrt(h), but we just need a rough estimate - we're
+    // distorting the heck out of spheres anyway.
+    h *= 0.5;
+    return vec2(-b-h, -b+h);
+}
 
-    // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = c * mix(iColorRGB, mix(iColorRGB, iColor2RGB, wave(c * 2.0)), iWow2);
-    fragColor = vec4(col, 1.);
+vec3 computePixelRay( in vec2 p, out vec3 cameraPos ) {
+    // camera orbits around explosion at fairly high speed to give it a
+    // rolling effect.
+
+    float camRadius = CAM_DIST;
+    float a = iTime*CAM_ROTATION_SPEED;
+    float b = CAM_TILT * sin(a * .014);
+
+    float phi = b * PI;
+    float camRadiusProjectedDown = camRadius * cos(phi);
+    float theta = -(a-iResolution.x)/80.;
+    float xoff = camRadiusProjectedDown * cos(theta);
+    float zoff = camRadiusProjectedDown * sin(theta);
+    float yoff = camRadius * sin(phi);
+    cameraPos = vec3(xoff,yoff,zoff);
+
+    // camera target
+    vec3 target = vec3(0.);
+
+    // camera frame
+    vec3 fo = normalize(target-cameraPos);
+    vec3 ri = normalize(vec3(fo.z, 0., -fo.x ));
+    vec3 up = normalize(cross(fo,ri));
+
+    // multiplier to emulate a fov control
+    float fov = .5;
+
+    // ray direction
+    return normalize(fo + fov*p.x*ri + fov*p.y*up);
+}
+
+void setup() {
+    // first ball always centered
+    balls[0] = Sphere(
+    vec3(0.),
+    vec3(0.,.7,0.),
+    0.0
+    );
+
+    float pseed = variation_seed;
+    float tseed = delay_seed;
+    float maxdelay = 0.0;
+    for ( int k = 1; k < mult_explosions; ++k ) {
+        float pseed = variation_seed + 3. * float(k-1);
+        float tseed = delay_seed + 3. * float(k-1);
+        vec2 phi = hash2(pseed) * vec2(2.*PI, PI*ball_spread);
+        vec2 tilted = vec2( sin(phi.y), cos(phi.y) );
+        vec3 rotated = vec3( tilted.x * cos(phi.x), tilted.y, tilted.x * sin(phi.x) );
+        balls[k].offset = 0.7 * rotated;
+        balls[k].dir = normalize( balls[k].offset );
+        balls[k].delay = delay_range * hash(tseed);
+        pseed += 3.;
+        tseed += 3.;
+        maxdelay = max(maxdelay, balls[k].delay);
+    }
+
+    if ( maxdelay > 0.0 ) {
+        // Now stretch the ball explosion delays to the maximum allowed range.
+        // So that the last ball starts with a delay of exactly delay_range and thus we do not waste any final time with just empty space.
+        for ( int k = 0; k < mult_explosions; ++k )
+        balls[k].delay *= delay_range / maxdelay;
+    }
+}
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    float t = getTime();
+
+    setup();
+
+    // get aspect corrected normalized pixel coordinate
+    vec2 q = (fragCoord.xy / iResolution.xy);
+    vec2 p = -1.0 + 2.0*q;
+    p *= iScale;
+
+    // move down a bit to center explosion on car
+    p.y += 0.3;
+
+    // set up camera for ray marching
+    vec3 rayDir, cameraPos;
+    rayDir = computePixelRay( p, cameraPos );
+
+    // starting color is black
+    vec4 col = vec4(0.);
+
+    // does pixel ray intersect with the explosion's bounding sphere?
+    vec2 boundingSphereInter = iSphere( cameraPos, rayDir, expRadius );
+    if(iWowTrigger && boundingSphereInter.x > 0.) {
+        // if so, we raymarch through the explosion to get field density
+        float d = 4000.0;
+        col = raymarch( cameraPos, rayDir, boundingSphereInter, t, d );
+    }
+
+    // adjust color contrast and brightness
+    col.xyz = col.xyz*col.xyz*(1.0+contrast*(1.0-col.xyz));
+    col.a = 0.995;
+    fragColor = col;
 }

--- a/te-app/resources/shaders/triangle_noise.fs
+++ b/te-app/resources/shaders/triangle_noise.fs
@@ -1,10 +1,7 @@
 #define TE_NOTRANSLATE
 
-vec3 hsv2rgb(vec3 c) {
-    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
-    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
-    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
-}
+#include <include/constants.fs>
+#include <include/colorspace.fs>
 
 // build 2D rotation matrix
 mat2 rotate2D(float a) {
@@ -56,9 +53,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
 
     float noise = 0.5 + triangleNoise(0.2 * uv);
     noise = log(10.0 * pow(noise, iWow1));
+    noise = clamp(noise, 0.0, 1.0);
 
     // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = noise * mix(iColorRGB, mix(iColor2RGB, iColorRGB, smoothstep(0.5, 0.9, noise)), iWow2);
+    //vec3 col = noise * mix(iColorRGB, mix(iColor2RGB, iColorRGB, smoothstep(0.5, 0.9, noise)), iWow2);
+    vec3 col = noise * mix(iColorRGB, getGradientColor(noise * noise), 1.0 - iWow2);
 
-    fragColor = vec4(col, 1.);
+    fragColor = vec4(col, 0.995);
 }

--- a/te-app/resources/shaders/turbulent_noise_lines.fs
+++ b/te-app/resources/shaders/turbulent_noise_lines.fs
@@ -89,7 +89,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float bri = mix(res, line, iWow1);
 
     // Wow2 controls the mix of foreground color vs. gradient
-    vec3 col = bri * mix(iColorRGB, getGradientColor(smoothstep(0.1,0.8, bri * bri)), iWow2);
+    vec3 col = bri * mix(iColorRGB, getGradientColor(smoothstep(0.1,0.8, bri * bri)), 1.0 - iWow2);
 
     fragColor = vec4(col, 1.);
 }

--- a/te-app/src/main/java/titanicsend/pattern/ben/XorceryDiamonds.java
+++ b/te-app/src/main/java/titanicsend/pattern/ben/XorceryDiamonds.java
@@ -3,6 +3,7 @@ package titanicsend.pattern.ben;
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import titanicsend.pattern.glengine.ConstructedShaderPattern;
+import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 @LXCategory("Native Shaders Panels")
@@ -13,6 +14,14 @@ public class XorceryDiamonds extends ConstructedShaderPattern {
 
   @Override
   protected void createShader() {
+
+    controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+    controls.setRange(TEControlTag.SIZE, 2.5, 7.0, 0.1);
+
     addShader("xorcery_diamonds.fs");
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -249,7 +249,7 @@ public abstract class GLShader {
     if (uniformSource == null) {
       throw new IllegalArgumentException("UniformSource cannot be null");
     }
-    this.uniformSources.add(0,uniformSource);
+    this.uniformSources.add(uniformSource);
     return this;
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -249,7 +249,7 @@ public abstract class GLShader {
     if (uniformSource == null) {
       throw new IllegalArgumentException("UniformSource cannot be null");
     }
-    this.uniformSources.add(uniformSource);
+    this.uniformSources.add(0,uniformSource);
     return this;
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TEAutoDriftPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TEAutoDriftPattern.java
@@ -17,15 +17,7 @@ public class TEAutoDriftPattern extends DriftEnabledPattern {
     super(lx, defaultView);
 
     // Create shader instance
-    TEShader shader =
-        addShader(
-            GLShader.config(lx)
-                .withFilename(this.getShaderFile())
-                .withUniformSource(
-                    (s) -> {
-                      // calculate incremental transform based on elapsed time
-                      s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
-                    }));
+    TEShader shader = addShader(GLShader.config(lx).withFilename(this.getShaderFile()));
 
     // use common control configuration data from shader to set control defaults,
     // then register controls with Chromatik.

--- a/te-app/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/DriftEnabledPattern.java
@@ -27,15 +27,17 @@ public abstract class DriftEnabledPattern extends GLShaderPattern {
 
   private void updateTranslation(double deltaMs) {
     // calculate change in position since last frame.
-    xOffset += getXPos() * deltaMs / 1000.;
-    yOffset += getYPos() * deltaMs / 1000.;
+    xOffset += super.getXPos() * deltaMs / 1000.;
+    yOffset += super.getYPos() * deltaMs / 1000.;
   }
 
-  protected double getXPosition() {
+  @Override
+  public double getXPos() {
     return xOffset;
   }
 
-  protected double getYPosition() {
+  @Override
+  public double getYPos() {
     return yOffset;
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/jon/FourStar.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/FourStar.java
@@ -18,13 +18,11 @@ public class FourStar extends GLShaderPattern {
     controls.setRange(TEControlTag.QUANTITY, 5.0, 2.0, MAX_RAYS);
     controls.setRange(TEControlTag.WOW1, 0.5, 0.0, 0.6); // diffraction effect
     controls.setRange(TEControlTag.SPEED, .25, -4.0, 4.0);
-    controls.setRange(TEControlTag.SPIN,2.0 ,-4.0, 4.0);
+    controls.setRange(TEControlTag.SPIN, 2.0, -4.0, 4.0);
 
     controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
     controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
     controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
-
-
 
     addCommonControls();
     addShader("fourstar.fs");

--- a/te-app/src/main/java/titanicsend/pattern/jon/FourStar.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/FourStar.java
@@ -7,11 +7,25 @@ import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 @LXCategory("Native Shaders Panels")
 public class FourStar extends GLShaderPattern {
+  // must match the value in fourstar.fs
+  private static final float MAX_RAYS = 8.0f;
 
   public FourStar(LX lx) {
     super(lx, TEShaderView.ALL_PANELS);
 
-    controls.setRange(TEControlTag.WOW1, 0.5, 0, 1);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 0.15, 0.0, 1.0); // beat reactivity
+    controls.setRange(TEControlTag.SIZE, 0.5, 1.0, 0.0); // brightness & size of the star
+    controls.setRange(TEControlTag.QUANTITY, 5.0, 2.0, MAX_RAYS);
+    controls.setRange(TEControlTag.WOW1, 0.5, 0.0, 0.6); // diffraction effect
+    controls.setRange(TEControlTag.SPEED, .25, -4.0, 4.0);
+    controls.setRange(TEControlTag.SPIN,2.0 ,-4.0, 4.0);
+
+    controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+
+
+
     addCommonControls();
     addShader("fourstar.fs");
   }

--- a/te-app/src/main/java/titanicsend/pattern/jon/RainBands.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/RainBands.java
@@ -25,13 +25,6 @@ public class RainBands extends DriftEnabledPattern {
     // register common controls with LX
     addCommonControls();
 
-    addShader(
-        GLShader.config(lx)
-            .withFilename("rain_noise.fs")
-            .withUniformSource(
-                (s) -> {
-                  // calculate incremental transform based on elapsed time
-                  s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
-                }));
+    addShader(GLShader.config(lx).withFilename("rain_noise.fs"));
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/SimplexPosterized.java
@@ -20,14 +20,6 @@ public class SimplexPosterized extends DriftEnabledPattern {
 
     // register common controls with LX
     addCommonControls();
-
-    addShader(
-        GLShader.config(lx)
-            .withFilename("simplex_posterized.fs")
-            .withUniformSource(
-                (s) -> {
-                  // calculate incremental transform based on elapsed time
-                  s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
-                }));
+    addShader(GLShader.config(lx).withFilename("simplex_posterized.fs"));
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/jon/SpaceExplosionFX.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/SpaceExplosionFX.java
@@ -33,15 +33,22 @@ public class SpaceExplosionFX extends GLShaderPattern {
   boolean running;
 
   // how long an explosion lasts, in variable speed seconds
-  static final double eventDuration = 0.75;
+  private static final double eventDuration = 1.15;
+  private float explosionSeed = 0.0f;
 
   // Constructor
   public SpaceExplosionFX(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
 
-    controls.setRange(TEControlTag.SPEED, 0, -2, 2); // speed
+    controls.setRange(TEControlTag.SPEED, 0.5, -2, 2); // speed
     controls.setExponent(TEControlTag.SPEED, 2.0);
-    controls.setValue(TEControlTag.SPEED, 0.5);
+
+    controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
     addCommonControls();
 
@@ -81,6 +88,7 @@ public class SpaceExplosionFX extends GLShaderPattern {
         // reset the pattern's clock to sync to button press
         retrigger(TEControlTag.SPEED);
         eventStartTime = 0; // current time, since we just reset the clock
+        explosionSeed = (float) Math.random(); // random seed for explosion visuals
 
         // start explosion state machine and turn on visuals
         running = true;
@@ -100,6 +108,7 @@ public class SpaceExplosionFX extends GLShaderPattern {
             // another explosion
             retrigger(TEControlTag.SPEED);
             eventStartTime = 0;
+            explosionSeed = (float) Math.random();
             explode = true;
           }
         } else {
@@ -117,5 +126,6 @@ public class SpaceExplosionFX extends GLShaderPattern {
     // Send our visual flag, rather than the simple button value from the
     // control, to the shader.
     s.setUniform("iWowTrigger", explode);
+    s.setUniform("explosionSeed", explosionSeed);
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/jon/TriangleNoise.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/TriangleNoise.java
@@ -24,14 +24,6 @@ public class TriangleNoise extends DriftEnabledPattern {
 
     // register common controls with LX
     addCommonControls();
-
-    addShader(
-        GLShader.config(lx)
-            .withFilename("triangle_noise.fs")
-            .withUniformSource(
-                (s) -> {
-                  // calculate incremental transform based on elapsed time
-                  s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
-                }));
+    addShader(GLShader.config(lx).withFilename("triangle_noise.fs"));
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/TurbulenceLines.java
@@ -12,8 +12,7 @@ public class TurbulenceLines extends DriftEnabledPattern {
     super(lx, TEShaderView.ALL_POINTS);
 
     // common controls setup
-    controls.setRange(TEControlTag.SPEED, 0, -4, 4);
-    controls.setValue(TEControlTag.SPEED, 1.0);
+    controls.setRange(TEControlTag.SPEED, 2, -8, 8);
 
     controls.setRange(TEControlTag.SIZE, 1, 1.25, 0.4);
     controls.setRange(TEControlTag.QUANTITY, 60, 20, 200);
@@ -24,19 +23,6 @@ public class TurbulenceLines extends DriftEnabledPattern {
 
     // register common controls with LX
     addCommonControls();
-
-    addShader(
-        GLShader.config(lx)
-            .withFilename("turbulent_noise_lines.fs")
-            .withUniformSource(
-                (s) -> {
-                  // calculate incremental transform based on elapsed time
-                  s.setUniform("iTranslate", (float) getXPosition(), (float) getYPosition());
-
-                  // override iTime so we can speed up noise field progression while leaving the
-                  // controls
-                  // in a more reasonable range
-                  s.setUniform("iTime", 2f * (float) getTime());
-                }));
+    addShader(GLShader.config(lx).withFilename("turbulent_noise_lines.fs"));
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -149,7 +149,7 @@ public class ShaderPanelsPatternConfig {
       controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
       addShader(
-      GLShader.config(lx).withFilename("space_explosion.fs").withTextures("color_noise.png"));
+      GLShader.config(lx).withFilename("space_explosion.fs"));
     }
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -148,8 +148,7 @@ public class ShaderPanelsPatternConfig {
       controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
       controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
-      addShader(
-      GLShader.config(lx).withFilename("space_explosion.fs"));
+      addShader(GLShader.config(lx).withFilename("space_explosion.fs"));
     }
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -138,11 +138,18 @@ public class ShaderPanelsPatternConfig {
 
     @Override
     protected void createShader() {
-      controls.setRange(TEControlTag.SPEED, 0, -1.5, 1.5); // speed
+      controls.setRange(TEControlTag.SPEED, 0.5, -2, 2); // speed
       controls.setExponent(TEControlTag.SPEED, 2.0);
-      controls.setValue(TEControlTag.SPEED, 0.5);
 
-      addShader("space_explosion.fs");
+      controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
+      controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
+      controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+      controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+      controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+      controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
+
+      addShader(
+      GLShader.config(lx).withFilename("space_explosion.fs").withTextures("color_noise.png"));
     }
   }
 


### PR DESCRIPTION
# Shader Visual Updates August 2025
## GENERAL 
Fixed DriftEnabledPattern, so we can drift through endless noise fields again.

## SHADERS
### RhythmicStatic
- Enhanced palette support
- Spin/Angle

#### XorceryDiamonds
- Enhanced palette support
- Spin/Angle (dual radial spin)
- Scale
- Wow1: beat reactivity

#### TriangleNoise
- Enhanced palette support
- Wow2: Monochromeness

#### TurbulenceLines
- Enhanced palette support
- Wow2: Monochromeness

#### SimplexPosterized
- Enhanced palette support
- Wow2: Monochromeness

#### RadialSimplex
- Enhanced palette support
- Wow2: Monochromeness

#### RhythmicStatic
- Enhanced palette support
- Spin/Angle
- Better color randomness for the static

#### FourStar
- Ok.. it works as intended now.
- Size: Brightness & Size of Star
- Quantity: Number of rays
- Spin/Angle: Start rotation
- Wow1: Color "diffraction" effect
- LvlReact: Beat reactivity

#### Circuitry
- Enhanced palette support
- Wow1: Slight background tint

#### SpaceExplosion/SpaceExplosionFX
- Now resembles actual explosion
- In glorious palette color
- WowTrigger: Start explosion (SpaceExplosionFX only)

#### Video Preview
https://www.youtube.com/watch?v=4nUZAA_oMJY