### PR TITLE
Shader Updates, Round 2

### DIFF
--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea  -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea  -Djava.awt.headless=true " />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/te-app/resources/shaders/arcedges.fs
+++ b/te-app/resources/shaders/arcedges.fs
@@ -1,4 +1,5 @@
-#define LINE_COUNT 52
+#define LINE_COUNT 104
+uniform int lineCount;
 uniform vec4[LINE_COUNT] lines;
 
 float sparkAmp;
@@ -79,6 +80,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     float widthVariation = levelReact * max(0,bassRatio/volumeRatio) *
             0.1 * abs(noise(2.0 * uv + iTime));
     for (int i = 0; i < LINE_COUNT; i++) {
+        if (i >= lineCount) break;
 
       float dist = glowline2(uv,lines[i], baseWidth + widthVariation);
 

--- a/te-app/resources/shaders/dual_wave.fs
+++ b/te-app/resources/shaders/dual_wave.fs
@@ -1,0 +1,75 @@
+// Basic dual-wave algorithm developed from a discussion of
+// frame buffer-less, multidimensional KITT patterns on the Pixelblaze forum.
+// https://forum.electromage.com/t/kitt-without-arrays/1219
+
+#include <include/constants.fs>
+#include <include/colorspace.fs>
+
+uniform bool runEffect = false;
+
+// Pixelblaze-flavored helper functions for shaders
+float sawtooth(float time,float period) {
+    return mod(time,period) / period;
+}
+
+float triangle(float n) {
+    return  2. * (0.5 - abs(fract(n) - 0.5));
+}
+
+float wave(float n) {
+    return 0.5+(sin(TAU * abs(fract(n))) * 0.5);
+}
+
+float square(float n,float dutyCycle) {
+    return (abs(fract(n)) <= dutyCycle) ? 1.0 : 0.0;
+}
+
+// random number generators
+float rand(vec2 p) {
+    return fract(sin(dot(p, vec2(12.543, 514.123)))*4732.12);
+}
+
+vec2 random2(vec2 p) {
+    return vec2(rand(p), rand(p*vec2(12.9898, 78.233)));
+}
+
+// 2D rotation matrix
+mat2 rotate2D(float a) {
+    float c = cos(a), s = sin(a);
+    return mat2(c, -s, s, c);
+}
+
+// KITT!
+void mainImage( out vec4 fragColor, in vec2 fragCoord )  {
+    if (!runEffect) {
+        fragColor = vec4(0.0);
+        return;
+    }
+
+    float tailPct = iScale;         // length of the tail in 0..1
+
+    // Normalize incoming pixel coords
+    vec2 uv = fragCoord / iResolution.xy;
+    uv -= 0.5;                       // center
+    uv *= rotate2D(iRotationAngle);  // rotate
+    uv += 0.5;                       // back to original position
+
+    // and after all that, the x coordinate is the only one we need
+    float x =  floor(iQuantity) * uv.x;
+
+    // get time-based position offset for the waves, and square it to
+    // shape the motion a little.
+    float t1 = fract(iTime);
+    t1 = t1 * t1;
+
+    // build the two moving waves
+    float pct1 = x - t1;
+    float pct2 = -x - t1;
+
+    float bri = max(max(0.,(tailPct - 1.0 + sawtooth(pct1,1.0)) / tailPct),
+        max(0.,(tailPct - 1.0 + sawtooth(pct2,1.0)) / tailPct));
+    // use smoothstep to keep the front edge very bright
+    bri = smoothstep(0.0, 0.6, bri);
+
+    fragColor = vec4(iColorRGB,bri * bri * bri);
+}

--- a/te-app/resources/shaders/edgefall.fs
+++ b/te-app/resources/shaders/edgefall.fs
@@ -25,7 +25,7 @@ const float lineNoiseAmplitude = 0.00575;
 // For TE, we also perturb the line slightly as we draw so it's never totally static
 float glowline(vec2 U, vec4 seg, float glow) {
     seg.xy -= U; seg.zw -= U;
-    float a = mod ( ( atan(seg.y,seg.x) - atan(seg.w,seg.z) ) / PI, 2.);
+    float a = mod((atan(seg.y,seg.x) - atan(seg.w,seg.z)) / PI, 2.);
 
     a += lineNoiseAmplitude * sin(60. * U.y - iTime * 3.0);
     return pow(min( a, 2.-a ),glow/6.);

--- a/te-app/resources/shaders/edgefall.fs
+++ b/te-app/resources/shaders/edgefall.fs
@@ -10,10 +10,15 @@ precision mediump float;
   iSpeed
 */
 
-#define LINE_COUNT 52
+#define LINE_COUNT 104
+uniform float basis;
+uniform float glowLevel;
+uniform int lineCount;
 uniform vec4[LINE_COUNT] lines;
 
-const float PI = 3.14159265359;
+#include <include/constants.fs>
+#include <include/colorspace.fs>
+
 const float lineNoiseAmplitude = 0.00575;
 
 // line drawing algorithm from Fabrice Neyret: Makes interesting, pointy-ended lines.
@@ -35,9 +40,11 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     float bri = 0.0;
 
     for (int i = 0; i < LINE_COUNT; i++) {
-       bri = clamp(1.5 * glowline( uv, lines[i],iScale),0.0,1.0);
-       color += bri * mix(iColorRGB,mix(iColorRGB,iColor2RGB,bri),iWow2);
+       if (i >= lineCount) break;
+       bri = clamp(1.5 * glowline( uv, lines[i],glowLevel),0.0,1.0);
+       color += bri * mix(iColorRGB,getGradientColor(bri),iWow2);
     }
+    float fade = 1.0 - basis * basis;
 
-    fragColor = vec4(color,1.0);
+    fragColor = vec4(color,fade);
 }

--- a/te-app/resources/shaders/fireedges.fs
+++ b/te-app/resources/shaders/fireedges.fs
@@ -1,4 +1,5 @@
 #define MAX_LINE_COUNT 104
+
 uniform int lineCount;
 uniform vec4[MAX_LINE_COUNT] lines;
 

--- a/te-app/resources/shaders/fireedges.fs
+++ b/te-app/resources/shaders/fireedges.fs
@@ -10,6 +10,10 @@ uniform vec4[MAX_LINE_COUNT] lines;
 const float MaxLength = .1;
 const float Dumping = 10.0;
 
+float random(float x) {
+    return fract(sin(x) * 43758.5453123);
+}
+
 vec3 hash3(vec3 p) {
     p = vec3(dot(p, vec3(127.1, 311.7, 74.7)),
     dot(p, vec3(269.5, 183.3, 246.1)),
@@ -69,7 +73,7 @@ float normalizeScalar(float value, float max) {
 
 vec3 color(vec2 p) {
     // generate animated noise field
-    vec3 coord =  vec3(10.0 * p, iTime * 0.25);
+    vec3 coord =  vec3(10.0 * p, iTime * 0.3 + 0.2 * random(floor(p.y * 20.0)));
     float n = abs(noise(coord));
     n += 0.5 * abs(noise(coord * 2.0));
     n += 0.25 * abs(noise(coord * 4.0));
@@ -116,6 +120,9 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     //vec2 coord  = _getModelCoordinates().xy;
     vec2 q = fragCoord.xy / iResolution.xy;
     vec2 coord = 2.0 * q - 1.0;
+    // bouncy scaling
+    float impulse = pow(stemBass, 4.);
+    coord *= 1.0 + (levelReact / 10.0 * sin(TAU * impulse));
 
     vec3 col = color(coord);
     col = pow(col, vec3(0.75)); // gamma correction

--- a/te-app/resources/shaders/icemelt.fs
+++ b/te-app/resources/shaders/icemelt.fs
@@ -1,7 +1,17 @@
-// Probably the sillies shader I've made so far.
+// This is a silly shader, but it looks really nice.
 // Water running down a melting ice cliff.
 #pragma name "Icemelt"
 #pragma iChannel1 "resources/shaders/textures/icecliff.png"
+
+#pragma TEControl.QUANTITY.Range(0.6,0.2,1.0)
+#pragma TEControl.LEVELREACTIVITY.Disable
+#pragma TEControl.FREQREACTIVITY.Disable
+#pragma TEControl.ANGLE.Disable
+#pragma TEControl.SPIN.Disable
+#pragma TEControl.SIZE.Disable
+#pragma TEControl.WOW1.Disable
+#pragma TEControl.WOW2.Disable
+#pragma TEControl.WOWTRIGGER.Disable
 
 float random(float x) {
     return fract(sin(x) * 10000.);
@@ -43,23 +53,34 @@ float waterNoise(vec2 p) {
     float y = movingNoise(p + 100.);
     return movingNoise(p + vec2(x, y));
 }
+
 void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     float t = 20. + iTime;
     vec2 uv = fragCoord.xy / iResolution.xy;
-    float n = waterNoise(vec2(0.0, iTime) + uv * (vec2(60.0,60.0)));
+    float n = waterNoise(vec2(0.0, iTime) + uv * (vec2(40.0,20.0)));
 
     // Optional: make a Ken Burns documentary (w/slow pan) for this texture!
-    //uv.x += 0.1 * sin(iTime / 16.0);
+    uv.x = fract(uv.x + 0.1 * sin(iTime / 32.0));
 
-    // no water on very prominent ice features
+    // Sample the texture, which is largely blue and white. We'll use
+    // the red channel as a proxy for the a bump map of the ice cliff.
+    // The less red is present, the farther from white we'll be.  This
+    // makes a good appoximation of the areas where water would naturally
+    // flow.
     vec3 under = texture(iChannel1,uv).rgb;
-    float val = under.r * under.r * under.r;
-    n = (val >= iWow1) ? n * max(0.0,iWow1 - val) : n;
-    n = mix(0.0,n,iWow1 / (val + 0.0006));
+    float val = under.r * under.r;
+    // Layer water noise over the texture in low areas
+    float mask = smoothstep(iQuantity - 0.05, iQuantity + 0.05, val);
+    n *= 1.0 - mask;
 
+    // Now sample the texture again using the water noise value to
+    // calculate offset due to "refraction" from the water.
     under = texture(iChannel1,uv + (n / 52.)).rgb;
-    under = under * under * under; // increase contrast
 
+    // Ice is pretty white -- let's make detail more visible by
+    // increase the contrast of the final image.
+    under = under * under * under;
 
-    fragColor = vec4(mix(under, vec3(.1, .2, 1.), n / 24.0),1.0);
+    // mix texture color with water color value for final color.
+    fragColor = vec4(mix(under, vec3(.1, .3, 1.), n / 24.0),1.0);
 }

--- a/te-app/resources/shaders/icemelt.fs
+++ b/te-app/resources/shaders/icemelt.fs
@@ -53,9 +53,13 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
 
     // no water on very prominent ice features
     vec3 under = texture(iChannel1,uv).rgb;
-    float val = under.r * under.r;
+    float val = under.r * under.r * under.r;
     n = (val >= iWow1) ? n * max(0.0,iWow1 - val) : n;
+    n = mix(0.0,n,iWow1 / (val + 0.0006));
+
     under = texture(iChannel1,uv + (n / 52.)).rgb;
+    under = under * under * under; // increase contrast
+
 
     fragColor = vec4(mix(under, vec3(.1, .2, 1.), n / 24.0),1.0);
 }

--- a/te-app/resources/shaders/icemelt.fs
+++ b/te-app/resources/shaders/icemelt.fs
@@ -1,0 +1,61 @@
+// Probably the sillies shader I've made so far.
+// Water running down a melting ice cliff.
+#pragma name "Icemelt"
+#pragma iChannel1 "resources/shaders/textures/icecliff.png"
+
+float random(float x) {
+    return fract(sin(x) * 10000.);
+}
+
+float noise(vec2 p) {
+    return random(p.x + p.y * 10000.);
+}
+
+vec2 sw(vec2 p) { return vec2(floor(p.x), floor(p.y)); }
+vec2 se(vec2 p) { return vec2(ceil(p.x), floor(p.y)); }
+vec2 nw(vec2 p) { return vec2(floor(p.x), ceil(p.y)); }
+vec2 ne(vec2 p) { return vec2(ceil(p.x), ceil(p.y)); }
+
+float smoothNoise(vec2 p) {
+    vec2 interp = smoothstep(0., 1., fract(p));
+    float s = mix(noise(sw(p)), noise(se(p)), interp.x);
+    float n = mix(noise(nw(p)), noise(ne(p)), interp.x);
+    return mix(s, n, interp.y);
+}
+
+float fbmNoise(vec2 p) {
+    float x = smoothNoise(p      );
+    x += smoothNoise(p * 2. ) / 2.;
+    x += smoothNoise(p * 4. ) / 4.;
+    x += smoothNoise(p * 8. ) / 8.;
+    x /= 1. + 1./2. + 1./4. + 1./8.;
+    return x;
+}
+
+float movingNoise(vec2 p) {
+    float x = fbmNoise(p + iTime);
+    float y = fbmNoise(p - iTime);
+    return fbmNoise(p + vec2(x, y));
+}
+
+float waterNoise(vec2 p) {
+    float x = movingNoise(p);
+    float y = movingNoise(p + 100.);
+    return movingNoise(p + vec2(x, y));
+}
+void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
+    float t = 20. + iTime;
+    vec2 uv = fragCoord.xy / iResolution.xy;
+    float n = waterNoise(vec2(0.0, iTime) + uv * (vec2(60.0,60.0)));
+
+    // Optional: make a Ken Burns documentary (w/slow pan) for this texture!
+    //uv.x += 0.1 * sin(iTime / 16.0);
+
+    // no water on very prominent ice features
+    vec3 under = texture(iChannel1,uv).rgb;
+    float val = under.r * under.r;
+    n = (val >= iWow1) ? n * max(0.0,iWow1 - val) : n;
+    under = texture(iChannel1,uv + (n / 52.)).rgb;
+
+    fragColor = vec4(mix(under, vec3(.1, .2, 1.), n / 24.0),1.0);
+}

--- a/te-app/resources/shaders/kaleidosonic.fs
+++ b/te-app/resources/shaders/kaleidosonic.fs
@@ -46,8 +46,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     uv = Kaleidoscope(uv, iQuantity);
 
     // levelReact controls audio-linked scaling "bounce" and minimum blob size
-    float level = levelReact * clamp(bassRatio, 0.5, 8.);
-    float intensity = levelReact * clamp(volumeRatio, 0.5, 8.);
+    float level = levelReact * 0.1 * clamp(bassRatio, 0.5, 8.);
+    float intensity = levelReact * 0.1 *  clamp(volumeRatio, 0.5, 8.);
 
     // modulate overall scale by level just a little for more movement.
     // (too much looks jittery)
@@ -86,8 +86,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     }
 
     // apply color modulation based on the field density
-    float colorMix = mod(final_density * 1.618, 1.0);
-    vec3 final_color = getGradientColor(colorMix); //mix(iColor2RGB,iColorRGB,colorMix);
+    float colorMix = fract(final_density);
+    vec3 final_color = getGradientColor(iTime + colorMix);
 
     // iWow2 controls the final gamma correction, which acts as a rough
     // contrast control, letting you thin out the kaleidoscope if you want.

--- a/te-app/resources/shaders/solid_color.fs
+++ b/te-app/resources/shaders/solid_color.fs
@@ -1,0 +1,3 @@
+void mainImage( out vec4 fragColor, vec2 fragCoord ) {
+    fragColor = vec4(iColorRGB,1.0);
+}

--- a/te-app/src/main/java/titanicsend/pattern/jon/ArcEdges.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/ArcEdges.java
@@ -10,7 +10,8 @@ import titanicsend.pattern.yoffa.framework.TEShaderView;
 
 @LXCategory("Combo FG")
 public class ArcEdges extends GLShaderPattern {
-  static final int LINE_COUNT = 52;
+  static final int MAX_LINE_COUNT = 104;
+  int lineCount = 0;
   boolean updateGeometry = true;
   FloatBuffer gl_segments;
   float[][] saved_lines;
@@ -24,7 +25,7 @@ public class ArcEdges extends GLShaderPattern {
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.333, 0.0, 1.0);
 
     // Noise field magnitude - controls size + density of arcs
-    controls.setRange(TEControlTag.SIZE, 0.025, 0.001, 0.08);
+    controls.setRange(TEControlTag.SIZE, 0.04, 0.001, 0.08);
 
     // Controls number of arcs by modifying noise field position offset
     controls.setRange(TEControlTag.QUANTITY, 0.6, 0.72, 0.5);
@@ -35,6 +36,11 @@ public class ArcEdges extends GLShaderPattern {
     // effect of the audio reactivity controls
     controls.setRange(TEControlTag.WOW1, 0.015, 0.001, 0.04);
 
+    controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
+
     // register common controls with the UI
     addCommonControls();
 
@@ -42,15 +48,16 @@ public class ArcEdges extends GLShaderPattern {
     // to GLSL shaders.
     // NOTE: This buffer needs to be *exactly* large enough to contain
     // the number of line segments you're using.  No smaller, no bigger.
-    this.gl_segments = Buffers.newDirectFloatBuffer(LINE_COUNT * 4 * 4);
+    this.gl_segments = Buffers.newDirectFloatBuffer(MAX_LINE_COUNT * 4 * 4);
 
     // buffer to hold line descriptors taken from the vehicle
-    saved_lines = new float[LINE_COUNT][4];
+    saved_lines = new float[MAX_LINE_COUNT][4];
 
     // NOTE: To add more edges, you need to change LINE_COUNT so the
     // segment buffer will be the right size.
     // TODO - eventually, we'll want arcs on the fore/aft car ends too.
-    CarGeometryPatternTools.getPanelConnectedEdges(getModelTE(), "^S.*$", saved_lines, LINE_COUNT);
+    lineCount =
+        CarGeometryPatternTools.getAllEdgesOnSide(getModelTE(), -1, saved_lines, MAX_LINE_COUNT);
 
     // add the OpenGL shader and its frame-time setup function
     addShader(
@@ -62,7 +69,7 @@ public class ArcEdges extends GLShaderPattern {
                   // Shader uniforms associated with a context stay resident
                   // on the GPU,so we only need to set them when something changes.
                   if (updateGeometry) {
-                    sendSegments(s, saved_lines, LINE_COUNT);
+                    sendSegments(s, saved_lines, lineCount);
                     updateGeometry = false;
                   }
                 }));
@@ -72,9 +79,9 @@ public class ArcEdges extends GLShaderPattern {
   void setUniformLine(int segNo, float x1, float y1, float x2, float y2) {
     // TE.log("setLine %d : %.4f %.4f, %.4f %.4f",segNo,x1,y1,x2,y2);
     gl_segments.position(segNo * 4);
-    gl_segments.put(-x1);
+    gl_segments.put(x1);
     gl_segments.put(y1);
-    gl_segments.put(-x2);
+    gl_segments.put(x2);
     gl_segments.put(y2);
     gl_segments.rewind();
   }
@@ -86,6 +93,7 @@ public class ArcEdges extends GLShaderPattern {
     for (int i = 0; i < nLines; i++) {
       setUniformLine(i, lines[i][0], lines[i][1], lines[i][2], lines[i][3]);
     }
+    s.setUniform("lineCount", nLines);
     s.setUniform("lines", gl_segments, 4);
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/jon/CarGeometryPatternTools.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/CarGeometryPatternTools.java
@@ -83,11 +83,9 @@ public class CarGeometryPatternTools {
     List<TEEdgeModel> edges = model.getEdges();
     for (TEEdgeModel edge : edges) {
       if (edge != null) {
-        LXPoint v1 = edge.points[0];
-        LXPoint v2 = edge.points[edge.points.length - 1];
         // if it's on the side we want, or directly on the centerline,
         // add it to the list of lines.
-        if (signum * v1.z > 0.0 || v1.z == 0.0) {
+        if (signum * edge.centroid.z >= 0.0) {
           getLineFromEdge(model, lines, edgeCount, edge.getId());
           edgeCount++;
           if (edgeCount >= lineCount) break;

--- a/te-app/src/main/java/titanicsend/pattern/jon/EdgeFall.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/EdgeFall.java
@@ -10,10 +10,10 @@ import java.nio.FloatBuffer;
 import titanicsend.pattern.glengine.GLShader;
 import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
+import titanicsend.util.TEMath;
 
 @LXCategory("Combo FG")
 public class EdgeFall extends GLShaderPattern {
-  VariableSpeedTimer realTime;
   double eventStartTime;
   double elapsedTime;
   int fallingCycleBeats;
@@ -21,7 +21,8 @@ public class EdgeFall extends GLShaderPattern {
   static final double burstDuration = 0.2;
   boolean isFalling;
 
-  static final int LINE_COUNT = 52;
+  static final int MAX_LINE_COUNT = 104;
+  int lineCount;
   FloatBuffer gl_segments;
   float[][] saved_lines;
   float[][] working_lines;
@@ -30,11 +31,11 @@ public class EdgeFall extends GLShaderPattern {
   // Work to be done per frame
   private void setUniforms(GLShader s) {
     float glowLevel;
+    float cyclePct;
 
-    realTime.tick();
-
-    double t = realTime.getTime();
+    double t = getTime();
     elapsedTime = Math.abs(t - eventStartTime);
+    cyclePct = 0.0f;
 
     beatCounter += lx.engine.tempo.beat() ? 1 : 0;
 
@@ -44,13 +45,14 @@ public class EdgeFall extends GLShaderPattern {
 
     // tiny state machine for falling vs. resting states
     if (isFalling) {
+      cyclePct = (float) TEMath.clamp(elapsedTime / (double) fallingCycleBeats, 0.0, 1.0);
       // simulate short explosive burst (by greatly increasing line
       // width/glow) when event is first triggered
       if (elapsedTime < burstDuration) {
         glowLevel *= (float) (elapsedTime / burstDuration);
       }
-      // reset automatically at end of cycle
-      else if (beatCounter > fallingCycleBeats) {
+      // reset automatically at end of cycle, after a brief delay
+      else if (beatCounter > (fallingCycleBeats + 5)) {
         reset(0);
         isFalling = false;
       }
@@ -62,19 +64,17 @@ public class EdgeFall extends GLShaderPattern {
 
     glowLevel -= 80f * (float) getBassLevel() * (float) getLevelReactivity();
 
-    // set line brightness.  We need to override the default behavior because
-    // when a fall is triggered, we make everything very, very bright for a short time
-    // to simulate an explosive burst.
-    s.setUniform("iScale", glowLevel);
-
-    // override the default variable timer, since this shader needs actual 1:1 seconds.
-    s.setUniform("iTime", realTime.getTimef());
-
     // send current line segment position data
-    for (int i = 0; i < LINE_COUNT; i++) {
+    for (int i = 0; i < lineCount; i++) {
       setUniformLine(
           i, working_lines[i][0], working_lines[i][1], working_lines[i][2], working_lines[i][3]);
     }
+
+    // set line brightness. When a fall is triggered, we make everything
+    // very, very bright for a short time to simulate an explosive burst.
+    s.setUniform("basis", cyclePct);
+    s.setUniform("glowLevel", glowLevel);
+    s.setUniform("lineCount", lineCount);
     s.setUniform("lines", gl_segments, 4);
   }
 
@@ -82,22 +82,23 @@ public class EdgeFall extends GLShaderPattern {
   public EdgeFall(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
 
-    // set up timer for fall cycle length.
-    realTime = new VariableSpeedTimer();
-
     // set default speed to 1:1 - line motion looks good that way
     controls.setRange(TEControlTag.SPEED, 1, -4, 4);
-
-    // Size controls line width/glow
+    // SIZE controls line width/glow
     controls.setRange(TEControlTag.SIZE, 80, 200, 37);
     controls.setExponent(TEControlTag.SIZE, 0.3);
-
-    // wow1 - falling phase duration before auto reset (in beats at current tempo)
+    // WOW1 - falling phase duration before auto reset (in beats at current tempo)
     controls
         .setRange(TEControlTag.WOW1, 4.0, 1, 16)
         .setUnits(TEControlTag.WOW1, LXParameter.Units.INTEGER);
+    // WOW2 - controls palette color mix
+    controls.setRange(TEControlTag.WOW2, 0.7, 0.0, 1.0);
 
-    // wow2 controls palette color mix
+    // disable unused controls
+    controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPIN));
+    controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
     addCommonControls();
 
@@ -107,21 +108,22 @@ public class EdgeFall extends GLShaderPattern {
     // to GLSL shaders.
     // NOTE: This buffer needs to be *exactly* large enough to contain
     // the number of line segments you're using.  No smaller, no bigger.
-    this.gl_segments = Buffers.newDirectFloatBuffer(LINE_COUNT * 4 * 4);
+    this.gl_segments = Buffers.newDirectFloatBuffer(MAX_LINE_COUNT * 4 * 4);
 
     // buffer to hold line descriptors taken from the vehicle
-    saved_lines = new float[LINE_COUNT][4];
+    saved_lines = new float[MAX_LINE_COUNT][4];
 
     // working storage so we can move those lines around
-    working_lines = new float[LINE_COUNT][4];
+    working_lines = new float[MAX_LINE_COUNT][4];
 
     // per-line x and y velocity components
-    line_velocity = new float[LINE_COUNT][2];
+    line_velocity = new float[MAX_LINE_COUNT][2];
 
     // Select the edges we want to draw. NOTE: To add more edges, you need
     // to change LINE_COUNT so the segment buffer will be the right size. OpenGL
     // is very picky about this!
-    CarGeometryPatternTools.getPanelConnectedEdges(getModelTE(), "^S.*$", saved_lines, LINE_COUNT);
+    lineCount =
+        CarGeometryPatternTools.getAllEdgesOnSide(getModelTE(), -1, saved_lines, MAX_LINE_COUNT);
 
     // initialize in the at-rest state
     reset(-99);
@@ -138,9 +140,9 @@ public class EdgeFall extends GLShaderPattern {
   void setUniformLine(int segNo, float x1, float y1, float x2, float y2) {
     // TE.log("setLine %d : %.4f %.4f, %.4f %.4f",segNo,x1,y1,x2,y2);
     gl_segments.position(segNo * 4);
-    gl_segments.put(-x1);
+    gl_segments.put(x1);
     gl_segments.put(y1);
-    gl_segments.put(-x2);
+    gl_segments.put(x2);
     gl_segments.put(y2);
     gl_segments.rewind();
   }
@@ -156,7 +158,7 @@ public class EdgeFall extends GLShaderPattern {
 
   // set speed and direction of falling lines
   void randomizeLineVelocities() {
-    for (int i = 0; i < LINE_COUNT; i++) {
+    for (int i = 0; i < lineCount; i++) {
       line_velocity[i][0] = randomBetween(-8, 8, 1);
       line_velocity[i][1] = randomBetween(-5, 5, 1);
     }
@@ -168,7 +170,7 @@ public class EdgeFall extends GLShaderPattern {
     if (isFalling) {
       float d = (float) (-0.5 * elapsedTime / fallingCycleBeats);
 
-      for (int i = 0; i < LINE_COUNT; i++) {
+      for (int i = 0; i < lineCount; i++) {
         dst[i][0] = src[i][0] + d * line_velocity[i][0]; // x1
         dst[i][1] = src[i][1] + d * line_velocity[i][1]; // y1
         dst[i][2] = src[i][2] + d * line_velocity[i][0]; // x2
@@ -177,7 +179,7 @@ public class EdgeFall extends GLShaderPattern {
     } else {
       // use structured noise to move the lines around with the beat
       float d = 0.075f * (float) getTrebleLevel() * (float) getFrequencyReactivity();
-      for (int i = 0; i < LINE_COUNT; i++) {
+      for (int i = 0; i < lineCount; i++) {
         float n = (float) getTime() + (float) i / 2f;
         dst[i][0] = src[i][0] + d * stb_perlin_noise3(n, 0.5f, 0.5f, 10, 10, 10);
         dst[i][1] = src[i][1] + d * stb_perlin_noise3(0.5f, n, 0.5f, 10, 10, 10);

--- a/te-app/src/main/java/titanicsend/pattern/jon/FireEdges.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/FireEdges.java
@@ -20,18 +20,19 @@ public class FireEdges extends GLShaderPattern {
   public FireEdges(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
 
-    // Controls HOW MUCH FIRE IS FIRE!!!
-    controls.setRange(TEControlTag.QUANTITY, 0.5, 1, 0.2);
 
-    // Controls how much of the color range of the current palette is
+
+    // LEVELREACTIVITY - Amount of "bounce" in reaction to bass stem signal
+    controls.setRange(TEControlTag.LEVELREACTIVITY,0.2,0.0, 0.35);
+    // WOW1 - How much of the color range of the current palette is
     // used to tint the fire. (0.0 = basically just the first color,
     // 1.0 = all colors in the palette)
-    controls.setRange(TEControlTag.WOW1, 0.5, 0, 1);
+    controls.setRange(TEControlTag.WOW1, 0.5, 0., 1.);
+    // WOW2 - Controls the mix of palette-tinted fire vs. fire-colored fire.
+    controls.setRange(TEControlTag.WOW2, 1., 0., 1.);
+    // QUANTITY - HOW MUCH FIRE!!!
+    controls.setRange(TEControlTag.QUANTITY, 0.5, 1., 0.2);
 
-    // Controls the mix of palette-tinted fire vs. fire-colored fire.
-    controls.setRange(TEControlTag.WOW2, 0., 0, 1);
-
-    controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
     controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
     controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
     controls.markUnused(controls.getLXControl(TEControlTag.YPOS));

--- a/te-app/src/main/java/titanicsend/pattern/jon/FireEdges.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/FireEdges.java
@@ -20,10 +20,8 @@ public class FireEdges extends GLShaderPattern {
   public FireEdges(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
 
-
-
     // LEVELREACTIVITY - Amount of "bounce" in reaction to bass stem signal
-    controls.setRange(TEControlTag.LEVELREACTIVITY,0.2,0.0, 0.35);
+    controls.setRange(TEControlTag.LEVELREACTIVITY, 0.2, 0.0, 0.35);
     // WOW1 - How much of the color range of the current palette is
     // used to tint the fire. (0.0 = basically just the first color,
     // 1.0 = all colors in the palette)

--- a/te-app/src/main/java/titanicsend/pattern/jon/FxDualWave.java
+++ b/te-app/src/main/java/titanicsend/pattern/jon/FxDualWave.java
@@ -12,8 +12,9 @@ import titanicsend.pattern.yoffa.framework.TEShaderView;
 public class FxDualWave extends GLShaderPattern {
   double eventStartTime;
   double lastBasis;
+  boolean stopRequest; // true if the effect should stop at the end of this cycle
   boolean running; // true if effect timing state machine is running
-  boolean runEffect; // true if the effect visual should be displayed
+  boolean showVisual; // true if the effect visual should be displayed
 
   // how long a single instance of the effect lasts, in variable speed seconds
   private static final double eventDuration = 2.0;
@@ -44,22 +45,24 @@ public class FxDualWave extends GLShaderPattern {
     // initialize state machine for run control
     eventStartTime = 0;
     lastBasis = 0;
+    stopRequest = false;
     running = false;
-    runEffect = false;
+    showVisual = false;
 
     // SPEED - transit speed of the waves
-    controls.setRange(TEControlTag.SPEED, 1.0, -4, 4);
+    controls.setRange(TEControlTag.SPEED, 0.5, -2, 2);
     // SIZE - width of the waves
-    controls.setRange(TEControlTag.SIZE, 0.2, 0.05, 0.8);
+    controls.setRange(TEControlTag.SIZE, 0.2, 0.05, 0.5);
     // WOW1 - Trigger mode
     controls.setControl(TEControlTag.WOW1, triggerMode);
+    // WOW2 - palette color mix level
+    controls.setRange(TEControlTag.WOW2, 0.5, 0.0, 1.0);
     // QUANTITY - number of duplicates of the wave
     controls.setRange(TEControlTag.QUANTITY, 1.0, 1.0, 12.0);
 
     // disable unused controls
     controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
     controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
-    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
     controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
     controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
 
@@ -90,44 +93,41 @@ public class FxDualWave extends GLShaderPattern {
     // if the effect is running, check event duration to see if we
     // need to retrigger, or just keep showing the visual
     if (running) {
+      // if we're in RUN mode, we always show the effect
       if (triggerMode.getEnum() == TriggerMode.RUN) {
-        // if we're in RUN mode, we always show the effect
-        runEffect = true;
+        showVisual = true;
       }
-      // if we're in one-shot mode, see if the effect has run its full duration
+      // If we're triggering from a button press, wait for a beat before
+      // starting the effect visual.
+      else if (getBeatState() && !showVisual) {
+        // reset the pattern's clock to sync to the beat
+        retrigger(TEControlTag.SPEED);
+        eventStartTime = getTime();
+        showVisual = true;
+        stopRequest = true;
+      }
+      // if we're in one-shot mode and have reached the end of the cycle,
+      // stop the effect and return to idle state
       else if (Math.abs(getTime() - eventStartTime) > eventDuration) {
-        if (getWowTrigger()) {
-          // If we're triggering for the first time, wait for a beat before
-          // starting the effect visual.
-          if (!runEffect) {
-            if (getBeatState()) {
-              // reset the pattern's clock to sync to the beat
-              retrigger(TEControlTag.SPEED);
-              eventStartTime = 0;
-              runEffect = true;
-            }
+        if (stopRequest && showVisual) {
+          // if the button was released, stop the effect
+          // if it's held down, keep running
+          if (!getWowTrigger()) {
+            running = false;
+            showVisual = false;
+          } else {
+            eventStartTime = getTime();
           }
-        } else {
-          // WowTrigger button is up and we're not in continuous run
-          // mode, so stop the effect and return to idle state
-          running = false;
-          runEffect = false;
         }
+        // we're in mid-cycle. Continue running the effect
       } else {
-        // continue running the effect
-        runEffect = true;
+        showVisual = true;
       }
-    } else if (getWowTrigger()) {
-      // On initial trigger, set event start clock high
-      // so it causes a beat timing check on the next frame
-      eventStartTime = 999.;
-      // start state machine
-      running = true;
     }
 
     // Send our visual control flag, rather than the raw value from the
     // WowTrigger control to the shader.
-    s.setUniform("runEffect", runEffect);
+    s.setUniform("runEffect", showVisual);
   }
 
   // Button activation logic.  Keep going while button is held,
@@ -139,20 +139,28 @@ public class FxDualWave extends GLShaderPattern {
     // trigger pattern when wow button is pressed.
     // restart if retriggered before cycle is complete.
     if (on) {
-      this.active = true;
-      this.stopRequest = false;
-      this.startTime = getTime() * 1000.0;
+      if (!running) {
+        this.running = true;
+        this.showVisual = false;
+        this.stopRequest = false;
+      }
     } else {
       if (this.triggerMode.getEnum() == TriggerMode.ONCE) {
         this.stopRequest = true;
       }
     }
+  }
 
   @Override
   public void onParameterChanged(LXParameter parameter) {
     super.onParameterChanged(parameter);
     if (parameter == triggerMode) {
       if (triggerMode.getEnum() == TriggerMode.ONCE) {
-        this.active = false;
-
+        // this.running = false;
+        this.stopRequest = true;
+      } else {
+        this.running = true;
+      }
+    }
+  }
 }

--- a/te-app/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
@@ -2,8 +2,6 @@ package titanicsend.pattern.justin;
 
 import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
-import heronarts.lx.model.LXPoint;
-import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
 

--- a/te-app/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/justin/TESolidPattern.java
@@ -4,10 +4,11 @@ import heronarts.lx.LX;
 import heronarts.lx.LXCategory;
 import heronarts.lx.model.LXPoint;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
 
 @LXCategory(LXCategory.COLOR)
-public class TESolidPattern extends TEPerformancePattern {
+public class TESolidPattern extends GLShaderPattern {
 
   public TESolidPattern(LX lx) {
     super(lx);
@@ -24,18 +25,7 @@ public class TESolidPattern extends TEPerformancePattern {
     controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
     controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
     addCommonControls();
-  }
 
-  @Override
-  protected void runTEAudioPattern(double deltaMs) {
-    int color1 = calcColor();
-
-    for (LXPoint p : getModel().getPoints()) {
-      if (this.modelTE.isGapPoint(p)) {
-        continue;
-      }
-
-      colors[p.index] = color1;
-    }
+    addShader("solid_color.fs");
   }
 }


### PR DESCRIPTION
# Shader Visual Updates for 2025, Round 2

## GENERAL 
 - minor fixes & improvements in CarGeometryPatternTools.java

## SHADERS

#### IceMelt
New - Meltwater running down glacial ice
- QUANTITY:  How much of the glacier is melting

#### TESolid
- Now compatible w/GPU mode for blazing speed!

#### OutrunGrid
- Enhanced palette support
- LvlReact - controls audio-based animated terrain height
- All other controls: Same as before.

#### FxDualWave
- Now compatible w/GPU mode
- Enhanced palette support
- Spin/Angle 
- Size: Width of waves
- Scale: Number of replicates
- Wow1: Trigger mode ("ONCE" or "RUN")
- Wow2: Palette gradient mix level (0=monochrome, 1=gradient)

#### ArcEdges
- Updated geometry for GPU Mixer
- Updated default settings to look better w/new shader engine.

#### EdgeFall
- Updated geometry for GPU Mixer
- Exploding lines now fade out over time, and there's a brief delay before reset
- pressing WowTrigger once explodes lines, pressing again resets instantly

#### FireEdges
- LVLREACT - Added whole car "bounce" on bass stem.  Try this out if you can.  I think it'll be really dramatic at full size on the car.

#### Kaleidosonic
- Scaled reactivity to sane values
- Improved color selection