### PR TITLE
Clean up model enumeration in SimplifyEffect

### DIFF
--- a/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/SimplifyEffect.java
@@ -148,6 +148,8 @@ public class SimplifyEffect extends LXEffect
 
   final List<LXModel> models = new ArrayList<LXModel>();
 
+  private boolean needsRefresh = true;
+
   public SimplifyEffect(LX lx) {
     super(lx);
 
@@ -157,20 +159,18 @@ public class SimplifyEffect extends LXEffect
     addParameter("gain", this.gain);
 
     this.lx.addListener(this);
-
-    refreshModels();
   }
 
   @Override
   public void onParameterChanged(LXParameter p) {
     if (p == this.view || p == this.depth) {
-      refreshModels();
+      this.needsRefresh = true;
     }
   }
 
   @Override
   public void modelGenerationChanged(LX lx, LXModel model) {
-    refreshModels();
+    this.needsRefresh = true;
   }
 
   protected void refreshModels() {
@@ -182,6 +182,11 @@ public class SimplifyEffect extends LXEffect
 
   @Override
   protected void run(double deltaMs, double enabledAmount) {
+    if (this.needsRefresh) {
+      this.needsRefresh = false;
+      refreshModels();
+    }
+
     final double amount = this.amount.getValue();
     final BlendMode blendMode = this.blendMode.getEnum();
     final float gate = this.gate.getValuef();


### PR DESCRIPTION
Uses a `needsRefresh` flag to delay model refreshing until the next run loop.  Prevents unnecessary refreshes at init and when parameters are restored on file open, where in both cases the effect does not yet have the content of a parent.