### PR TITLE
Don't auto-enable midi surface types if multiple could be in use

### DIFF
--- a/te-app/src/main/java/titanicsend/app/dev/DevSwitch.java
+++ b/te-app/src/main/java/titanicsend/app/dev/DevSwitch.java
@@ -28,7 +28,6 @@ import titanicsend.dmx.DmxEngine;
 import titanicsend.dmx.model.AdjStealthModel;
 import titanicsend.dmx.model.BeaconModel;
 import titanicsend.lasercontrol.TELaserTask;
-import titanicsend.lx.DirectorAPCminiMk2;
 import titanicsend.midi.MidiNames;
 import titanicsend.osc.CrutchOSC;
 import titanicsend.output.ChromatechSocket;
@@ -536,12 +535,11 @@ public class DevSwitch extends LXComponent implements LXSerializable, LX.Project
   /** Returns TRUE for normal surfaces that should be enabled for TE production */
   private boolean isTESurface(LXMidiSurface surface) {
     return surface instanceof titanicsend.lx.APC40Mk2
-        || surface instanceof heronarts.lx.midi.surface.APC40Mk2
-        || surface instanceof heronarts.lx.midi.surface.APCminiMk2
-        || surface instanceof DirectorAPCminiMk2
-        || surface instanceof studio.jkb.supermod.APCminiMk2
-        || surface instanceof heronarts.lx.midi.surface.MidiFighterTwister
-        || surface instanceof studio.jkb.supermod.MidiFighterTwister
+        // || surface instanceof heronarts.lx.midi.surface.APCminiMk2
+        // || surface instanceof DirectorAPCminiMk2
+        // || surface instanceof studio.jkb.supermod.APCminiMk2
+        // || surface instanceof heronarts.lx.midi.surface.MidiFighterTwister
+        // || surface instanceof studio.jkb.supermod.MidiFighterTwister
         || surface instanceof heronarts.lx.midi.surface.DJM900nxs2
         || surface instanceof heronarts.lx.midi.surface.DJMV10;
   }


### PR DESCRIPTION
This was causing problems with the new midi setup.  It would auto-enable multiple surfaces tied to the same midi I/Os, making the surface behavior wonky and dual-reading the inputs.
