### PR TITLE
Fix bad run.xml file

### DIFF
--- a/.run/Titanic's End.run.xml
+++ b/.run/Titanic's End.run.xml
@@ -4,7 +4,7 @@
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="Projects/BM2024_TE.lxp" />
-    <option name="VM_PARAMETERS" value="-ea -Djava.awt.headless=true " />
+    <option name="VM_PARAMETERS" value="-ea -XstartOnFirstThread -Djava.awt.headless=true " />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/te-app" />
     <method v="2">
       <option name="Make" enabled="true" />


### PR DESCRIPTION
Fixes error in PR 708:  Inadvertently left `.run\Titanic's End.run.xml` file configured for Windows/Linux.