### PR TITLE
Use small point size for HRGrid to avoid GPU overload at certain zoom levels

### DIFF
--- a/te-app/Fixtures/Grids/HiResGrid/HiResGrid.lxf
+++ b/te-app/Fixtures/Grids/HiResGrid/HiResGrid.lxf
@@ -44,7 +44,8 @@
       numPoints: "$width",
       instances: "$height",
       spacing: "$widthFt*12/($width-1)",
-      y: "$instance*$heightFt*12/($height-1)"
+      y: "$instance*$heightFt*12/($height-1)",
+      "pointSize": 0.1
     }
   ]
 }


### PR DESCRIPTION
Forces point size to 0.1 for grids.  At certain angles and zoom levels (I think with a lot of overlapping points?), the GPU can get dragged down rendering the LXPoints.  Use a tiny point size has prevented this problem for me locally.