### PR TITLE
Add new component to send color palette to Resolume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ Logs/
 *.onnx
 /te-app/resources/shaders/cache/
 .claude/
+
+.agent_logs/*
+**log

--- a/.run/Titanic's End GPU.run.xml
+++ b/.run/Titanic's End GPU.run.xml
@@ -1,5 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Titanic's End GPU" type="Application" factoryName="Application">
+    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="--resolution 1920x1200" />

--- a/.run/Titanic's End GPU.run.xml
+++ b/.run/Titanic's End GPU.run.xml
@@ -1,7 +1,5 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Titanic's End GPU" type="Application" factoryName="Application">
-    <option name="ALTERNATIVE_JRE_PATH" value="temurin-21" />
-    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
     <option name="MAIN_CLASS_NAME" value="heronarts.lx.studio.TEApp" />
     <module name="te-app" />
     <option name="PROGRAM_PARAMETERS" value="--resolution 1920x1200" />

--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -310,6 +310,10 @@ public class TEApp extends LXStudio {
 
       new TEGradientSource(lx);
 
+      // Initialize Resolume gradient publisher (logs palette color changes for now)
+      lx.engine.registerComponent(
+          "resolumePalette", new titanicsend.osc.TEResolumeGradientPublisher(lx));
+
       // JKB Autopilot
       // lx.engine.registerComponent("autopilot", this.autopilotJKB = new AutopilotExample(lx));
       // initializeAutopilotLibraryJKB();

--- a/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
+++ b/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
@@ -22,6 +22,8 @@ public class TEResolumeGradientPublisher extends LXComponent
   private boolean pendingLog0 = false;
   private boolean pendingLog1 = false;
   private boolean pendingPublish = false;
+  // Global logging switch (disabled by default)
+  private boolean enableLogging = false;
 
   // Base OSC path for the Resolume effect
   private static final String OSC_EFFECT_BASE =
@@ -130,22 +132,24 @@ public class TEResolumeGradientPublisher extends LXComponent
     // (hue, saturation, brightness). Scheduling onto the engine task queue ensures
     // we log only once per user change rather than 2-3 times, and do so on the
     // engine thread after all parameter updates have settled for this tick.
-    if (index == 0) {
-      if (pendingLog0) return;
-      pendingLog0 = true;
-      lx.engine.addTask(
-          () -> {
-            pendingLog0 = false;
-            logColorChange(0, this.color0);
-          });
-    } else if (index == 1) {
-      if (pendingLog1) return;
-      pendingLog1 = true;
-      lx.engine.addTask(
-          () -> {
-            pendingLog1 = false;
-            logColorChange(1, this.color1);
-          });
+    if (enableLogging) {
+      if (index == 0) {
+        if (pendingLog0) return;
+        pendingLog0 = true;
+        lx.engine.addTask(
+            () -> {
+              pendingLog0 = false;
+              logColorChange(0, this.color0);
+            });
+      } else if (index == 1) {
+        if (pendingLog1) return;
+        pendingLog1 = true;
+        lx.engine.addTask(
+            () -> {
+              pendingLog1 = false;
+              logColorChange(1, this.color1);
+            });
+      }
     }
 
     // Also coalesce OSC publishing to one action after changes to either color0 or color1

--- a/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
+++ b/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
@@ -58,18 +58,7 @@ public class TEResolumeGradientPublisher extends LXComponent implements LXSwatch
     // Initialize reusable ColorStops
     this.stopBlack.setRGB(LXColor.BLACK);
 
-    if (this.enabled.isOn()) {
-      bindToActiveSwatch();
-      // Debug: Log initialization
-      LX.log(
-          "TEResolumeGradientPublisher initialized - enabled: "
-              + this.enabled.isOn()
-              + ", logging: "
-              + this.enableLogging.isOn());
-      LX.log("  OSC engine available: " + (lx.engine.osc != null));
-    } else {
-      LX.log("TEResolumeGradientPublisher disabled...");
-    }
+    bindToActiveSwatch();
   }
 
   private void bindToActiveSwatch() {

--- a/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
+++ b/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
@@ -1,0 +1,242 @@
+package titanicsend.osc;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXComponent;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.color.LXDynamicColor;
+import heronarts.lx.color.LXPalette;
+import heronarts.lx.color.LXSwatch;
+import heronarts.lx.parameter.LXParameterListener;
+import titanicsend.lx.LXGradientUtils;
+
+/**
+ * Minimal utility that listens to the active LX palette colors (primary/secondary) and logs
+ * changes. This establishes the integration point for later OSC publishing.
+ */
+public class TEResolumeGradientPublisher extends LXComponent
+    implements LXSwatch.Listener, LXPalette.Listener {
+
+  private LXSwatch activeSwatch;
+  private LXDynamicColor color0;
+  private LXDynamicColor color1;
+  private boolean pendingLog0 = false;
+  private boolean pendingLog1 = false;
+  private boolean pendingPublish = false;
+
+  // Base OSC path for the Resolume effect
+  private static final String OSC_EFFECT_BASE =
+      "/composition/video/effects/colorize16palette/effect/";
+
+  private final LXParameterListener color0Listener =
+      (p) -> {
+        scheduleLog(0);
+      };
+
+  private final LXParameterListener color1Listener =
+      (p) -> {
+        scheduleLog(1);
+      };
+
+  public TEResolumeGradientPublisher(LX lx) {
+    super(lx);
+    // Listen for palette changes and bind to the active swatch
+    lx.engine.palette.addListener(this);
+    bindToActiveSwatch();
+  }
+
+  private void bindToActiveSwatch() {
+    this.activeSwatch = lx.engine.palette.swatch;
+    if (this.activeSwatch != null) {
+      try {
+        this.activeSwatch.addListener(this);
+      } catch (Exception ignored) {
+      }
+      rebindColors();
+    }
+  }
+
+  private void unbindFromActiveSwatch() {
+    if (this.activeSwatch != null) {
+      try {
+        this.activeSwatch.removeListener(this);
+      } catch (Exception ignored) {
+      }
+      this.activeSwatch = null;
+    }
+    unbindColorListeners();
+  }
+
+  private void unbindColorListeners() {
+    if (this.color0 != null) {
+      try {
+        this.color0.color.removeListener(this.color0Listener);
+      } catch (Exception ignored) {
+      }
+      this.color0 = null;
+    }
+    if (this.color1 != null) {
+      try {
+        this.color1.color.removeListener(this.color1Listener);
+      } catch (Exception ignored) {
+      }
+      this.color1 = null;
+    }
+  }
+
+  private void rebindColors() {
+    unbindColorListeners();
+    if (this.activeSwatch == null) return;
+    int numColors = this.activeSwatch.colors.size();
+    if (numColors > 0) {
+      this.color0 = this.activeSwatch.getColor(0);
+      try {
+        this.color0.color.addListener(this.color0Listener, true);
+      } catch (Exception ignored) {
+      }
+    }
+    if (numColors > 1) {
+      this.color1 = this.activeSwatch.getColor(1);
+      try {
+        this.color1.color.addListener(this.color1Listener, true);
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  private void logColorChange(int index, LXDynamicColor dynamicColor) {
+    if (dynamicColor == null) {
+      return;
+    }
+    float h = dynamicColor.color.hue.getValuef();
+    float s = dynamicColor.color.saturation.getValuef();
+    float b = dynamicColor.color.brightness.getValuef();
+    int cFromHSB = LXColor.hsb(h, s, b);
+    String hex = String.format("#%06X", (0xFFFFFF & cFromHSB));
+    LX.log(
+        String.format(
+            "Palette color%d changed: %s hsb(%.1f, %.1f, %.1f) rgb(%d,%d,%d)",
+            index,
+            hex,
+            h,
+            s,
+            b,
+            (cFromHSB & LXColor.R_MASK) >>> LXColor.R_SHIFT,
+            (cFromHSB & LXColor.G_MASK) >>> LXColor.G_SHIFT,
+            (cFromHSB & LXColor.B_MASK)));
+  }
+
+  private void scheduleLog(int index) {
+    // Debounce/coalesce: a single palette color change emits multiple parameter events
+    // (hue, saturation, brightness). Scheduling onto the engine task queue ensures
+    // we log only once per user change rather than 2-3 times, and do so on the
+    // engine thread after all parameter updates have settled for this tick.
+    if (index == 0) {
+      if (pendingLog0) return;
+      pendingLog0 = true;
+      lx.engine.addTask(
+          () -> {
+            pendingLog0 = false;
+            logColorChange(0, this.color0);
+          });
+    } else if (index == 1) {
+      if (pendingLog1) return;
+      pendingLog1 = true;
+      lx.engine.addTask(
+          () -> {
+            pendingLog1 = false;
+            logColorChange(1, this.color1);
+          });
+    }
+
+    // Also coalesce OSC publishing to one action after changes to either color0 or color1
+    if (!pendingPublish) {
+      pendingPublish = true;
+      lx.engine.addTask(
+          () -> {
+            pendingPublish = false;
+            publishGradientIfReady();
+          });
+    }
+  }
+
+  private boolean canSendOsc() {
+    return this.lx != null
+        && this.lx.engine != null
+        && this.lx.engine.osc != null
+        && this.lx.engine.osc.transmitActive.isOn();
+  }
+
+  private void sendOsc(String address, float value) {
+    if (canSendOsc()) {
+      lx.engine.osc.sendMessage(address, value);
+    }
+  }
+
+  // Build a 16-color OKLab gradient with these anchors:
+  // index 0 = black, index 4 = color0, index 15 = color1
+  private void publishGradientIfReady() {
+    if (this.color0 == null || this.color1 == null) return;
+
+    // Prepare ColorStops for OKLab blending
+    LXGradientUtils.ColorStop stopBlack = new LXGradientUtils.ColorStop();
+    stopBlack.setRGB(LXColor.BLACK);
+    LXGradientUtils.ColorStop stop0 = new LXGradientUtils.ColorStop();
+    stop0.set(this.color0);
+    LXGradientUtils.ColorStop stop1 = new LXGradientUtils.ColorStop();
+    stop1.set(this.color1);
+
+    for (int i = 0; i < 16; i++) {
+      int color;
+      if (i <= 4) {
+        float t = (i) / 4f; // 0..1 from black to color0
+        // Ease-out cubic for smoother approach to color0 at index 4
+        float tEase = 1f - (1f - t) * (1f - t) * (1f - t);
+        color = LXGradientUtils.BlendFunction.OKLAB.blend(stopBlack, stop0, tEase);
+      } else {
+        float t = (i - 4) / 11f; // 0..1 from color0 to color1 over indices 4..15
+        color = LXGradientUtils.BlendFunction.OKLAB.blend(stop0, stop1, t);
+      }
+
+      float hueNorm = LXColor.h(color) / 360f;
+      float satNorm = LXColor.s(color) / 100f;
+      float briNorm = LXColor.b(color) / 100f;
+
+      String base = OSC_EFFECT_BASE + "lxcolor" + (i + 1);
+      sendOsc(base + "/hue", hueNorm);
+      sendOsc(base + "/saturation", satNorm);
+      sendOsc(base + "/brightness", briNorm);
+    }
+  }
+
+  // LXSwatch.Listener
+  @Override
+  public void colorAdded(LXSwatch swatch, LXDynamicColor color) {
+    // Rebind when colors are added to ensure we track index 0 and 1 only
+    rebindColors();
+  }
+
+  @Override
+  public void colorRemoved(LXSwatch swatch, LXDynamicColor color) {
+    rebindColors();
+  }
+
+  // LXPalette.Listener
+  @Override
+  public void swatchAdded(LXPalette palette, LXSwatch swatch) {}
+
+  @Override
+  public void swatchRemoved(LXPalette palette, LXSwatch swatch) {}
+
+  @Override
+  public void swatchMoved(LXPalette palette, LXSwatch swatch) {}
+
+  @Override
+  public void dispose() {
+    unbindFromActiveSwatch();
+    try {
+      lx.engine.palette.removeListener(this);
+    } catch (Exception ignored) {
+    }
+    super.dispose();
+  }
+}

--- a/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
+++ b/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
@@ -25,7 +25,7 @@ public class TEResolumeGradientPublisher extends LXComponent implements LXSwatch
       new BooleanParameter("Enabled", true).setDescription("Enable OSC publishing to Resolume");
 
   public final BooleanParameter enableLogging =
-      new BooleanParameter("Enable Logging", true).setDescription("Enable color change logging");
+      new BooleanParameter("Enable Logging", false).setDescription("Enable color change logging");
 
   // Base OSC path for the Resolume effect
   private static final String OSC_EFFECT_BASE =

--- a/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
+++ b/te-app/src/main/java/titanicsend/osc/TEResolumeGradientPublisher.java
@@ -115,19 +115,17 @@ public class TEResolumeGradientPublisher extends LXComponent implements LXSwatch
     float b = dynamicColor.color.brightness.getValuef();
     int cFromHSB = LXColor.hsb(h, s, b);
     String hex = String.format("#%06X", (0xFFFFFF & cFromHSB));
-    if (this.enableLogging.isOn()) {
-      LX.log(
-          String.format(
-              "Palette color%d changed: %s hsb(%.1f, %.1f, %.1f) rgb(%d,%d,%d)",
-              index,
-              hex,
-              h,
-              s,
-              b,
-              (cFromHSB & LXColor.R_MASK) >>> LXColor.R_SHIFT,
-              (cFromHSB & LXColor.G_MASK) >>> LXColor.G_SHIFT,
-              (cFromHSB & LXColor.B_MASK)));
-    }
+    LX.log(
+        String.format(
+            "Palette color%d changed: %s hsb(%.1f, %.1f, %.1f) rgb(%d,%d,%d)",
+            index,
+            hex,
+            h,
+            s,
+            b,
+            (cFromHSB & LXColor.R_MASK) >>> LXColor.R_SHIFT,
+            (cFromHSB & LXColor.G_MASK) >>> LXColor.G_SHIFT,
+            (cFromHSB & LXColor.B_MASK)));
   }
 
   private void colorChanged(int index) {


### PR DESCRIPTION
Add Resolume OKLab gradient publisher; default-disable logging:
- Implemented titanicsend.osc.TEResolumeGradientPublisher and registered it in TEApp.Plugin as resolumePalette.
- Listens to active LXPalette/LXSwatch, binding only to colors 0 and 1; rebinds on swatch changes.
- Coalesces multiple H/S/B parameter events via engine-task scheduling to avoid duplicate handling and ensure updates occur after values settle.
- Generates a 16-color OKLab gradient:
  -- index 0 = black, index 4 = color0, index 15 = color1
  -- smoothed black→color0 segment with ease-out blending to reduce the jump near index 4
- Publishes normalized H/S/B to Resolume OSC:
  -- Base const: /composition/video/effects/colorize16palette/effect/
  -- Per-color paths: /lxcolor{1..16}/{hue|saturation|brightness}
- Introduced enableLogging flag (default false) to suppress palette change logs while keeping OSC publishing active.