### PR TITLE
Smooth Happy Chibi speed changes

### DIFF
--- a/te-app/resources/shaders/happy_chibi.fs
+++ b/te-app/resources/shaders/happy_chibi.fs
@@ -104,7 +104,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     vec2 uv = fragCoord.xy / iResolution.xy;
     uv = (uv - 0.5) * vec2(iResolution.x / iResolution.y, 1.0) + 0.5;
 
-    float t = iTime * iSpeed;
+    float t = iTime;
     
     vec3 totalColor = vec3(0.0);
     float totalAlpha = 0.0;

--- a/te-app/src/main/java/titanicsend/pattern/selina/HappyChibi.java
+++ b/te-app/src/main/java/titanicsend/pattern/selina/HappyChibi.java
@@ -23,7 +23,7 @@ public class HappyChibi extends GLShaderPattern {
   public HappyChibi(LX lx) {
     super(lx, TEShaderView.DOUBLE_LARGE);
 
-    controls.setRange(TEControlTag.SPEED, 1.0, 0.1, 3.0);
+    controls.setRange(TEControlTag.SPEED, 1.0, 0.01, 6.0);
     controls.setRange(TEControlTag.SIZE, 1.0, 0.5, 2.0);
     controls.setRange(TEControlTag.QUANTITY, 15, 1, 40);
 


### PR DESCRIPTION
Drive-by fix for Happy Chibi: prevent speed changes from making the animation jump.

Use just `iTime` instead of `iSpeed` and update control uniforms to match. This should have a similar speed range to the original. 