### PR TITLE
Quantized Random Strobe

### DIFF
--- a/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/RandomStrobeEffect.java
@@ -44,6 +44,8 @@ import titanicsend.model.TEPanelModel;
 @LXCategory("Titanics End")
 public class RandomStrobeEffect extends TEEffect implements LX.Listener {
 
+  private static final String TAG_MOTHERSHIP_WINDOW = "window";
+
   private abstract class Element {
     protected double offset;
 
@@ -83,6 +85,19 @@ public class RandomStrobeEffect extends TEEffect implements LX.Listener {
     @Override
     protected LXPoint[] getPoints() {
       return this.edge.points;
+    }
+  }
+
+  private class ModelElement extends Element {
+    private final LXModel model;
+
+    private ModelElement(LXModel model) {
+      this.model = model;
+    }
+
+    @Override
+    protected LXPoint[] getPoints() {
+      return this.model.points;
     }
   }
 
@@ -218,6 +233,12 @@ public class RandomStrobeEffect extends TEEffect implements LX.Listener {
       EdgeElement e = new EdgeElement(edge);
       e.randomizeOffset();
       this.elements.add(e);
+    }
+
+    for (LXModel mothershipWindow : getModel().sub(TAG_MOTHERSHIP_WINDOW)) {
+      ModelElement element = new ModelElement(mothershipWindow);
+      element.randomizeOffset();
+      this.elements.add(element);
     }
   }
 

--- a/te-app/src/main/java/titanicsend/ui/effect/UIRandomStrobeEffect.java
+++ b/te-app/src/main/java/titanicsend/ui/effect/UIRandomStrobeEffect.java
@@ -2,14 +2,20 @@ package titanicsend.ui.effect;
 
 import heronarts.glx.ui.UI2dComponent;
 import heronarts.glx.ui.UI2dContainer;
-import heronarts.lx.studio.LXStudio.UI;
+import heronarts.glx.ui.component.UIButton;
+import heronarts.glx.ui.vg.VGraphics;
+import heronarts.lx.studio.LXStudio;
 import heronarts.lx.studio.ui.device.UIDevice;
 import heronarts.lx.studio.ui.device.UIDeviceControls;
 import titanicsend.effect.RandomStrobeEffect;
 
 public class UIRandomStrobeEffect implements UIDeviceControls<RandomStrobeEffect> {
 
-  private UI2dComponent speed,
+  private UI2dComponent runBeats,
+      runBeatsLabel,
+      runTime,
+      runTimeLabel,
+      speed,
       minFreq,
       maxFreq,
       minFreqLabel,
@@ -18,20 +24,36 @@ public class UIRandomStrobeEffect implements UIDeviceControls<RandomStrobeEffect
       tempoPhaseOffset;
 
   @Override
-  public void buildDeviceControls(UI ui, UIDevice uiDevice, RandomStrobeEffect strobe) {
+  public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, RandomStrobeEffect strobe) {
     uiDevice.setLayout(UI2dContainer.Layout.HORIZONTAL);
     uiDevice.setChildSpacing(4);
 
     addColumn(
             uiDevice,
-            "Rate",
+            "Duration",
+            new UIButton(50, strobe.launch)
+                .setHeight(50)
+                .setTextAlignment(VGraphics.Align.CENTER, VGraphics.Align.MIDDLE),
             newButton(strobe.tempoSync),
+            this.runBeats = newDropMenu(strobe.runBeats),
+            this.runBeatsLabel = controlLabel(ui, "Run Beats"),
+            this.runTime = newDoubleBox(strobe.runTimeMs),
+            this.runTimeLabel = controlLabel(ui, "Run Time"))
+        .setChildSpacing(6);
+
+    addVerticalBreak(ui, uiDevice);
+
+    addColumn(
+            uiDevice,
+            "Rate",
+            // Non-sync (milliseconds) mode
             this.speed = newKnob(strobe.speed),
             this.minFreq = newDoubleBox(strobe.minFrequency),
             this.minFreqLabel = controlLabel(ui, "Min"),
             this.maxFreq = newDoubleBox(strobe.maxFrequency),
             this.maxFreqLabel = controlLabel(ui, "Max"),
-            this.tempoDivision = newEnumBox(strobe.tempoDivision),
+            // Sync (tempo) mode
+            this.tempoDivision = newDropMenu(strobe.tempoDivision),
             this.tempoPhaseOffset = newKnob(strobe.tempoPhaseOffset))
         .setChildSpacing(6);
 
@@ -45,16 +67,21 @@ public class UIRandomStrobeEffect implements UIDeviceControls<RandomStrobeEffect
             newKnob(strobe.bias))
         .setChildSpacing(6);
 
+    // Toggle UI element visibility based on Sync parameter
     uiDevice.addListener(
         strobe.tempoSync,
         (p) -> {
           updateTempoSync(strobe);
-        });
-    updateTempoSync(strobe);
+        },
+        true);
   }
 
   private void updateTempoSync(RandomStrobeEffect strobe) {
     boolean isSync = strobe.tempoSync.isOn();
+    this.runBeats.setVisible(isSync);
+    this.runBeatsLabel.setVisible(isSync);
+    this.runTime.setVisible(!isSync);
+    this.runTimeLabel.setVisible(!isSync);
     this.speed.setVisible(!isSync);
     this.minFreq.setVisible(!isSync);
     this.maxFreq.setVisible(!isSync);


### PR DESCRIPTION
Four updates to RandomStrobe, each in its own commit:
- Added quantized launch!  In Tempo Sync mode, run length is 1, 4, or 8 beats, and strobe speed is tempo-based.  In non-tempo sync mode, run length is milliseconds and strobe speed is Hz.
- Combined the internal `Element` classes into a single list.
- Proper handling for `modelChanged` events
- Added Mothership windows to RandomStrobe elements!

And one global update:
- Launch quantization depends on a global value being set in the tempo module.  To keep it consistent for shows I added it to the Control Panel (aka DevSwitch).

Video of quantized launch:
https://www.youtube.com/watch?v=Gegs3XgPoAw