### PR TITLE
Use OSC message splitting without loop risk

### DIFF
--- a/osc-remapper/src/main/java/titanicsend/oscremapper/OscRemapperPlugin.java
+++ b/osc-remapper/src/main/java/titanicsend/oscremapper/OscRemapperPlugin.java
@@ -222,7 +222,7 @@ public class OscRemapperPlugin implements LXStudio.Plugin {
   private void startOscCapture() {
     try {
       // Add transmission listener to capture ALL outgoing OSC messages
-      lx.engine.osc.addTransmissionListener(this.transmissionListener);
+      lx.engine.osc.addMessageListener(this.transmissionListener);
       LOG.debug("OSC remapping started - listening to all transmitted OSC messages");
     } catch (Exception e) {
       LOG.error(e, "Failed to start OSC remapping");
@@ -233,7 +233,7 @@ public class OscRemapperPlugin implements LXStudio.Plugin {
   private void stopOscCapture() {
     try {
       // Remove transmission listener
-      lx.engine.osc.removeTransmissionListener(this.transmissionListener);
+      lx.engine.osc.removeMessageListener(this.transmissionListener);
       LOG.debug("OSC remapping stopped");
     } catch (Exception e) {
       LOG.error(e, "Failed to stop OSC remapping");

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 			break compatibility with the other 2 repos). Just a shortcut to avoid
 			re-compiling and vendorizing all 3 libraries.
 		-->
-		<temp.osc.lx.version>1.1.1-TE.5a.OSC-SNAPSHOT</temp.osc.lx.version>
+		<temp.osc.lx.version>1.1.1-TE.5a.GPU-SNAPSHOT</temp.osc.lx.version>
 
 		<!-- Project dependency versions -->
 		<gigglepixel.version>0.0.3</gigglepixel.version>


### PR DESCRIPTION
Made some changes to the LX injection point.  

- Infinite loop risk is avoided by merging new message variations *after* the split point, so they will not be re-processed.
- I ended up renaming `TransmissionListener` to `MessageListener`, because it's now happening early in the `sendMessage()` path rather than at transmission point.
- `MessageListener` callbacks can send a variation by calling `sendMessageVariant()`.  If they try to call sendMessage() an error will be thrown.
- Now supports all OSC message types (float, int, String)
- `sendMessage` and `sendMessageVariant` calls do not need try/catch blocks

You should be able to remove all the infinite loop checking being done in the `OscRemapper` module, and save some overhead.