### PR TITLE
fix(patternRack): use getMixerChannel instead of getMixerChannel in DmxPattern/etc

### DIFF
--- a/te-app/src/main/java/titanicsend/dmx/effect/DmxEffect.java
+++ b/te-app/src/main/java/titanicsend/dmx/effect/DmxEffect.java
@@ -32,7 +32,7 @@ public abstract class DmxEffect extends LXEffect {
    */
   @Override
   public LXLayeredComponent setBuffer(LXBuffer buffer) {
-    this.dmx = DmxEngine.get().getDmxModelBuffer(buffer, this.getChannel());
+    this.dmx = DmxEngine.get().getDmxModelBuffer(buffer, this.getPattern().getMixerChannel());
     return super.setBuffer(buffer);
   }
 

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DmxPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DmxPattern.java
@@ -42,7 +42,7 @@ public abstract class DmxPattern extends LXPattern {
    */
   @Override
   public LXLayeredComponent setBuffer(LXBuffer buffer) {
-    this.dmx = DmxEngine.get().getDmxModelBuffer(buffer, this.getChannel());
+    this.dmx = DmxEngine.get().getDmxModelBuffer(buffer, this.getMixerChannel());
     return super.setBuffer(buffer);
   }
 

--- a/te-app/src/main/java/titanicsend/pattern/jeff/EdgeSymmetry.java
+++ b/te-app/src/main/java/titanicsend/pattern/jeff/EdgeSymmetry.java
@@ -83,8 +83,8 @@ public class EdgeSymmetry extends TEPattern {
 
   public void run(double deltaMs) {
     int color = colorParam.getColor();
-    if (getChannel() != null) {
-      if (getChannel().blendMode.getObject().getClass().equals(MultiplyBlend.class)) {
+    if (getMixerChannel() != null) {
+      if (getMixerChannel().blendMode.getObject().getClass().equals(MultiplyBlend.class)) {
         // Operate in Mask mode
         setEdges(LXColor.BLACK);
         color = LXColor.WHITE;


### PR DESCRIPTION
## Context

> (why i was poking around with composite mode / racks)

We have a lot of effects on master channel that we'll want to control with the effects controller.

We also have a bunch of trigger-enabled "FX" patterns, useful for finger-drumming, that are on our FX channel (e.g. BassLightning, SpaceExplosion).

Previously, we'd keep this channel on our APC channel 8, and we'd need to switch over to it, select a specific pattern within the FX channel (e.g. BassLightning), even if we'd midi-mapped a trigger for BassLightning somewhere.

Instead, I'm thinking:
- FX channel always at 100%, on channel 9+ (off APC)
- all patterns in this channel are black until trigger hits
- Run either in composite mode (or maybe pattern rack? composite mode probably gets the job done for us, but it seems rack-adjacent so I was testing this out)

If we set it up this way, AFAIK, we could then MIDI-map triggers for each of these FX patterns, and finger drum them at will (without needing to bring up that channel and select a pattern before its trigger will actually affect the master channel output).

> (Feedback welcome on this approach!)

## Bug

Steps to repro:
- go to FX channel
- select top 5 patterns
- right click, "group to rack"
- see the following stack trace:

<img width="254" height="129" alt="Screen Shot 2025-08-10 at 8 02 27 PM" src="https://github.com/user-attachments/assets/75eaab07-969f-4d49-9657-9fb17798c743" />


```
[LX 2025/08/10 19:59:33] Unexpected error in device loop heronarts.lx.pattern.PatternRack: class heronarts.lx.pattern.PatternRack cannot be cast to class heronarts.lx.mixer.LXChannel (heronarts.lx.pattern.PatternRack and heronarts.lx.mixer.LXChannel are in unnamed module of loader 'app')
java.lang.ClassCastException: class heronarts.lx.pattern.PatternRack cannot be cast to class heronarts.lx.mixer.LXChannel (heronarts.lx.pattern.PatternRack and heronarts.lx.mixer.LXChannel are in unnamed module of loader 'app')
	at heronarts.lx.pattern.LXPattern.getChannel(LXPattern.java:417)
	at titanicsend.dmx.pattern.DmxPattern.setBuffer(DmxPattern.java:45)
	at heronarts.lx.mixer.LXPatternEngine.loop(LXPatternEngine.java:1058)
	at heronarts.lx.pattern.PatternRack.run(PatternRack.java:72)
	at heronarts.lx.pattern.LXPattern.onLoop(LXPattern.java:677)
	at heronarts.lx.LXLayeredComponent.loop(LXLayeredComponent.java:106)
	at heronarts.lx.LXDeviceComponent.loop(LXDeviceComponent.java:388)
	at heronarts.lx.mixer.LXPatternEngine.loop(LXPatternEngine.java:1060)
	at heronarts.lx.mixer.LXChannel.loop(LXChannel.java:462)
	at heronarts.lx.mixer.LXMixerEngine.loop(LXMixerEngine.java:1045)
	at heronarts.lx.LXEngine._run(LXEngine.java:1170)
	at heronarts.lx.LXEngine.run(LXEngine.java:1017)
```