### PR TITLE
Look/minilab3 part7

### DIFF
--- a/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
+++ b/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
@@ -262,7 +262,11 @@ public class EffectsMiniLab3 extends LXMidiSurface implements LXMidiSurface.Bidi
   protected void onEnable(boolean on) {
     if (on) {
       register();
-      initialize();
+      try {
+        initialize();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     } else {
       if (this.isRegistered) {
         unregister();
@@ -273,12 +277,19 @@ public class EffectsMiniLab3 extends LXMidiSurface implements LXMidiSurface.Bidi
   @Override
   protected void onReconnect() {
     if (this.enabled.isOn()) {
-      initialize();
+      try {
+        initialize();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 
-  private void initialize() {
+  private void initialize() throws InterruptedException {
     sendModeDAW();
+    Thread.sleep(3);
+    sendBank(this.isBankA);
+    Thread.sleep(3);
     sendPadColors();
   }
 
@@ -696,6 +707,9 @@ public class EffectsMiniLab3 extends LXMidiSurface implements LXMidiSurface.Bidi
     // echo if we set it with a sysex?
     verbose("Received Bank: " + (isBankA ? "A" : "B"));
     this.isBankA = isBankA;
+    // sometimes upon reconnect, buttons go all white but we do get a sysex for bank received -
+    // use this to send pad colors to stay consistent
+    sendPadColors();
   }
 
   // Receive Logical Inputs (mapped from physical)

--- a/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
+++ b/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
@@ -877,6 +877,31 @@ public class EffectsMiniLab3 extends LXMidiSurface implements LXMidiSurface.Bidi
 
   private void sendBank(byte bank) {
     // TODO: set the bank with sysex
+    // NOTE(look): not sure if working - i used the protocols from bank received here...
+    byte[] sysex = new byte[13];
+    applySysexHeader(sysex);
+    sysex[7] = 0x02;
+    sysex[8] = 0x00;
+    sysex[9] = 0x40;
+    sysex[10] = 0x03;
+    sysex[11] = bank;
+    //    sysex[10] = 0x63;
+    //    sysex[11] = bank ? 0x01 : 0x02;
+    sysex[12] = END_SYSEX;
+    sendSysex(sysex);
+
+    /*
+      private void handleSysExData(String sysEx) {
+    switch (sysEx) {
+      case "f000206b7f420200406301f7":
+      case "f000206b7f420200400300f7":
+        this.toBankMode(PadBank.BANK_A);
+        break;
+      case "f000206b7f420200406302f7":
+      case "f000206b7f420200400301f7":
+        this.toBankMode(PadBank.BANK_B);
+        break;
+     */
   }
 
   // Send Pad Colors

--- a/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
+++ b/te-app/src/main/java/titanicsend/lx/EffectsMiniLab3.java
@@ -785,9 +785,7 @@ public class EffectsMiniLab3 extends LXMidiSurface implements LXMidiSurface.Bidi
     if (effectParam == null) {
       return;
     }
-    float normalizedValue = value / 127f;
-    // TODO: ensure all effects have range 0-1? or handle normalization some other way?
-    effectParam.setValue(normalizedValue);
+    effectParam.setNormalized(value / 127f);
   }
 
   /** Set the value of a global parameter */


### PR DESCRIPTION
fix normalized param ranges, and support unplugging and replugging the controller and having it return to the correct pad colors for the current bank (by responding to bank received).

Tried to proactively set bank, but couldnt easily find that in bitwig classes