### PR TITLE
tweak(DotPolka): invert size, and increase the max size a bit

### DIFF
--- a/te-app/resources/shaders/dotpolka.fs
+++ b/te-app/resources/shaders/dotpolka.fs
@@ -265,7 +265,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
   vec2 uv = (fragCoord * 2. - iResolution.xy) / iResolution.y;
   vec2 uvPreTransform = uv;
 
-  uv *= iScale;
+  uv /= iScale;
 
   float beatMultiple = iSpeedDiscrete;
   float beat = fract(iBeatTime * beatMultiple);

--- a/te-app/src/main/java/titanicsend/pattern/cnk/DotPolka.java
+++ b/te-app/src/main/java/titanicsend/pattern/cnk/DotPolka.java
@@ -33,7 +33,7 @@ public class DotPolka extends GLShaderPattern {
 
   public DotPolka(LX lx) {
     super(lx, TEShaderView.ALL_POINTS);
-    controls.setRange(TEControlTag.SIZE, 8.0, 20.0, 1.0);
+    controls.setRange(TEControlTag.SIZE, 0.6, 0.05, 2.0);
     controls.setRange(TEControlTag.SPIN, 0.0, -0.125, 0.125); // Much gentler spin range
     controls.setRange(TEControlTag.LEVELREACTIVITY, 0.1, 0.0, 1.0);
     controls.setRange(TEControlTag.FREQREACTIVITY, 0.0, 0.0, 1.0);


### PR DESCRIPTION
For the sake of consistency, inverting the size parameter so smaller size is smaller in the shader.

Also bumping up the max size a bit, because it almost becomes a second type of pattern when its zoomed in super huge :) Lots of possibilities here.

https://github.com/user-attachments/assets/bd2ca3ac-4170-405b-a22d-e506601f7a16

