### PR TITLE
(WIP - please don't merge yet) Presets: rename 'open' to 'load', add option to 'merge'

### DIFF
--- a/te-app/src/main/java/titanicsend/preset/PresetEngine.java
+++ b/te-app/src/main/java/titanicsend/preset/PresetEngine.java
@@ -73,7 +73,7 @@ public class PresetEngine extends LXComponent {
     updateLibraryName();
   }
 
-  public void addLibrary(String path) {
+  public void mergeLibrary(String path) {
     this.currentLibrary.load(new File(path), false);
     updateLibraryName();
   }

--- a/te-app/src/main/java/titanicsend/preset/PresetEngine.java
+++ b/te-app/src/main/java/titanicsend/preset/PresetEngine.java
@@ -68,8 +68,13 @@ public class PresetEngine extends LXComponent {
     updateLibraryName();
   }
 
-  public void openLibrary(String path) {
-    this.currentLibrary.load(new File(path));
+  public void loadLibrary(String path) {
+    this.currentLibrary.load(new File(path), true);
+    updateLibraryName();
+  }
+
+  public void addLibrary(String path) {
+    this.currentLibrary.load(new File(path), false);
     updateLibraryName();
   }
 

--- a/te-app/src/main/java/titanicsend/preset/PresetEngine.java
+++ b/te-app/src/main/java/titanicsend/preset/PresetEngine.java
@@ -73,7 +73,7 @@ public class PresetEngine extends LXComponent {
     updateLibraryName();
   }
 
-  public void mergeLibrary(String path) {
+  public void importLibrary(String path) {
     this.currentLibrary.load(new File(path), false);
     updateLibraryName();
   }

--- a/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
+++ b/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
@@ -28,7 +28,7 @@ public class UIUserPresetManager extends UICollapsibleSection {
 
     PresetEngine engine = PresetEngine.get();
 
-    final float buttonWidth = (getContentWidth() - (2 * BUTTON_SPACING)) / 3;
+    final float buttonWidth = (getContentWidth() - (2 * BUTTON_SPACING)) / 4;
 
     final UILabel fileName =
         (UILabel)
@@ -56,7 +56,7 @@ public class UIUserPresetManager extends UICollapsibleSection {
                 .setBorderRounding(4)
                 .setDescription("Start an empty User Presets library"),
 
-            // Open
+            // Load
             new UIButton(0, 0, buttonWidth, 18) {
               @Override
               public void onClick() {
@@ -73,12 +73,37 @@ public class UIUserPresetManager extends UICollapsibleSection {
                             "User Presets File",
                             new String[] {"userPresets"},
                             engine.getLibrary().getFile().getPath(),
-                            engine::openLibrary));
+                            engine::loadLibrary));
               }
-            }.setLabel("Open")
+            }.setLabel("Load")
                 .setMomentary(true)
                 .setBorderRounding(4)
-                .setDescription("Open a User Presets library"),
+                .setDescription(
+                    "Load a User Presets library (Replacing previously-loaded library)"),
+
+            // Merge
+            new UIButton(0, 0, buttonWidth, 18) {
+              @Override
+              public void onClick() {
+                if (engine.getLibrary() == null) {
+                  LX.error("No user preset library found, can not save.");
+                  return;
+                }
+
+                lx.showConfirmDialog(
+                    "Merge User Presets file? New presets will be loaded alongside current library.",
+                    () ->
+                        lx.showOpenFileDialog(
+                            "Merge User Presets Library",
+                            "User Presets File",
+                            new String[] {"userPresets"},
+                            engine.getLibrary().getFile().getPath(),
+                            engine::loadLibrary));
+              }
+            }.setLabel("Merge")
+                .setMomentary(true)
+                .setBorderRounding(4)
+                .setDescription("Merge a User Presets library into the already-loaded library"),
 
             // Save
             new UIButton(64, 0, buttonWidth, 18) {

--- a/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
+++ b/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
@@ -81,7 +81,7 @@ public class UIUserPresetManager extends UICollapsibleSection {
                 .setDescription(
                     "Load a User Presets library (Replacing previously-loaded library)"),
 
-            // Merge
+            // Import
             new UIButton(0, 0, buttonWidth, 18) {
               @Override
               public void onClick() {
@@ -91,19 +91,19 @@ public class UIUserPresetManager extends UICollapsibleSection {
                 }
 
                 lx.showConfirmDialog(
-                    "Merge User Presets file? New presets will be loaded alongside current library.",
+                    "Import another User Presets file? Presets in the selected file will be added to the current loaded file.",
                     () ->
                         lx.showOpenFileDialog(
-                            "Merge User Presets Library",
+                            "Import User Presets Library",
                             "User Presets File",
                             new String[] {"userPresets"},
                             engine.getLibrary().getFile().getPath(),
-                            engine::mergeLibrary));
+                            engine::importLibrary));
               }
-            }.setLabel("Merge")
+            }.setLabel("Import")
                 .setMomentary(true)
                 .setBorderRounding(4)
-                .setDescription("Merge a User Presets library into the already-loaded library"),
+                .setDescription("Import a User Presets library into the already-loaded library"),
 
             // Save
             new UIButton(64, 0, buttonWidth, 18) {

--- a/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
+++ b/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
@@ -98,7 +98,7 @@ public class UIUserPresetManager extends UICollapsibleSection {
                             "User Presets File",
                             new String[] {"userPresets"},
                             engine.getLibrary().getFile().getPath(),
-                            engine::loadLibrary));
+                            engine::mergeLibrary));
               }
             }.setLabel("Merge")
                 .setMomentary(true)

--- a/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
@@ -186,7 +186,7 @@ public class UserPresetCollection implements LXSerializable {
   private boolean inLoad = false;
 
   public static final String KEY_CLASS = "clazz";
-  public static final String KEY_PRESETS = "presets";
+  private static final String KEY_PRESETS = "presets";
 
   @Override
   public void save(LX lx, JsonObject obj) {

--- a/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
@@ -35,6 +35,10 @@ public class UserPresetCollection implements LXSerializable {
     this.clazz = clazz;
   }
 
+  public String getClazz() {
+    return clazz;
+  }
+
   public UserPreset addPreset() {
     return addPreset(null);
   }
@@ -186,7 +190,7 @@ public class UserPresetCollection implements LXSerializable {
   private boolean inLoad = false;
 
   public static final String KEY_CLASS = "clazz";
-  private static final String KEY_PRESETS = "presets";
+  public static final String KEY_PRESETS = "presets";
 
   @Override
   public void save(LX lx, JsonObject obj) {
@@ -209,7 +213,8 @@ public class UserPresetCollection implements LXSerializable {
     }
   }
 
-  private void loadPreset(JsonObject presetObj) {
+  // NOTE(look): making this package-protected
+  void loadPreset(JsonObject presetObj) {
     UserPreset preset = new UserPreset(this.lx, this.clazz);
     preset.load(this.lx, presetObj);
 

--- a/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetCollection.java
@@ -35,10 +35,6 @@ public class UserPresetCollection implements LXSerializable {
     this.clazz = clazz;
   }
 
-  public String getClazz() {
-    return clazz;
-  }
-
   public UserPreset addPreset() {
     return addPreset(null);
   }
@@ -213,8 +209,7 @@ public class UserPresetCollection implements LXSerializable {
     }
   }
 
-  // NOTE(look): making this package-protected
-  void loadPreset(JsonObject presetObj) {
+  private void loadPreset(JsonObject presetObj) {
     UserPreset preset = new UserPreset(this.lx, this.clazz);
     preset.load(this.lx, presetObj);
 

--- a/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
@@ -112,7 +112,7 @@ public class UserPresetLibrary implements LXSerializable {
       if (removeExisting) {
         removeAll();
       }
-      // For both "Merge" and "Load", add all presets from file to collections
+      // For both "Import" and "Load", add all presets from file to collections
       load(this.lx, obj);
       this.file = file;
     } catch (FileNotFoundException ex) {

--- a/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
@@ -1,7 +1,5 @@
 package titanicsend.preset;
 
-import static titanicsend.preset.UserPresetCollection.KEY_CLASS;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -110,17 +108,11 @@ public class UserPresetLibrary implements LXSerializable {
     TE.log("Loading user presets: %s", file.getPath());
     try (FileReader fr = new FileReader(file)) {
       JsonObject obj = new Gson().fromJson(fr, JsonObject.class);
-      //      if (removeExisting) {
-      //        TE.log("LOAD/REPLACE user presets from file: %s", file.getPath());
-      //        removeAll();
-      //        load(this.lx, obj);
-      //      } else {
-      //        TE.log("MERGE user presets from file: %s", file.getPath());
-      //        merge(obj);
-      //      }
+      // For "Load", clear the patterns first
       if (removeExisting) {
         removeAll();
       }
+      // For both "Merge" and "Load", add all presets from file to collections
       load(this.lx, obj);
       this.file = file;
     } catch (FileNotFoundException ex) {
@@ -143,12 +135,12 @@ public class UserPresetLibrary implements LXSerializable {
     JsonArray collectionsArray = obj.getAsJsonArray(KEY_COLLECTIONS);
     for (JsonElement patternElement : collectionsArray) {
       JsonObject patternObj = (JsonObject) patternElement;
-      loadCollection(patternObj, -1);
+      loadCollection(patternObj);
     }
   }
 
-  private void loadCollection(JsonObject patternObj, int index) {
-    String clazz = patternObj.get(KEY_CLASS).getAsString();
+  private void loadCollection(JsonObject patternObj) {
+    String clazz = patternObj.get(UserPresetCollection.KEY_CLASS).getAsString();
     // Find existing or create new
     // Existing are referenced by UI elements so we won't throw them away and recreate them.
     UserPresetCollection c = get(clazz);

--- a/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
@@ -101,8 +101,15 @@ public class UserPresetLibrary implements LXSerializable {
   }
 
   public void load(File file) {
+    load(file, true);
+  }
+
+  public void load(File file, boolean removeExisting) {
     TE.log("Loading user presets: %s", file.getPath());
     try (FileReader fr = new FileReader(file)) {
+      if (removeExisting) {
+        removeAll();
+      }
       load(this.lx, new Gson().fromJson(fr, JsonObject.class));
       this.file = file;
     } catch (FileNotFoundException ex) {
@@ -121,7 +128,6 @@ public class UserPresetLibrary implements LXSerializable {
 
   @Override
   public void load(LX lx, JsonObject obj) {
-    removeAll();
 
     // Load collections
     JsonArray collectionsArray = obj.getAsJsonArray(KEY_COLLECTIONS);

--- a/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
@@ -1,7 +1,6 @@
 package titanicsend.preset;
 
 import static titanicsend.preset.UserPresetCollection.KEY_CLASS;
-import static titanicsend.preset.UserPresetCollection.KEY_PRESETS;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -111,12 +110,18 @@ public class UserPresetLibrary implements LXSerializable {
     TE.log("Loading user presets: %s", file.getPath());
     try (FileReader fr = new FileReader(file)) {
       JsonObject obj = new Gson().fromJson(fr, JsonObject.class);
+      //      if (removeExisting) {
+      //        TE.log("LOAD/REPLACE user presets from file: %s", file.getPath());
+      //        removeAll();
+      //        load(this.lx, obj);
+      //      } else {
+      //        TE.log("MERGE user presets from file: %s", file.getPath());
+      //        merge(obj);
+      //      }
       if (removeExisting) {
         removeAll();
-        load(this.lx, obj);
-      } else {
-        merge(obj);
       }
+      load(this.lx, obj);
       this.file = file;
     } catch (FileNotFoundException ex) {
       TE.error("User preset library not found: %s", file.getPath());
@@ -148,28 +153,5 @@ public class UserPresetLibrary implements LXSerializable {
     // Existing are referenced by UI elements so we won't throw them away and recreate them.
     UserPresetCollection c = get(clazz);
     c.load(this.lx, patternObj);
-  }
-
-  public void merge(JsonObject obj) {
-    JsonArray collectionsArray = obj.getAsJsonArray(KEY_COLLECTIONS);
-    for (JsonElement patternElement : collectionsArray) {
-      JsonObject patternObj = (JsonObject) patternElement;
-      String clazz = patternObj.get(KEY_CLASS).getAsString();
-
-      // Create (OR get existing) collection for a pattern class
-      UserPresetCollection collection = get(clazz);
-
-      if (!collection.getClazz().equals(clazz)) {
-        throw new IllegalArgumentException("don't match: " + clazz);
-      }
-
-      if (obj.has(KEY_PRESETS)) {
-        JsonArray presetsArray = obj.getAsJsonArray(KEY_PRESETS);
-        for (JsonElement presetElement : presetsArray) {
-          JsonObject presetObj = (JsonObject) presetElement;
-          collection.loadPreset(presetObj);
-        }
-      }
-    }
   }
 }

--- a/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
+++ b/te-app/src/main/java/titanicsend/preset/UserPresetLibrary.java
@@ -114,7 +114,10 @@ public class UserPresetLibrary implements LXSerializable {
       }
       // For both "Import" and "Load", add all presets from file to collections
       load(this.lx, obj);
-      this.file = file;
+      // Do not change the current library file if this was an import
+      if (removeExisting) {
+        this.file = file;
+      }
     } catch (FileNotFoundException ex) {
       TE.error("User preset library not found: %s", file.getPath());
     } catch (IOException iox) {


### PR DESCRIPTION
- "Load": open new library and replace existing library entirely (renamed from "Open")
- "Merge": open library and add all the presets to what's currently loaded

So if we have user-specific preset files we want to integrate, you can load BM24.userPresets, merge Look.userPresets, save BM24.userPresets

<img width="199" height="94" alt="image" src="https://github.com/user-attachments/assets/d76f8de8-0287-4dcc-83be-e13b97fec62c" />
