### PR TITLE
Brightness Control for CandyFlip

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
+++ b/te-app/src/main/java/titanicsend/pattern/piemonte/CandyFlip.java
@@ -201,8 +201,7 @@ public class CandyFlip extends TEPerformancePattern {
 
   @Override
   public void runTEAudioPattern(double deltaMs) {
-    // currentTime += deltaMs * getSpeed();
-    currentTime = getTimeMs();
+    currentTime += deltaMs * getSpeed();
 
     // Clear display
     for (LXPoint point : model.points) {


### PR DESCRIPTION
A couple of small changes, just to save the on-playa crew some time:
- CandyFlip is a pure Java pattern, and doesn't need a shader.  Changed to derive from `TEPerformancePattern`, and eliminate the `addShader(`) call.
- Brightness control now works as expected.