### PR TITLE
Use custom color parameter UI in performance mode

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -132,6 +132,7 @@ import titanicsend.pattern.yoffa.effect.BeaconEffect;
 import titanicsend.preset.PresetEngine;
 import titanicsend.preset.UIUserPresetManager;
 import titanicsend.ui.UI3DManager;
+import titanicsend.ui.UITEColorControl;
 import titanicsend.ui.UITEPerformancePattern;
 import titanicsend.ui.color.UIColorPaletteManagerSection;
 import titanicsend.ui.effect.UIRandomStrobeEffect;
@@ -754,7 +755,9 @@ public class TEApp extends LXStudio {
     public void initializeUI(LXStudio lx, LXStudio.UI ui) {
       log("TEApp.Plugin.initializeUI()");
 
-      ((LXStudio.Registry) lx.registry).addUIDeviceControls(UITEPerformancePattern.class);
+      LXStudio.Registry registry = (LXStudio.Registry) lx.registry;
+      registry.addUIDeviceControls(UITEPerformancePattern.class);
+      registry.addUIParameterControl(UITEColorControl.class);
 
       this.superMod.initializeUI(lx, ui);
     }

--- a/te-app/src/main/java/titanicsend/ui/UITEColorControl.java
+++ b/te-app/src/main/java/titanicsend/ui/UITEColorControl.java
@@ -19,14 +19,27 @@
  */
 package titanicsend.ui;
 
+import heronarts.glx.ui.UI;
 import heronarts.glx.ui.UIFocus;
-import heronarts.glx.ui.component.UIKnob;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
 import titanicsend.color.TEColorParameter;
 
-public class UITEColorControl extends UITEColorPicker implements UIFocus {
+public class UITEColorControl extends UITEColorPicker
+    implements UIDeviceControls.ParameterControl<TEColorParameter>, UIFocus {
+
+  public UITEColorControl(UI ui, TEColorParameter color) {
+    this(ui, color, color.offset);
+  }
+
+  public UITEColorControl(UI ui, TEColorParameter color, LXParameter parameter) {
+    super(color);
+    // TODO: create a normal UIKnob for subparameters other than Offset (or decline building it?)
+    setDeviceMode(true);
+  }
 
   public UITEColorControl(float x, float y, TEColorParameter color) {
-    super(x, y, UIKnob.WIDTH, UIKnob.HEIGHT, color);
+    super(x, y, color);
     setDeviceMode(true);
     setCorner(Corner.TOP_RIGHT);
   }

--- a/te-app/src/main/java/titanicsend/ui/UITEColorPicker.java
+++ b/te-app/src/main/java/titanicsend/ui/UITEColorPicker.java
@@ -69,11 +69,11 @@ public class UITEColorPicker extends UI2dComponent {
   private boolean deviceMode = false;
 
   public UITEColorPicker(TEColorParameter color) {
-    this(UIKnob.WIDTH, UIKnob.WIDTH, color);
+    this(0, 0, color);
   }
 
-  public UITEColorPicker(float w, float h, TEColorParameter color) {
-    this(0, 0, w, h, color);
+  public UITEColorPicker(float x, float y, TEColorParameter color) {
+    this(x, y, UIKnob.WIDTH, UIKnob.HEIGHT, color);
   }
 
   public UITEColorPicker(float x, float y, float w, float h, TEColorParameter color) {


### PR DESCRIPTION
Brings in our nice color picker in Performance mode:
<img width="400" height="564" alt="image" src="https://github.com/user-attachments/assets/236c0df5-8939-47bb-9588-468900d01858" />

Made possible by a new Chromatik feature as of April this year.

Includes minor edits:
- Used UIKnob.HEIGHT for height, so the parameter label ends up in the correct place.
- Changed constructor option from (w, h) to (x, y) because we only modify the position, never the size.

A couple caveats to sort out later:
- The pop-up goes off the right side of the screen in performance mode.  I have some thoughts on fixing this in upstream.
- If you edit the remote controls (not normally done on TE), all subparameters get the same UI widget.  This might need an upstream change as well.