### PR TITLE
APC40: Shift+Knob to browse UserPresets

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -167,6 +167,10 @@ public class TECommonControls {
     return controlList.get(tag);
   }
 
+  public OffairDiscreteParameter<UserPresetCollection.Selector> getPresetSelectorOffair() {
+    return this.presetSelectorOffair;
+  }
+
   /**
    * Retrieve backing LX control object for given tag
    *


### PR DESCRIPTION
As requested: browse user presets by holding `Shift` and turning the top knob.  Only works if your `Shift` button isn't gummed up with playa dust!

~Behavior is a bit jumpy if you browse patterns, then browse presets, then go back to browsing patterns.  The pattern list will jump to the new knob value.  Thinking this is incremental progress.  If time permits we'll try to save the knob values and restore them.~
Edit: This is done.