### PR TITLE
tweak(RhythmicStatic): use wow2 for color mix

### DIFF
--- a/te-app/resources/shaders/rhythm_static.fs
+++ b/te-app/resources/shaders/rhythm_static.fs
@@ -74,7 +74,7 @@ void mainImage( out vec4 fragColor, in vec2 fragCoord ) {
     }
 
     // interpolate random color from current palette
-    vec3 color = getGradientColor(fract(rVec.x + rVec.y));
+    vec3 color = mix(iColorRGB, getGradientColor(fract(rVec.x + rVec.y)), iWow2);
 
     // threshold values by iQuantity, gamma adjust, and flash the whole thing to the beat
     // with depth controlled by WOW1.

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/config/ShaderPanelsPatternConfig.java
@@ -75,8 +75,6 @@ public class ShaderPanelsPatternConfig {
           .setUnits(TEControlTag.SIZE, LXParameter.Units.INTEGER);
       controls.setRange(TEControlTag.QUANTITY, 0.25, 0.02, 1); // number of layers
 
-      controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
-
       addShader("rhythm_static.fs");
     }
   }


### PR DESCRIPTION
I thought it'd be nice to expose option for gradient lerp vs. single color, so we can stem-map the color mix and pop from monochrome to gradient-lerp.