### PR TITLE
Fix shader coordinates not recalculating after fixture move

### DIFF
--- a/te-app/src/main/java/titanicsend/effect/TEEffect.java
+++ b/te-app/src/main/java/titanicsend/effect/TEEffect.java
@@ -2,6 +2,7 @@ package titanicsend.effect;
 
 import heronarts.lx.LX;
 import heronarts.lx.effect.LXEffect;
+import heronarts.lx.model.LXModel;
 import heronarts.lx.studio.TEApp;
 import titanicsend.model.TEWholeModel;
 
@@ -13,5 +14,25 @@ public abstract class TEEffect extends LXEffect {
     super(lx);
 
     this.modelTE = TEApp.wholeModel;
+
+    // Listen to model generation changes (geometry changes) at top level and treat it
+    // as a modelChanged event, because the points have moved.  JKB: LX fix needed here?
+    this.lx.addListener(this.lxListener);
+  }
+
+  private final LX.Listener lxListener =
+      new LX.Listener() {
+        @Override
+        public void modelGenerationChanged(LX lx, LXModel model) {
+          // The model (object) didn't change but the points moved. Redirect to onModelChanged() to
+          // force recalculation (such as for shader lxModelCoordinates to reload)
+          onModelChanged(getModelView());
+        }
+      };
+
+  @Override
+  public void dispose() {
+    this.lx.removeListener(this.lxListener);
+    super.dispose();
   }
 }


### PR DESCRIPTION
We had an issue where repositioning a fixture would cause shaders to suddenly look like they were treating the car as one pixel.

Fixed that.