### PR TITLE
Preprocessor Fix

### DIFF
--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true " />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
@@ -9,7 +9,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.shader_engine.ShaderUtils;
-import titanicsend.util.TE;
 
 public class GLPreprocessorHelpers {
   /** Converts strings from control definition #pragmas to shader configuration opcode values */

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
@@ -223,7 +223,11 @@ public class GLPreprocessorHelpers {
           try {
             control.parameterId = TEControlTag.valueOf(tagName);
           } catch (IllegalArgumentException exception) {
-            TE.error("Unsupported tag name: %s", varName);
+            // Ignore #iUniforms with no corresponding tag as they are either typos, in which
+            // case the shader will not compile, or they correspond to additional custom uniforms
+            // supplied by a pattern's Java front-end.
+            // TE.log("Unsupported tag name: %s", varName);
+            continue;
           }
           control.opcode = ShaderConfigOpcode.SET_RANGE;
           control.name = control.parameterId.getLabel();

--- a/te-app/src/main/java/titanicsend/pattern/glengine/ShaderPatternClassFactory.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/ShaderPatternClassFactory.java
@@ -60,9 +60,10 @@ public class ShaderPatternClassFactory {
     return false;
   }
 
-  public boolean hasConfigData(List<ShaderConfiguration> config) {
+  public boolean isAutoShader(List<ShaderConfiguration> config) {
     for (ShaderConfiguration c : config) {
-      if (c.opcode != ShaderConfigOpcode.ADD_LX_PARAMETER) return true;
+      if (c.opcode == ShaderConfigOpcode.AUTO ||
+      c.opcode == ShaderConfigOpcode.SET_CLASS_NAME) return true;
     }
     return false;
   }
@@ -109,8 +110,8 @@ public class ShaderPatternClassFactory {
 
       // if the shader has no embedded configuration at all, we have to assume
       // that it's set up the "normal" way.  Skip it.
-      if (hasConfigData(config) == false) {
-        // TE.log("Shader " + shaderFile + " has no configuration data.  Skipping.");
+      if (isAutoShader(config) == false) {
+        // TE.log("Shader " + shaderFile + " is not an auto shader.  Skipping.");
         continue;
       }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/ShaderPatternClassFactory.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/ShaderPatternClassFactory.java
@@ -62,8 +62,8 @@ public class ShaderPatternClassFactory {
 
   public boolean isAutoShader(List<ShaderConfiguration> config) {
     for (ShaderConfiguration c : config) {
-      if (c.opcode == ShaderConfigOpcode.AUTO ||
-      c.opcode == ShaderConfigOpcode.SET_CLASS_NAME) return true;
+      if (c.opcode == ShaderConfigOpcode.AUTO || c.opcode == ShaderConfigOpcode.SET_CLASS_NAME)
+        return true;
     }
     return false;
   }


### PR DESCRIPTION
- Preprocessor now ignores #iUniform tags if they don't have an associated TEControlTag.   This enables the use of custom uniforms during development w/the VSCode plugin.  Previously a custom #iUniform would cause an exception to be thrown, and the associated shader would not load.
- Shaders now must have either `#pragma auto` or `#pragma name` to be configured as a TEAutoShader.  Formerly anything with a `#pragma` that we understood was interpreted as an autoshader, which occasionally lead to shaders having duplicate entries in the Chromatik patterns list.  This fix allows the use of our preprocessor directives in shaders created from Java. It eliminates the duplicate entries.  And down the road, with a little more work, it will allow us to change some common control settings from GLSL without restarting the Java app. 