### PR TITLE
DJ Lights: independent left/right colors, presets list, and car positions

### DIFF
--- a/te-app/Fixtures/Beacons/DJLightLeft.lxf
+++ b/te-app/Fixtures/Beacons/DJLightLeft.lxf
@@ -10,7 +10,11 @@
 
   "components": [
     {
-      "type": "point", "pointSize": 40
+      "type": "point",
+      "pointSize": 40,
+      "x": -120,
+      "y": 170,
+      "z": -50
     }
   ]
 }

--- a/te-app/Fixtures/Beacons/DJLightLeft.lxf
+++ b/te-app/Fixtures/Beacons/DJLightLeft.lxf
@@ -1,6 +1,6 @@
 {
   "label": "DJLightLeft",
-  "tags": [ "dmx", "djLight", "dmxFixture" ],
+  "tags": [ "dmx", "djLight", "dmxFixture", "left" ],
   "meta": {
     "dmx": "titanicsend.dmx.model.AdjStealthModel",
     "dmx_host": "10.0.0.204",

--- a/te-app/Fixtures/Beacons/DjLightRight.lxf
+++ b/te-app/Fixtures/Beacons/DjLightRight.lxf
@@ -1,6 +1,6 @@
 {
   "label": "DJLightRight",
-  "tags": [ "dmx", "djLight", "dmxFixture" ],
+  "tags": [ "dmx", "djLight", "dmxFixture", "right" ],
   "meta": {
     "dmx": "titanicsend.dmx.model.AdjStealthModel",
     "dmx_host": "10.0.0.204",

--- a/te-app/Fixtures/Beacons/DjLightRight.lxf
+++ b/te-app/Fixtures/Beacons/DjLightRight.lxf
@@ -9,7 +9,11 @@
   },
   "components": [
     {
-      "type": "point", "pointSize": 40
+      "type": "point",
+      "pointSize": 40,
+      "x": 120,
+      "y": 170,
+      "z": -50
     }
   ]
 }

--- a/te-app/src/main/java/titanicsend/color/TEColorParameter.java
+++ b/te-app/src/main/java/titanicsend/color/TEColorParameter.java
@@ -36,7 +36,7 @@ public class TEColorParameter extends ColorParameter implements GradientUtils.Gr
   private final ColorSource COLOR_SOURCE_DEFAULT = ColorSource.NORMAL;
 
   public final EnumParameter<ColorSource> colorSource =
-      new EnumParameter<ColorSource>("ColorSource", COLOR_SOURCE_DEFAULT) {
+      new EnumParameter<ColorSource>("Source", COLOR_SOURCE_DEFAULT) {
         @Override
         public LXParameter reset() {
           // JKB: Don't worry about this, just avoiding a minor bug

--- a/te-app/src/main/java/titanicsend/dmx/pattern/BeaconDirectPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/BeaconDirectPattern.java
@@ -104,6 +104,6 @@ public class BeaconDirectPattern extends BeaconPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, BeaconDirectPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/BeaconEasyPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/BeaconEasyPattern.java
@@ -83,6 +83,6 @@ public class BeaconEasyPattern extends BeaconPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, BeaconEasyPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/BeaconEverythingPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/BeaconEverythingPattern.java
@@ -169,6 +169,6 @@ public class BeaconEverythingPattern extends BeaconPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, BeaconEverythingPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/BeaconGamePattern.java
@@ -356,6 +356,6 @@ public class BeaconGamePattern extends BeaconPattern
 
   @Override
   public void buildDeviceControls(LXStudio.UI ui, UIDevice uiDevice, BeaconGamePattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/BeaconStraightUpPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/BeaconStraightUpPattern.java
@@ -66,6 +66,6 @@ public class BeaconStraightUpPattern extends BeaconPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, BeaconStraightUpPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsDirectPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsDirectPattern.java
@@ -78,6 +78,6 @@ public class DjLightsDirectPattern extends DjLightsPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, DjLightsDirectPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
@@ -125,6 +125,6 @@ public class DjLightsEasyPattern extends DjLightsPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, DjLightsEasyPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
@@ -6,7 +6,6 @@ import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.BooleanParameter.Mode;
 import heronarts.lx.parameter.CompoundParameter;
 import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIDevice;
 import heronarts.lx.studio.ui.device.UIDeviceControls;
@@ -60,20 +59,15 @@ public class DjLightsEasyPattern extends DjLightsPattern
 
     this.dimmer.setNormalized(.5);
 
-    this.setCustomRemoteControls(
-        new LXListenableNormalizedParameter[] {
-          this.pan,
-          this.tilt,
-          this.strobeSpeed,
-          this.strobe,
-          this.linkedColor.offset,
-          this.linkedColor.hue,
-          this.linkedColor.saturation,
-          this.linkedColor.brightness,
-          this.dimmer,
-          this.focus,
-          this.mirror
-        });
+    this.setRemoteControls(
+        this.pan,
+        this.tilt,
+        this.strobeSpeed,
+        this.strobe,
+        this.linkedColor.offset,
+        this.dimmer,
+        this.focus,
+        this.mirror);
   }
 
   @Override

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsEasyPattern.java
@@ -41,7 +41,8 @@ public class DjLightsEasyPattern extends DjLightsPattern
           .setWrappable(false)
           .setDescription("Strobe Speed");
 
-  public final TEColorParameter linkedColor;
+  public final TEColorParameter colorL;
+  public final TEColorParameter colorR;
 
   public DjLightsEasyPattern(LX lx) {
     super(lx);
@@ -50,12 +51,11 @@ public class DjLightsEasyPattern extends DjLightsPattern
     addParameter("tilt", this.tilt);
     addParameter("strobeSpeed", this.strobeSpeed);
     addParameter("strobe", this.strobe);
-    addParameter("color", this.linkedColor = new TEColorParameter("Color"));
+    addParameter("colorL", this.colorL = new TEColorParameter("ColorL"));
+    addParameter("colorR", this.colorR = new TEColorParameter("ColorR"));
     addParameter("dimmer", this.dimmer);
     addParameter("focus", this.focus);
     addParameter("mirror", this.mirror);
-
-    // linkedColor.mode.setValue(LinkedColorParameter.Mode.PALETTE);
 
     this.dimmer.setNormalized(.5);
 
@@ -64,7 +64,8 @@ public class DjLightsEasyPattern extends DjLightsPattern
         this.tilt,
         this.strobeSpeed,
         this.strobe,
-        this.linkedColor.offset,
+        this.colorL.offset,
+        this.colorR.offset,
         this.dimmer,
         this.focus,
         this.mirror);
@@ -80,18 +81,24 @@ public class DjLightsEasyPattern extends DjLightsPattern
     double dimmer = this.dimmer.getNormalized();
     double focus = this.focus.getNormalized();
 
-    int color = this.linkedColor.calcColor();
-    int r = ((color >> 16) & 0xff);
-    int g = ((color >> 8) & 0xff);
-    int b = (color & 0xff);
-    int w = (r < g) ? ((r < b) ? r : b) : ((g < b) ? g : b);
-    r -= w;
-    g -= w;
-    b -= w;
-
     int i = 0;
     for (DmxModel d : this.modelTE.getDjLights()) {
       if (d instanceof AdjStealthModel) {
+
+        // Determine Left or Right DJ light by checking fixture tags
+        boolean isRight = d.model.tags.contains("right");
+
+        // Use color from the Left or Right parameter
+        int color = isRight ? this.colorR.calcColor() : this.colorL.calcColor();
+        int r = ((color >> 16) & 0xff);
+        int g = ((color >> 8) & 0xff);
+        int b = (color & 0xff);
+        int w = (r < g) ? ((r < b) ? r : b) : ((g < b) ? g : b);
+        r -= w;
+        g -= w;
+        b -= w;
+
+        // Optionally mirror every other light. Or just set it on the hardware fixture.
         if (mirror && i++ % 2 == 1) {
           setDmxNormalized(d, AdjStealthModel.INDEX_PAN, 1 - pan);
         } else {
@@ -110,6 +117,9 @@ public class DjLightsEasyPattern extends DjLightsPattern
           setDmxValue(d, AdjStealthModel.INDEX_SHUTTER, AdjStealthModel.SHUTTER_OPEN);
         }
         setDmxNormalized(d, AdjStealthModel.INDEX_FOCUS, focus);
+
+        // Scale the screen color by the dimmer amount?
+        // color = LXColor.scaleBrightness(color, dimmer);
 
         // Mirror the DMX fixture's color to the LXPoint that represents it on the screen
         setColor(d.model, color);

--- a/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsShowPattern.java
+++ b/te-app/src/main/java/titanicsend/dmx/pattern/DjLightsShowPattern.java
@@ -167,6 +167,6 @@ public class DjLightsShowPattern extends DjLightsPattern
 
   @Override
   public void buildDeviceControls(UI ui, UIDevice uiDevice, DjLightsShowPattern device) {
-    UIUtils.buildMftStyleDeviceControls(ui, uiDevice, device);
+    UIUtils.buildTEDeviceControls(ui, uiDevice, device);
   }
 }

--- a/te-app/src/main/java/titanicsend/ui/UIUtils.java
+++ b/te-app/src/main/java/titanicsend/ui/UIUtils.java
@@ -1,5 +1,6 @@
 package titanicsend.ui;
 
+import heronarts.glx.ui.UI2dContainer;
 import heronarts.glx.ui.component.UIColorControl;
 import heronarts.glx.ui.component.UIKnob;
 import heronarts.glx.ui.component.UISwitch;
@@ -13,6 +14,7 @@ import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIDevice;
 import titanicsend.color.TEColorParameter;
+import titanicsend.preset.UIUserPresetCollection;
 
 public class UIUtils {
 
@@ -52,5 +54,17 @@ public class UIUtils {
       ++ki;
     }
     uiDevice.setContentWidth((col + 1) * (4 * (UIKnob.WIDTH + 2) + 15) - 15 - 2);
+  }
+
+  /** Build the normal device controls for TE */
+  public static void buildTEDeviceControls(UI ui, UIDevice uiDevice, LXDeviceComponent device) {
+    uiDevice.setLayout(UI2dContainer.Layout.HORIZONTAL, 2);
+
+    uiDevice.addChildren(
+        // Remote controls, MFT-layout
+        new UIMFTControls(ui, device, uiDevice.getContentHeight()),
+
+        // User Presets list
+        new UIUserPresetCollection(ui, device, uiDevice.getContentHeight()));
   }
 }

--- a/te-app/src/main/java/titanicsend/ui/UIUtils.java
+++ b/te-app/src/main/java/titanicsend/ui/UIUtils.java
@@ -1,60 +1,12 @@
 package titanicsend.ui;
 
 import heronarts.glx.ui.UI2dContainer;
-import heronarts.glx.ui.component.UIColorControl;
-import heronarts.glx.ui.component.UIKnob;
-import heronarts.glx.ui.component.UISwitch;
 import heronarts.lx.LXDeviceComponent;
-import heronarts.lx.color.LinkedColorParameter;
-import heronarts.lx.parameter.BooleanParameter;
-import heronarts.lx.parameter.BoundedFunctionalParameter;
-import heronarts.lx.parameter.BoundedParameter;
-import heronarts.lx.parameter.DiscreteParameter;
-import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.studio.LXStudio.UI;
 import heronarts.lx.studio.ui.device.UIDevice;
-import titanicsend.color.TEColorParameter;
 import titanicsend.preset.UIUserPresetCollection;
 
 public class UIUtils {
-
-  /** Constructs device controls in 4x4 grids, matching the layout of the MidiFighterTwisters */
-  public static void buildMftStyleDeviceControls(
-      UI ui, UIDevice uiDevice, LXDeviceComponent device) {
-    int ki = 0;
-    int col = 0;
-    for (LXNormalizedParameter param : device.getRemoteControls()) {
-      if (ki == 16) {
-        ki = 0;
-        col++;
-      }
-      float x = (ki % 4) * (UIKnob.WIDTH + 2) + (col * ((4 * (UIKnob.WIDTH + 2) + 15) + 2));
-      float y = -3 + (ki / 4) * (UIKnob.HEIGHT);
-      if (param instanceof TEColorParameter.TEColorOffsetParameter) {
-        new UITEColorControl(x, y, (TEColorParameter) param.getParentParameter())
-            .addToContainer(uiDevice);
-      } else if (param instanceof LinkedColorParameter) {
-        // TODO: find correct UI control
-        new UIColorControl(x, y, (LinkedColorParameter) param).addToContainer(uiDevice);
-      } else if (param instanceof BoundedParameter
-          || param instanceof DiscreteParameter
-          || param instanceof BoundedFunctionalParameter) {
-        new UIKnob(x, y).setParameter(param).addToContainer(uiDevice);
-      } else if (param instanceof BooleanParameter) {
-        new UISwitch(x, y).setParameter(param).addToContainer(uiDevice);
-      } else if (param == null) {
-        // Leave a space
-      } else {
-        // Hey developer: probably added a type in isEligibleControlParameter() that wasn't handled
-        // down here.
-        throw new RuntimeException(
-            "Cannot generate control, unsupported pattern parameter type: " + param.getClass());
-      }
-
-      ++ki;
-    }
-    uiDevice.setContentWidth((col + 1) * (4 * (UIKnob.WIDTH + 2) + 15) - 15 - 2);
-  }
 
   /** Build the normal device controls for TE */
   public static void buildTEDeviceControls(UI ui, UIDevice uiDevice, LXDeviceComponent device) {


### PR DESCRIPTION
Improvements to DJ lights:
- Independent colors for left/right DJ lights (in Show and Easy patterns)
- Added UI user presets list (also added to Beacon patterns)
- Cleaned up the Saturation parameters to avoid confusion. Still using Eli's aftermarket (extra) desaturation.  No need to expose the internal knob, it doesn't do anything when color comes from the palette.

You'll need to delete the patterns from your project file and re-add them to see the new parameters!

<img width="1508" height="1402" alt="image" src="https://github.com/user-attachments/assets/1cc2f165-3b53-416c-b439-b102320e3679" />
