### PR TITLE
MiniLab3 Part 6

### DIFF
--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -27,6 +27,10 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
 
   private static GlobalEffectManager instance;
 
+  public static GlobalEffectManager get() {
+    return instance;
+  }
+
   private final ObservableList<GlobalEffect<? extends LXEffect>> mutableSlots =
       new ObservableList<>();
   public final ObservableList<GlobalEffect<? extends LXEffect>> slots =
@@ -40,22 +44,13 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
 
   public GlobalEffectManager(LX lx) {
     super(lx, "effectManager");
-    GlobalEffectManager.instance = this;
+    instance = this;
 
     allocateEffectSlots();
 
     // When effects are added / removed / moved on Master Bus, listen and update
     this.lx.engine.mixer.masterBus.addListener(this.masterBusListener);
     refresh();
-  }
-
-  public static GlobalEffectManager get(LX lx) {
-    if (instance == null) {
-      // NOTE: making this function require LX so I can make the singleton never return null...
-      // maybe there's a better way to accomplish that?
-      instance = new GlobalEffectManager(lx);
-    }
-    return instance;
   }
 
   public void allocateSlot(GlobalEffect<? extends LXEffect> effect) {

--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -45,7 +45,7 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
     allocateEffectSlots();
 
     // When effects are added / removed / moved on Master Bus, listen and update
-    this.lx.engine.mixer.masterBus.addListener(this);
+    this.lx.engine.mixer.masterBus.addListener(this.masterBusListener);
     refresh();
   }
 
@@ -192,24 +192,27 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
         });
   }
 
-  @Override
-  public void effectAdded(LXBus channel, LXEffect effect) {
-    // If this effect matches one of our slots, we still need to check whether it is the first
-    // instance or secondary instance in the master effects. To keep things simple we can
-    // just refresh our slots every time there's a change.
-    refresh();
-  }
+  private final LXBus.Listener masterBusListener =
+      new LXBus.Listener() {
+        @Override
+        public void effectAdded(LXBus channel, LXEffect effect) {
+          // If this effect matches one of our slots, we still need to check whether it is the first
+          // instance or secondary instance in the master effects. To keep things simple we can
+          // just refresh our slots every time there's a change.
+          refresh();
+        }
 
-  @Override
-  public void effectRemoved(LXBus channel, LXEffect effect) {
-    // TODO: this isn't actually removing a missing effect from 'slots'.
-    refresh();
-  }
+        @Override
+        public void effectRemoved(LXBus channel, LXEffect effect) {
+          // TODO: this isn't actually removing a missing effect from 'slots'.
+          refresh();
+        }
 
-  @Override
-  public void effectMoved(LXBus channel, LXEffect effect) {
-    refresh();
-  }
+        @Override
+        public void effectMoved(LXBus channel, LXEffect effect) {
+          refresh();
+        }
+      };
 
   /** Refresh all slots */
   private void refresh() {
@@ -277,7 +280,7 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
 
   @Override
   public void dispose() {
-    this.lx.engine.mixer.masterBus.removeListener(this);
+    this.lx.engine.mixer.masterBus.removeListener(this.masterBusListener);
     for (GlobalEffect<? extends LXEffect> globalEffect : slots) {
       if (globalEffect != null) {
         globalEffect.dispose();

--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -199,7 +199,6 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
 
         @Override
         public void effectRemoved(LXBus channel, LXEffect effect) {
-          // TODO: this isn't actually removing a missing effect from 'slots'.
           refresh();
         }
 

--- a/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/GlobalEffectManager.java
@@ -11,8 +11,6 @@ import heronarts.lx.osc.LXOscComponent;
 import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.TriggerParameter;
 import heronarts.lx.utils.ObservableList;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 import titanicsend.effect.DistortEffect;
 import titanicsend.effect.ExplodeEffect;
@@ -35,12 +33,6 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
       new ObservableList<>();
   public final ObservableList<GlobalEffect<? extends LXEffect>> slots =
       mutableSlots.asUnmodifiableList();
-
-  public interface Listener {
-    void globalEffectStateUpdated(int slotIndex);
-  }
-
-  private final List<Listener> listeners = new ArrayList<>();
 
   public GlobalEffectManager(LX lx) {
     super(lx, "effectManager");
@@ -221,39 +213,15 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
       for (LXEffect effect : this.lx.engine.mixer.masterBus.effects) {
         if (globalEffect.matches(effect)) {
           // This will quick return if effect is already registered to the slot.
-          globalEffect.registerEffect(effect, this);
-          // Notify listeners of a state change.
-          this.effectStateUpdated(slots.indexOf(globalEffect));
+          globalEffect.setEffect(effect);
           found = true;
           break;
         }
       }
       if (!found) {
-        globalEffect.registerEffect(null, this);
+        globalEffect.setEffect(null);
       }
     }
-  }
-
-  public void effectStateUpdated(GlobalEffect<? extends LXEffect> globalEffect) {
-    int slotIndex = slots.indexOf(globalEffect);
-    if (slotIndex < 0) {
-      throw new IllegalArgumentException("Slot not found for " + globalEffect.getName());
-    }
-    effectStateUpdated(slotIndex);
-  }
-
-  public void effectStateUpdated(int slotIndex) {
-    for (Listener listener : listeners) {
-      listener.globalEffectStateUpdated(slotIndex);
-    }
-  }
-
-  public void addListener(Listener listener) {
-    listeners.add(listener);
-  }
-
-  public void removeListener(Listener listener) {
-    listeners.remove(listener);
   }
 
   public void debugStates() {
@@ -280,6 +248,7 @@ public class GlobalEffectManager extends LXComponent implements LXOscComponent, 
         globalEffect.dispose();
       }
     }
+    this.mutableSlots.clear();
     super.dispose();
   }
 }

--- a/te-app/src/main/java/titanicsend/app/effectmgr/Slot.java
+++ b/te-app/src/main/java/titanicsend/app/effectmgr/Slot.java
@@ -15,7 +15,7 @@ import java.util.Objects;
  * A translation layer between the GlobalEffectManager and an LXEffect instance. This will be
  * subclassed for every LXEffect type that can be used as a global effect.
  */
-public abstract class GlobalEffect<T extends LXEffect> {
+public abstract class Slot<T extends LXEffect> {
 
   public enum State {
     EMPTY, // Slot has been allocated, but no matching LXEffect exists in the current project
@@ -28,7 +28,7 @@ public abstract class GlobalEffect<T extends LXEffect> {
   private State state = State.EMPTY;
 
   public interface Listener {
-    void stateChanged(GlobalEffect globalEffect, State state);
+    void stateChanged(Slot slot, State state);
   }
 
   private final List<Listener> listeners = new ArrayList<>();
@@ -40,7 +40,7 @@ public abstract class GlobalEffect<T extends LXEffect> {
   public T effect;
 
   @SuppressWarnings("unchecked")
-  public GlobalEffect() {
+  public Slot() {
     // Extract the generic type parameter (T) of the subclass
     Type superType = getClass().getGenericSuperclass();
     if (superType instanceof ParameterizedType pType) {
@@ -126,7 +126,7 @@ public abstract class GlobalEffect<T extends LXEffect> {
       throw new IllegalArgumentException(
           "Effect instance "
               + effect.getLabel()
-              + " does not match GlobalEffect type "
+              + " does not match Slot type "
               + this.type.getName());
     }
 
@@ -187,7 +187,7 @@ public abstract class GlobalEffect<T extends LXEffect> {
 
   // Listeners
 
-  public GlobalEffect<T> addListener(Listener listener) {
+  public Slot<T> addListener(Listener listener) {
     Objects.requireNonNull(listener, "May not add null Listener");
     if (this.listeners.contains(listener)) {
       throw new IllegalStateException("Cannot add duplicate Listener: " + listener);
@@ -196,7 +196,7 @@ public abstract class GlobalEffect<T extends LXEffect> {
     return this;
   }
 
-  public GlobalEffect<T> removeListener(Listener listener) {
+  public Slot<T> removeListener(Listener listener) {
     if (!this.listeners.contains(listener)) {
       throw new IllegalStateException("Cannot remove non-existent Listener: " + listener);
     }

--- a/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
+++ b/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
@@ -243,7 +243,7 @@ public class EffectsMiniLab3 extends LXMidiSurface
     }
   }
 
-  private GlobalEffectManager effectManager;
+  private final GlobalEffectManager effectManager;
   private ObservableList.Listener<GlobalEffect<? extends LXEffect>> effectListener;
   private boolean isRegistered = false;
   private boolean shiftOn = false;
@@ -253,6 +253,7 @@ public class EffectsMiniLab3 extends LXMidiSurface
 
   public EffectsMiniLab3(LX lx, LXMidiInput input, LXMidiOutput output) {
     super(lx, input, output);
+    this.effectManager = GlobalEffectManager.get();
   }
 
   // Connection
@@ -283,9 +284,7 @@ public class EffectsMiniLab3 extends LXMidiSurface
 
   private void register() {
     this.isRegistered = true;
-    this.effectManager = null;
     this.effectListener = null;
-    this.effectManager = GlobalEffectManager.get(this.lx);
 
     List<GlobalEffect<? extends LXEffect>> slots = effectManager.slots;
 


### PR DESCRIPTION
Stacked PR, merge #748 first.

Cleans up the handling of State changes and notifications.  Shutdown errors are resolved.

Bold move: refactored `GlobalEffect` to `Slot`.  It is really a placeholder for an effect, not an actual effect.  `Slot` feels cleaner to read and helps distinguish between the location and the contents.