### PR TITLE
Off Air Parameters

### DIFF
--- a/te-app/src/main/java/titanicsend/model/justin/LXVirtualDiscreteParameter.java
+++ b/te-app/src/main/java/titanicsend/model/justin/LXVirtualDiscreteParameter.java
@@ -221,6 +221,14 @@ public abstract class LXVirtualDiscreteParameter<T extends DiscreteParameter>
   }
 
   @Override
+  public String getBaseOption() {
+    if (this.parameter != null) {
+      return this.parameter.getBaseOption();
+    }
+    return super.getBaseOption();
+  }
+
+  @Override
   public String[] getOptions() {
     if (this.parameter != null) {
       return this.parameter.getOptions();
@@ -247,13 +255,7 @@ public abstract class LXVirtualDiscreteParameter<T extends DiscreteParameter>
 
   @Override
   public void dispose() {
-    if (this.parameter != null) {
-      this.parameter.removeListener(this.realParameterListener);
-      if (this.parameter instanceof DisposableParameter) {
-        ((DisposableParameter) this.parameter).unlistenDispose(disposeParameterListener);
-      }
-      this.parameter = null;
-    }
+    setParameter(null, false);
     super.dispose();
   }
 }

--- a/te-app/src/main/java/titanicsend/parameter/OffairDiscreteParameter.java
+++ b/te-app/src/main/java/titanicsend/parameter/OffairDiscreteParameter.java
@@ -1,0 +1,142 @@
+package titanicsend.parameter;
+
+import heronarts.lx.LXComponent;
+import heronarts.lx.effect.LXEffect;
+import heronarts.lx.mixer.LXAbstractChannel;
+import heronarts.lx.mixer.LXMixerEngine;
+import heronarts.lx.mixer.LXPatternEngine;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.LXListenableNormalizedParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.pattern.LXPattern;
+import titanicsend.model.justin.LXVirtualDiscreteParameter;
+
+/**
+ * Wraps a discrete parameter and prevents the value from changing while the parent device is "live"
+ */
+public class OffairDiscreteParameter<T extends DiscreteParameter>
+    extends LXVirtualDiscreteParameter<T> {
+
+  public OffairDiscreteParameter(String label, T parameter) {
+    super(label, parameter);
+  }
+
+  /**
+   * Determine is this parameter is Off-Air, aka Not contributing to Live Output. JKB note: This
+   * could be sped up by tracking the device and channel.
+   */
+  private boolean offAir() {
+    LXPattern pattern = null;
+    boolean firstPatternEngine = true;
+
+    LXComponent parent = this.getParent();
+    while (parent != null) {
+      switch (parent) {
+        case LXEffect effect -> {
+          if (!effect.isEnabled()) {
+            // If effect is disabled, we're off air
+            return true;
+          }
+        }
+        case LXPattern lxPattern -> {
+          // Track the pattern so we can see if it is active or composited
+          pattern = lxPattern;
+        }
+        case LXPatternEngine.Container container -> {
+          LXPatternEngine patternEngine = container.getPatternEngine();
+          if (firstPatternEngine) {
+            firstPatternEngine = false;
+            if (pattern != null) {
+              if (patternEngine.isComposite()) {
+                if (pattern.compositeLevel.getValue() == 0) {
+                  // A composite pattern at zero composite level is off air
+                  return true;
+                }
+              } else if (patternEngine.getActivePattern() != pattern
+                  && (!patternEngine.isInTransition()
+                      || (patternEngine.getNextPattern() != pattern))) {
+                // Non-composite engine, and pattern is not active or next
+                return true;
+              }
+            }
+          }
+          // A container could also be a channel
+          if (container instanceof LXAbstractChannel channel && isChannelOffAir(channel)) {
+            return true;
+          }
+        }
+        case LXAbstractChannel abstractChannel -> {
+          // If channel disabled, fader down, or auto-muted, we're off air.
+          if (isChannelOffAir(abstractChannel)) {
+            return true;
+          }
+        }
+        case LXMixerEngine lxMixerEngine -> {
+          // Reached the top of the mixer tree
+          break;
+        }
+        default -> {}
+      }
+      // Check the next parent up the hierarchy
+      parent = parent.getParent();
+    }
+
+    // The device is live
+    bang();
+    return false;
+  }
+
+  private boolean isChannelOffAir(LXAbstractChannel abstractChannel) {
+    return !abstractChannel.enabled.isOn()
+        || abstractChannel.fader.getValue() == 0
+        || abstractChannel.isAutoMuted.isOn();
+  }
+
+  @Override
+  public DiscreteParameter setNormalized(double value) {
+    if (offAir()) {
+      super.setNormalized(value);
+    }
+    return this;
+  }
+
+  @Override
+  public LXListenableNormalizedParameter incrementNormalized(double amount) {
+    if (offAir()) {
+      super.incrementNormalized(amount);
+    }
+    return this;
+  }
+
+  @Override
+  public LXListenableNormalizedParameter incrementNormalized(double amount, boolean wrap) {
+    if (offAir()) {
+      super.incrementNormalized(amount, wrap);
+    }
+    return this;
+  }
+
+  @Override
+  public DiscreteParameter increment() {
+    if (offAir()) {
+      super.increment();
+    }
+    return this;
+  }
+
+  @Override
+  public DiscreteParameter decrement() {
+    if (offAir()) {
+      super.decrement();
+    }
+    return this;
+  }
+
+  @Override
+  public LXParameter reset() {
+    if (offAir()) {
+      super.reset();
+    }
+    return this;
+  }
+}

--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -8,18 +8,24 @@ import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
+import heronarts.lx.structure.view.LXViewEngine;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import titanicsend.color.TEColorParameter;
 import titanicsend.color.TEGradientSource;
+import titanicsend.parameter.OffairDiscreteParameter;
 import titanicsend.pattern.jon.TEControl;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.jon._CommonControlGetter;
+import titanicsend.preset.UserPresetCollection;
 import titanicsend.util.MissingControlsManager;
 import titanicsend.util.TE;
 
 public class TECommonControls {
+
+  public static final String KEY_PRESET_SELECTOR_OFFAIR = "presetOffair";
+  public static final String KEY_VIEW_OFFAIR = "viewOffair";
 
   private final TEPerformancePattern pattern;
 
@@ -31,6 +37,10 @@ public class TECommonControls {
   // Color control is accessible, in case the pattern needs something
   // other than the current color.
   public TEColorParameter color;
+
+  // Wrapped parameters that cannot be changed while live
+  private OffairDiscreteParameter<UserPresetCollection.Selector> presetSelectorOffair;
+  private OffairDiscreteParameter<LXViewEngine.Selector> viewOffair;
 
   // Panic control courtesy of JKB's Rubix codebase
   public final BooleanParameter panic =
@@ -348,6 +358,14 @@ public class TECommonControls {
       colorPrefix = "[x] ";
     }
     TEColorParameter colorParam = registerColorControl(colorPrefix);
+
+    // Wrap the Preset parameter to prevent it from being changed while live
+    this.presetSelectorOffair = new OffairDiscreteParameter<>("Preset", pat.presetSelector);
+    this.pattern.addParam(KEY_PRESET_SELECTOR_OFFAIR, this.presetSelectorOffair);
+
+    // Wrap the View parameter to prevent it from being changed while live
+    this.viewOffair = new OffairDiscreteParameter<>("View", pat.view);
+    this.pattern.addParam(KEY_VIEW_OFFAIR, this.viewOffair);
   }
 
   /** Included for consistency. We may need it later. */
@@ -368,7 +386,7 @@ public class TECommonControls {
         new LXListenableNormalizedParameter[] {
           getControl(TEControlTag.LEVELREACTIVITY).control,
           getControl(TEControlTag.FREQREACTIVITY).control,
-          this.pattern.view,
+          this.viewOffair,
           getControl(TEControlTag.SPEED).control,
           getControl(TEControlTag.XPOS).control,
           getControl(TEControlTag.YPOS).control,
@@ -377,7 +395,7 @@ public class TECommonControls {
           getControl(TEControlTag.ANGLE).control,
           getControl(TEControlTag.SPIN).control,
           this.panic,
-          this.pattern.presetSelector,
+          this.presetSelectorOffair,
           getControl(TEControlTag.WOW1).control,
           getControl(TEControlTag.WOW2).control,
           getControl(TEControlTag.WOWTRIGGER).control,
@@ -430,5 +448,7 @@ public class TECommonControls {
 
   public void dispose() {
     panic.removeListener(panicListener);
+    this.presetSelectorOffair.setParameter(null);
+    this.viewOffair.setParameter(null);
   }
 }

--- a/te-app/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPattern.java
@@ -270,7 +270,7 @@ public abstract class TEPattern extends DmxPattern {
     obj.add(KEY_DEFAULTS, toObject(lx, this.defaults));
 
     // Ensure non-serializable params not serialized.
-    removePresetSelector(obj);
+    removeParameter(obj, KEY_PRESET_SELECTOR);
   }
 
   public static JsonObject toObject(LX lx, Map<String, Double> map) {
@@ -284,7 +284,7 @@ public abstract class TEPattern extends DmxPattern {
   @Override
   public void load(LX lx, JsonObject obj) {
     // In case a preset selector was serialized by accident, remove it
-    removePresetSelector(obj);
+    removeParameter(obj, KEY_PRESET_SELECTOR);
 
     super.load(lx, obj);
 
@@ -327,11 +327,11 @@ public abstract class TEPattern extends DmxPattern {
     }
   }
 
-  private void removePresetSelector(JsonObject obj) {
+  protected static void removeParameter(JsonObject obj, String parameterKey) {
     if (obj.has(KEY_PARAMETERS)) {
       final JsonObject parametersObj = obj.getAsJsonObject(KEY_PARAMETERS);
-      if (parametersObj.has(KEY_PRESET_SELECTOR)) {
-        parametersObj.remove(KEY_PRESET_SELECTOR);
+      if (parametersObj.has(parameterKey)) {
+        parametersObj.remove(parameterKey);
       }
     }
   }

--- a/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -473,13 +473,27 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
   private static final String KEY_REMOTE_CONTROLS = "remoteControls";
 
   @Override
+  public void save(LX lx, JsonObject obj) {
+    super.save(lx, obj);
+
+    // Don't save off-air virtual parameters
+    removeOffAirParameters(obj);
+  }
+
+  @Override
   public void load(LX lx, JsonObject obj) {
     // Strip out custom remote controls to avoid stale versions overriding the new. (8-25: We've
     // been using custom remote controls wrong, which causes problems on project files and presets)
     if (obj.has(KEY_REMOTE_CONTROLS)) {
       obj.remove(KEY_REMOTE_CONTROLS);
     }
+    removeOffAirParameters(obj);
     super.load(lx, obj);
+  }
+
+  private void removeOffAirParameters(JsonObject obj) {
+    removeParameter(obj, TECommonControls.KEY_PRESET_SELECTOR_OFFAIR);
+    removeParameter(obj, TECommonControls.KEY_VIEW_OFFAIR);
   }
 
   @Override


### PR DESCRIPTION
A highly requested feature.

Adds a "safety wrapper" around certain parameters to prevent them from being changed while their pattern is mixed into the live output.  Prevents accidental visual jumps during a show.

Conditions that allow the parameter to be modified, because it is not live, include: channel fader is down, channel is disabled, pattern is not active and not being transitioned to on the channel, etc.

Added to the `View` and `PresetSelector` knobs on `TEPerformancePattern`.

Code notes:
- Built on our existing LXVirtualDiscreteParameter
- Off-Air parameters are removed from serialization