### PR TITLE
Fix a few dual-registration patterns

### DIFF
--- a/te-app/resources/shaders/candy_flip.fs
+++ b/te-app/resources/shaders/candy_flip.fs
@@ -1,10 +1,7 @@
 // Candy Flip - dots cascade out from edge joints and cause
 // a scattering butterfly effect, moving from one to the next
 
-#pragma name "CandyFlip"
 #include <include/colorspace.fs>
-#pragma TEControl.LEVELREACTIVITY.Disable
-#pragma TEControl.FREQREACTIVITY.Disable
 
 float hash(vec2 p) {
     return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);

--- a/te-app/resources/shaders/face_melt.fs
+++ b/te-app/resources/shaders/face_melt.fs
@@ -1,11 +1,6 @@
 // FACE MELT - a smiley face pattern with two-tone color glitch animation best viewed in deep playa.
 //
 
-#pragma name "FaceMelt"
-
-#pragma TEControl.LEVELREACTIVITY.Disable
-#pragma TEControl.FREQREACTIVITY.Disable
-
 #include <include/colorspace.fs>
 
 const float PI = asin(1.) * 2.;

--- a/te-app/resources/shaders/happy_chibi.fs
+++ b/te-app/resources/shaders/happy_chibi.fs
@@ -1,10 +1,6 @@
 // Happy Chibi - bouncing kawaii smiley face with animated highlights
 // for the deep playa!!!
 
-#pragma name "HappyChibi"
-#pragma TEControl.LEVELREACTIVITY.Disable
-#pragma TEControl.FREQREACTIVITY.Disable
-
 #include <include/colorspace.fs>
 
 float hash(vec2 p) {

--- a/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
+++ b/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
@@ -154,6 +154,7 @@ public class CandyFlip extends TEPerformancePattern {
     controls.markUnused(controls.getLXControl(TEControlTag.ANGLE));
 
     addCommonControls();
+    addShader("candy_flip.fs");
   }
 
   private void triggerBurst(TEVertex vertex, int generation) {

--- a/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
+++ b/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.model.TEVertex;
-import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.TEShaderView;

--- a/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
+++ b/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import titanicsend.model.TEEdgeModel;
 import titanicsend.model.TEVertex;
 import titanicsend.pattern.TEPerformancePattern;
+import titanicsend.pattern.glengine.GLShaderPattern;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.yoffa.framework.TEShaderView;
 import titanicsend.util.TEColor;
@@ -26,7 +27,7 @@ import titanicsend.util.TEColor;
  * with burst and cascade mechanics
  */
 @LXCategory("Edge FG")
-public class CandyFlip extends TEPerformancePattern {
+public class CandyFlip extends GLShaderPattern {
 
   // Particle system parameters
   private static final int MAX_PARTICLES_PER_VERTEX = 8;
@@ -198,7 +199,7 @@ public class CandyFlip extends TEPerformancePattern {
   }
 
   @Override
-  protected void runTEAudioPattern(double deltaMs) {
+  public void runTEAudioPattern(double deltaMs) {
     currentTime += deltaMs * getSpeed();
 
     // Clear display


### PR DESCRIPTION
Addresses @zranger1's comment: https://github.com/titanicsend/LXStudio-TE/pull/724#discussion_r2274371806

Shaders with Java classes shouldn't include `#pragma` lines, including the ones that cause them to get registered as autoshaders.

Also incidentally fixes a bug in CandyFlip.