### PR TITLE
Fix Brightness Control for All Shaders

### DIFF
--- a/te-app/resources/shaders/framework/template.fs
+++ b/te-app/resources/shaders/framework/template.fs
@@ -128,6 +128,8 @@ vec4 _blendFix(vec4 col) {
         // color will become the brightest possible version of itself.
         col.rgb = col.rgb / col.a;
     }
+    // and use the setting of the pattern's brightness control to determine the final brightness
+    col.a *= iBrightness;
     return col;
 }
 
@@ -157,12 +159,6 @@ void main() {
     // the 2023 pre-EDC blending behavior. Define TE_NOPOSTPROCESSING if you
     // want the unmodified shader output.
     #ifndef TE_NOPOSTPROCESSING
-    #ifndef TE_NOALPHAFIX
     finalColor = _blendFix(finalColor);
-    #else
-    // Old EDC blending - force black pixels to full transparency, otherwise
-    // use shader provided alpha
-    finalColor.a = ((finalColor.r + finalColor.g + finalColor.b) == 0.0) ? 0.0 : finalColor.a;
-    #endif
     #endif
 }

--- a/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -212,12 +212,30 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
    *     <p>At present, the brightness control lets you dim the current color, but if you want to
    *     brighten it, you have to do that with the channel fader or the color control.
    */
-  public int calcColor() {
+  public int calcColor(boolean setBrightness) {
     if (isStaleColor) {
-      _calcColor = TEColor.setBrightness(controls.color.calcColor(), (float) getBrightness());
+      _calcColor = controls.color.calcColor();
       isStaleColor = false;
     }
-    return _calcColor;
+    return (setBrightness) ? TEColor.setBrightness(_calcColor, (float) getBrightness()) : _calcColor;
+  }
+
+  /**
+   * For patterns that consume two solid colors, use this method to retrieve the 2nd color. Returns
+   * a color offset in position from the first color.
+   *
+   * @return
+   */
+  public int calcColor2(boolean setBrightness) {
+    if (isStaleColor) {
+      _calcColor2 = controls.color.calcColor();
+      isStaleColor = false;
+    }
+    return (setBrightness) ? TEColor.setBrightness(_calcColor2, (float) getBrightness()) : _calcColor2;
+  }
+
+  public int calcColor() {
+    return calcColor(true);
   }
 
   /**
@@ -227,24 +245,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
    * @return
    */
   public int calcColor2() {
-    if (isStaleColor2) {
-      _calcColor2 = TEColor.setBrightness(controls.color.calcColor2(), (float) getBrightness());
-      isStaleColor2 = false;
-    }
-    return _calcColor2;
+    return calcColor2(true);
   }
 
-  /**
-   * Gets the current color as set in the color control, without adjusting for brightness. This is
-   * used by the OpenGL renderer, which has a unified mechanism for handling brightness.
-   */
-  public int getColor() {
-    if (isStaleColorBase) {
-      _getColor = controls.color.calcColor();
-      isStaleColorBase = false;
-    }
-    return _getColor;
-  }
 
   public int getGradientColor(float lerp) {
     return TEColor.setBrightness(controls.color.getGradientColor(lerp), (float) getBrightness());

--- a/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPerformancePattern.java
@@ -217,7 +217,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
       _calcColor = controls.color.calcColor();
       isStaleColor = false;
     }
-    return (setBrightness) ? TEColor.setBrightness(_calcColor, (float) getBrightness()) : _calcColor;
+    return (setBrightness)
+        ? TEColor.setBrightness(_calcColor, (float) getBrightness())
+        : _calcColor;
   }
 
   /**
@@ -231,7 +233,9 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
       _calcColor2 = controls.color.calcColor();
       isStaleColor = false;
     }
-    return (setBrightness) ? TEColor.setBrightness(_calcColor2, (float) getBrightness()) : _calcColor2;
+    return (setBrightness)
+        ? TEColor.setBrightness(_calcColor2, (float) getBrightness())
+        : _calcColor2;
   }
 
   public int calcColor() {
@@ -247,7 +251,6 @@ public abstract class TEPerformancePattern extends TEAudioPattern {
   public int calcColor2() {
     return calcColor2(true);
   }
-
 
   public int getGradientColor(float lerp) {
     return TEColor.setBrightness(controls.color.getGradientColor(lerp), (float) getBrightness());

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -240,7 +240,8 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
           // the
           // previous shader
           uniforms.iDst.setValue(currentShaderDst);
-          uniforms.iBrightness.setValue(1.0f);  // TODO: provide control for this or use effect level?
+          uniforms.iBrightness.setValue(
+              1.0f); // TODO: provide control for this or use effect level?
           uniforms.iTime.setValue((float) getTime());
 
           // get current primary and secondary colors

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -47,7 +47,7 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
 
   private static class TEEffectUniforms {
     private Uniform.Sampler2D iDst;
-    private Uniform.Float1 level; // Is this universal for LXEffects?
+    private Uniform.Float1 iBrightness;
 
     private Uniform.Float1 iTime;
     private Uniform.Float3 iColorRGB;
@@ -218,6 +218,7 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
 
     // TODO: confirm shader template for TE Effect matches these uniforms:
     this.uniforms.iDst = s.getUniformSampler2D("iDst");
+    this.uniforms.iBrightness = s.getUniformFloat1("iBrightness");
     this.uniforms.iTime = s.getUniformFloat1("iTime");
     this.uniforms.iColorRGB = s.getUniformFloat3("iColorRGB");
     this.uniforms.iColorHSB = s.getUniformFloat3("iColorHSB");
@@ -239,7 +240,7 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
           // the
           // previous shader
           uniforms.iDst.setValue(currentShaderDst);
-
+          uniforms.iBrightness.setValue(1.0f);  // TODO: provide control for this or use effect level?
           uniforms.iTime.setValue((float) getTime());
 
           // get current primary and secondary colors

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -137,7 +137,7 @@ public class GLShaderPattern extends TEPerformancePattern implements GpuDevice {
     this.uniforms.iTime.setValue((float) getTime());
 
     // color-related uniforms
-    int col = calcColor();
+    int col = calcColor(false);
     this.uniforms.iColorRGB.setValue(
         (float) (0xff & LXColor.red(col)) / 255f,
         (float) (0xff & LXColor.green(col)) / 255f,
@@ -145,7 +145,7 @@ public class GLShaderPattern extends TEPerformancePattern implements GpuDevice {
     this.uniforms.iColorHSB.setValue(
         LXColor.h(col) / 360f, LXColor.s(col) / 100f, LXColor.b(col) / 100f);
 
-    col = calcColor2();
+    col = calcColor2(false);
     this.uniforms.iColor2RGB.setValue(
         (float) (0xff & LXColor.red(col)) / 255f,
         (float) (0xff & LXColor.green(col)) / 255f,


### PR DESCRIPTION
- changed the calcColor() functions in TEPerformancePattern so setting brightness is optional.  This way, without changing the calling pattern, Java patterns get what they need, and so does OpenGL.
- add iBrightness support to effects.  It allows us to unify the framework and we'll eventually want to use it in effects.
- removed obsolete, unused 2023 EDC blending behavior code in framework.
- And now there is One True Place for final brightness adjustment in shaders!