### PR TITLE
Add AutoSave option for user presets

### DIFF
--- a/te-app/src/main/java/titanicsend/preset/PresetEngine.java
+++ b/te-app/src/main/java/titanicsend/preset/PresetEngine.java
@@ -9,6 +9,7 @@ import heronarts.lx.LXModulatorComponent;
 import heronarts.lx.LXPresetComponent;
 import heronarts.lx.mixer.LXBus;
 import heronarts.lx.modulation.LXModulationContainer;
+import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.StringParameter;
@@ -36,9 +37,15 @@ public class PresetEngine extends LXComponent {
 
   public final StringParameter libraryName = new StringParameter("Library", "");
 
+  public final BooleanParameter autoSave =
+      new BooleanParameter("Auto Save User Presets", true)
+          .setDescription("Auto save library after a preset is Added or Updated");
+
   public PresetEngine(LX lx) {
     super(lx, "PresetEngine");
     current = this;
+
+    addParameter("autosave", this.autoSave);
 
     this.currentLibrary = new UserPresetLibrary(lx);
     updateLibraryName();
@@ -75,7 +82,18 @@ public class PresetEngine extends LXComponent {
 
   public void importLibrary(String path) {
     this.currentLibrary.load(new File(path), false);
-    updateLibraryName();
+    triggerAutoSave();
+  }
+
+  public void triggerAutoSave() {
+    if (this.autoSave.isOn()) {
+      LX.log("Autosaving user presets to " + this.currentLibrary.getFile().getName());
+      saveLibrary();
+    }
+  }
+
+  public void saveLibrary() {
+    this.currentLibrary.save(this.currentLibrary.getFile());
   }
 
   public void saveLibrary(String path) {

--- a/te-app/src/main/java/titanicsend/preset/UIUserPresetList.java
+++ b/te-app/src/main/java/titanicsend/preset/UIUserPresetList.java
@@ -102,6 +102,7 @@ public class UIUserPresetList extends UIItemList.ScrollList {
    */
   public UserPreset addPreset() {
     UserPreset preset = this.collection.addPreset(component);
+    PresetEngine.get().triggerAutoSave();
     // Listener will have added the listItem
     setActiveItem(this.presetToItem.get(preset));
     return preset;
@@ -110,6 +111,7 @@ public class UIUserPresetList extends UIItemList.ScrollList {
   public UIUserPresetList updateActive() {
     if (this.activeItem != null) {
       this.activeItem.preset.capture(this.component);
+      PresetEngine.get().triggerAutoSave();
     }
     return this;
   }
@@ -118,6 +120,7 @@ public class UIUserPresetList extends UIItemList.ScrollList {
     PresetItem item = (PresetItem) this.getFocusedItem();
     if (item != null) {
       collection.removePreset(item.preset);
+      PresetEngine.get().triggerAutoSave();
     }
     return this;
   }
@@ -166,17 +169,20 @@ public class UIUserPresetList extends UIItemList.ScrollList {
     @Override
     public void onRename(String label) {
       getLX().command.perform(new LXCommand.Parameter.SetString(this.preset.label, label));
+      PresetEngine.get().triggerAutoSave();
     }
 
     @Override
     public void onReorder(int index) {
       collection.movePreset(preset, index);
+      PresetEngine.get().triggerAutoSave();
     }
 
     @Override
     public void onDelete() {
       if (isDeleteEnabled) {
         collection.removePreset(preset);
+        PresetEngine.get().triggerAutoSave();
       }
     }
 

--- a/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
+++ b/te-app/src/main/java/titanicsend/preset/UIUserPresetManager.java
@@ -122,6 +122,17 @@ public class UIUserPresetManager extends UICollapsibleSection {
                 .setDescription("Save User Presets Library"))
         .addToContainer(this);
 
+    // Autosave
+    newHorizontalContainer(
+            14,
+            4,
+            new UIButton.Toggle(engine.autoSave),
+            new UILabel(getContentWidth() - 18, engine.autoSave.getLabel())
+                .setTextAlignment(VGraphics.Align.LEFT, VGraphics.Align.MIDDLE)
+                .setFont(ui.theme.getControlFont()))
+        .setDescription(engine.autoSave.getDescription())
+        .addToContainer(this);
+
     addListener(
         engine.libraryName,
         (p) -> {


### PR DESCRIPTION
Autosave option for User Presets:

<img width="187" height="90" alt="image" src="https://github.com/user-attachments/assets/b7b1b5cb-1a69-48cb-a25b-00e11af7761c" />

When enabled, autosaves occur after:
- Add preset
- Update preset
- Remove preset (or backspace delete)
- Rename preset
- Import userPresets library