### PR TITLE
Refactor names related to textures (low priority)

### DIFF
--- a/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
+++ b/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
@@ -32,7 +32,7 @@ public class NDIOutShader extends GLShader implements GLShader.UniformSource {
   private String ndiStreamLabel = "TitanicsEnd";
 
   private int modelCoordsTextureHandle = UNINITIALIZED;
-  private int modelIndexTextureHandle = UNINITIALIZED;
+  private int modelNeighborhoodTextureHandle = UNINITIALIZED;
 
   // Variables that will be passed to uniforms
   // Incoming texture handle
@@ -199,7 +199,8 @@ public class NDIOutShader extends GLShader implements GLShader.UniformSource {
    */
   public void setModelCoordinates(LXModel model) {
     this.modelCoordsTextureHandle = this.glEngine.textureCache.getModelCoordsTexture(model);
-    this.modelIndexTextureHandle = this.glEngine.textureCache.getModelIndexTexture(model);
+    this.modelNeighborhoodTextureHandle =
+        this.glEngine.textureCache.getModelNeighborhoodTexture(model);
   }
 
   @Override

--- a/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
+++ b/te-app/src/main/java/titanicsend/ndi/NDIOutShader.java
@@ -198,8 +198,8 @@ public class NDIOutShader extends GLShader implements GLShader.UniformSource {
    * @param model Current LXModel of the calling context, which is a LXView or the global model
    */
   public void setModelCoordinates(LXModel model) {
-    this.modelCoordsTextureHandle = this.glEngine.textureCache.getCoordinatesTexture(model);
-    this.modelIndexTextureHandle = this.glEngine.textureCache.getIndexMapTexture(model);
+    this.modelCoordsTextureHandle = this.glEngine.textureCache.getModelCoordsTexture(model);
+    this.modelIndexTextureHandle = this.glEngine.textureCache.getModelIndexTexture(model);
   }
 
   @Override

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLPreprocessorHelpers.java
@@ -82,8 +82,8 @@ public class GLPreprocessorHelpers {
 
     // the last character of token 0 is the integer channel identifier
     // valid channels are 1-9.  Channel 0 is reserved for audio input.
-    control.textureChannel = Integer.parseInt(line[0].substring(line[0].length() - 1));
-    if (control.textureChannel == 0) {
+    control.iChannel = Integer.parseInt(line[0].substring(line[0].length() - 1));
+    if (control.iChannel == 0) {
       throw new IllegalArgumentException(
           "iChannel0 is reserved for system audio. Use channels 1-9 for textures.");
     }

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -51,9 +51,9 @@ public abstract class GLShader {
 
   // Reserved texture unit assignments in our context
   public static final int TEXTURE_UNIT_AUDIO = 0;
-  public static final int TEXTURE_UNIT_COORDS = 1;
+  public static final int TEXTURE_UNIT_MODEL_COORDS = 1;
   public static final int TEXTURE_UNIT_BACKBUFFER = 2;
-  public static final int TEXTURE_UNIT_COORD_MAP = 3;
+  public static final int TEXTURE_UNIT_MODEL_INDEX = 3;
   public static final int FIRST_UNRESERVED_TEXTURE_UNIT = 4;
 
   /**
@@ -217,8 +217,8 @@ public abstract class GLShader {
 
     // Reserved texture units
     this.uniformTextureUnits.put(UniformNames.BACK_BUFFER, TEXTURE_UNIT_BACKBUFFER);
-    this.uniformTextureUnits.put(UniformNames.LX_MODEL_COORDS, TEXTURE_UNIT_COORDS);
-    this.uniformTextureUnits.put(UniformNames.LX_MODEL_INDEX, TEXTURE_UNIT_COORD_MAP);
+    this.uniformTextureUnits.put(UniformNames.LX_MODEL_COORDS, TEXTURE_UNIT_MODEL_COORDS);
+    this.uniformTextureUnits.put(UniformNames.LX_MODEL_INDEX, TEXTURE_UNIT_MODEL_INDEX);
   }
 
   // Buffers

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShader.java
@@ -53,7 +53,7 @@ public abstract class GLShader {
   public static final int TEXTURE_UNIT_AUDIO = 0;
   public static final int TEXTURE_UNIT_MODEL_COORDS = 1;
   public static final int TEXTURE_UNIT_BACKBUFFER = 2;
-  public static final int TEXTURE_UNIT_MODEL_INDEX = 3;
+  public static final int TEXTURE_UNIT_MODEL_NEIGHBORHOOD = 3;
   public static final int FIRST_UNRESERVED_TEXTURE_UNIT = 4;
 
   /**
@@ -218,7 +218,8 @@ public abstract class GLShader {
     // Reserved texture units
     this.uniformTextureUnits.put(UniformNames.BACK_BUFFER, TEXTURE_UNIT_BACKBUFFER);
     this.uniformTextureUnits.put(UniformNames.LX_MODEL_COORDS, TEXTURE_UNIT_MODEL_COORDS);
-    this.uniformTextureUnits.put(UniformNames.LX_MODEL_INDEX, TEXTURE_UNIT_MODEL_INDEX);
+    this.uniformTextureUnits.put(
+        UniformNames.LX_MODEL_NEIGHBORHOOD, TEXTURE_UNIT_MODEL_NEIGHBORHOOD);
   }
 
   // Buffers

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderEffect.java
@@ -176,7 +176,7 @@ public class GLShaderEffect extends TEEffect implements GpuDevice {
       this.modelChanged = false;
       LXModel m = getModel();
       for (TEShader shader : this.shaders) {
-        shader.setModelCoordinates(m);
+        shader.setModel(m);
       }
     }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/GLShaderPattern.java
@@ -86,7 +86,7 @@ public class GLShaderPattern extends TEPerformancePattern implements GpuDevice {
       this.modelChanged = false;
       LXModel m = getModel();
       for (TEShader shader : this.shaders) {
-        shader.setModelCoordinates(m);
+        shader.setModel(m);
       }
     }
 

--- a/te-app/src/main/java/titanicsend/pattern/glengine/ShaderConfiguration.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/ShaderConfiguration.java
@@ -32,7 +32,7 @@ public class ShaderConfiguration {
         + v1
         + ", v2="
         + v2
-        + ", textureChannel="
+        + ", iChannel="
         + iChannel
         + ", name='"
         + name

--- a/te-app/src/main/java/titanicsend/pattern/glengine/ShaderConfiguration.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/ShaderConfiguration.java
@@ -12,7 +12,7 @@ public class ShaderConfiguration {
   public double value;
   public double v1;
   public double v2;
-  public int textureChannel;
+  public int iChannel;
   public String name;
 
   @Override
@@ -33,7 +33,7 @@ public class ShaderConfiguration {
         + ", v2="
         + v2
         + ", textureChannel="
-        + textureChannel
+        + iChannel
         + ", name='"
         + name
         + '\''

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
@@ -43,15 +43,15 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
   // Render buffers: ping-pong FBOs and textures
   private PingPongFBO ppFBOs;
 
-  // Texture handle for the current view model coordinate texture
+  // Texture handles for the current view model textures
   private int modelCoordsTextureHandle = UNINITIALIZED;
-  private int modelIndexTextureHandle = UNINITIALIZED;
+  private int modelNeighborhoodTextureHandle = UNINITIALIZED;
 
   private static class TEShaderUniforms {
     private Uniform.Int1 audio;
     private Uniform.Int1 lxModelCoords;
     private Uniform.Int1 backBuffer;
-    private Uniform.Int1 lxModelIndex;
+    private Uniform.Int1 lxModelNeighborhood;
   }
 
   private final TEShaderUniforms uniforms = new TEShaderUniforms();
@@ -140,7 +140,7 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
     this.uniforms.audio = getUniformInt1(UniformNames.AUDIO_CHANNEL);
     this.uniforms.lxModelCoords = getUniformInt1(UniformNames.LX_MODEL_COORDS);
     this.uniforms.backBuffer = getUniformInt1(UniformNames.BACK_BUFFER);
-    this.uniforms.lxModelIndex = getUniformInt1(UniformNames.LX_MODEL_INDEX);
+    this.uniforms.lxModelNeighborhood = getUniformInt1(UniformNames.LX_MODEL_NEIGHBORHOOD);
   }
 
   @Override
@@ -178,8 +178,8 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
     bindTextureUnit(TEXTURE_UNIT_MODEL_COORDS, this.modelCoordsTextureHandle);
     this.uniforms.lxModelCoords.setValue(TEXTURE_UNIT_MODEL_COORDS);
 
-    bindTextureUnit(TEXTURE_UNIT_MODEL_INDEX, this.modelIndexTextureHandle);
-    this.uniforms.lxModelIndex.setValue(TEXTURE_UNIT_MODEL_INDEX);
+    bindTextureUnit(TEXTURE_UNIT_MODEL_NEIGHBORHOOD, this.modelNeighborhoodTextureHandle);
+    this.uniforms.lxModelNeighborhood.setValue(TEXTURE_UNIT_MODEL_NEIGHBORHOOD);
 
     // Clear backbuffer on first frame
     if (this.needsClearBackBuffer) {
@@ -272,7 +272,7 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
   public void unbindTextures() {
     // Unbind textures (except for audio, which stays bound for all patterns)
     unbindTextureUnit(TEXTURE_UNIT_MODEL_COORDS);
-    unbindTextureUnit(TEXTURE_UNIT_MODEL_INDEX);
+    unbindTextureUnit(TEXTURE_UNIT_MODEL_NEIGHBORHOOD);
     unbindTextureUnit(TEXTURE_UNIT_BACKBUFFER);
     for (TextureInfo ti : this.fileTextures) {
       unbindTextureUnit(ti.unit);
@@ -301,7 +301,8 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
    */
   public void setModel(LXModel model) {
     this.modelCoordsTextureHandle = this.glEngine.textureCache.getModelCoordsTexture(model);
-    this.modelIndexTextureHandle = this.glEngine.textureCache.getModelIndexTexture(model);
+    this.modelNeighborhoodTextureHandle =
+        this.glEngine.textureCache.getModelNeighborhoodTexture(model);
   }
 
   // Releases native resources allocated by this shader.

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TEShader.java
@@ -175,11 +175,11 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
     // use the current view's model coordinates texture which
     // has already been loaded to the GPU by the texture cache manager.
     // All we need to do is bind it to right GL texture unit.
-    bindTextureUnit(TEXTURE_UNIT_COORDS, this.modelCoordsTextureHandle);
-    this.uniforms.lxModelCoords.setValue(TEXTURE_UNIT_COORDS);
+    bindTextureUnit(TEXTURE_UNIT_MODEL_COORDS, this.modelCoordsTextureHandle);
+    this.uniforms.lxModelCoords.setValue(TEXTURE_UNIT_MODEL_COORDS);
 
-    bindTextureUnit(TEXTURE_UNIT_COORD_MAP, this.modelIndexTextureHandle);
-    this.uniforms.lxModelIndex.setValue(TEXTURE_UNIT_COORD_MAP);
+    bindTextureUnit(TEXTURE_UNIT_MODEL_INDEX, this.modelIndexTextureHandle);
+    this.uniforms.lxModelIndex.setValue(TEXTURE_UNIT_MODEL_INDEX);
 
     // Clear backbuffer on first frame
     if (this.needsClearBackBuffer) {
@@ -271,8 +271,8 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
   @Override
   public void unbindTextures() {
     // Unbind textures (except for audio, which stays bound for all patterns)
-    unbindTextureUnit(TEXTURE_UNIT_COORDS);
-    unbindTextureUnit(TEXTURE_UNIT_COORD_MAP);
+    unbindTextureUnit(TEXTURE_UNIT_MODEL_COORDS);
+    unbindTextureUnit(TEXTURE_UNIT_MODEL_INDEX);
     unbindTextureUnit(TEXTURE_UNIT_BACKBUFFER);
     for (TextureInfo ti : this.fileTextures) {
       unbindTextureUnit(ti.unit);
@@ -299,9 +299,9 @@ public class TEShader extends GLShader implements GLShader.UniformSource {
    *
    * @param model Current LXModel of the calling context, which is a LXView or the global model
    */
-  public void setModelCoordinates(LXModel model) {
-    this.modelCoordsTextureHandle = this.glEngine.textureCache.getCoordinatesTexture(model);
-    this.modelIndexTextureHandle = this.glEngine.textureCache.getIndexMapTexture(model);
+  public void setModel(LXModel model) {
+    this.modelCoordsTextureHandle = this.glEngine.textureCache.getModelCoordsTexture(model);
+    this.modelIndexTextureHandle = this.glEngine.textureCache.getModelIndexTexture(model);
   }
 
   // Releases native resources allocated by this shader.

--- a/te-app/src/main/java/titanicsend/pattern/glengine/TextureManager.java
+++ b/te-app/src/main/java/titanicsend/pattern/glengine/TextureManager.java
@@ -10,7 +10,7 @@ import static com.jogamp.opengl.GL.GL_TEXTURE_MIN_FILTER;
 import static com.jogamp.opengl.GL.GL_TEXTURE_WRAP_S;
 import static com.jogamp.opengl.GL.GL_TEXTURE_WRAP_T;
 import static titanicsend.pattern.glengine.GLShader.TEXTURE_UNIT_MODEL_COORDS;
-import static titanicsend.pattern.glengine.GLShader.TEXTURE_UNIT_MODEL_INDEX;
+import static titanicsend.pattern.glengine.GLShader.TEXTURE_UNIT_MODEL_NEIGHBORHOOD;
 
 import com.jogamp.opengl.GL4;
 import com.jogamp.opengl.GLAutoDrawable;
@@ -125,8 +125,8 @@ public class TextureManager implements LX.Listener {
     ModelTexture[] slots = new ModelTexture[MODEL_TEXTURE_COUNT];
     ModelTexture normalizedXYZ = new ModelTexture();
     slots[0] = normalizedXYZ;
-    ModelTexture indexMap = new ModelTexture();
-    slots[1] = indexMap;
+    ModelTexture neighborhood = new ModelTexture();
+    slots[1] = neighborhood;
     this.modelTextures.put(model, slots);
 
     // Double check size of engine and model points
@@ -190,15 +190,15 @@ public class TextureManager implements LX.Listener {
     gl4.glBindTexture(GL_TEXTURE_2D, 0);
     gl4.glActiveTexture(GL_TEXTURE0);
 
-    // And create an OpenGL texture to hold the index data
-    this.glEngine.bindTextureUnit(TEXTURE_UNIT_MODEL_INDEX, indexMap.getHandle());
+    // And create an OpenGL texture to hold the neighborhood data
+    this.glEngine.bindTextureUnit(TEXTURE_UNIT_MODEL_NEIGHBORHOOD, neighborhood.getHandle());
 
     gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     gl4.glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    // load the index data into the texture
+    // load the neighborhood data into the texture
     gl4.glTexImage2D(
         GL4.GL_TEXTURE_2D, 0, GL4.GL_RG32F, width, height, 0, GL4.GL_RG, GL4.GL_FLOAT, indices);
 
@@ -225,7 +225,7 @@ public class TextureManager implements LX.Listener {
       case TEXTURE_UNIT_MODEL_COORDS: // normalized coordinates
         tex = slots[0];
         break;
-      case TEXTURE_UNIT_MODEL_INDEX: // textureUnit mapping
+      case TEXTURE_UNIT_MODEL_NEIGHBORHOOD: // textureUnit mapping
         tex = slots[1];
         break;
       default:
@@ -265,11 +265,11 @@ public class TextureManager implements LX.Listener {
    * @param model The model (view) to copy coordinates from
    * @return The texture handle of the view's indices texture
    */
-  public int getModelIndexTexture(LXModel model) {
+  public int getModelNeighborhoodTexture(LXModel model) {
     if (!hasModelTextures(model)) {
       createModelTextures(model);
     }
-    return getModelTexture(model, TEXTURE_UNIT_MODEL_INDEX);
+    return getModelTexture(model, TEXTURE_UNIT_MODEL_NEIGHBORHOOD);
   }
 
   /**

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/FragmentShader.java
@@ -18,7 +18,7 @@ import titanicsend.pattern.glengine.ShaderConfiguration;
  */
 public class FragmentShader {
   private final String shaderName;
-  private final Map<Integer, String> channelToTexture;
+  private final Map<Integer, String> iChannelFileNames = new HashMap<>();
   private final List<ShaderConfiguration> shaderConfig = new ArrayList<>();
 
   private final List<LXParameter> mutableParameters = new ArrayList<>();
@@ -26,7 +26,6 @@ public class FragmentShader {
 
   public FragmentShader(File shaderFile, List<File> textureFiles) {
     String shaderBody;
-    this.channelToTexture = new HashMap<>();
 
     // try the new way
     GLPreprocessor glp = new GLPreprocessor();
@@ -44,7 +43,7 @@ public class FragmentShader {
       for (int i = 0; i < textureFiles.size(); i++) {
         // automatically assign textures to iChannels, starting
         // at 1 since audio will be at iChannel0.
-        channelToTexture.put(i + 1, textureFiles.get(i).getPath());
+        iChannelFileNames.put(i + 1, textureFiles.get(i).getPath());
       }
     }
     // otherwise, see if there are any texture declarations or extra parameters
@@ -53,7 +52,7 @@ public class FragmentShader {
       for (ShaderConfiguration config : shaderConfig) {
         switch (config.opcode) {
           case SET_TEXTURE:
-            channelToTexture.put(config.textureChannel, new File(config.name).getPath());
+            iChannelFileNames.put(config.iChannel, new File(config.name).getPath());
             break;
           case ADD_LX_PARAMETER:
             mutableParameters.add(config.lxParameter);
@@ -69,8 +68,8 @@ public class FragmentShader {
     return shaderName;
   }
 
-  public Map<Integer, String> getChannelToTexture() {
-    return channelToTexture;
+  public Map<Integer, String> getiChannelFilenames() {
+    return iChannelFileNames;
   }
 
   public List<ShaderConfiguration> getShaderConfig() {

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/NativeShader.java
@@ -328,7 +328,7 @@ public class NativeShader implements GLEventListener {
 
   private void loadTextureFiles(FragmentShader fragmentShader) {
     for (Map.Entry<Integer, String> textureInput :
-        fragmentShader.getChannelToTexture().entrySet()) {
+        fragmentShader.getiChannelFilenames().entrySet()) {
       try {
         File file = new File(textureInput.getValue());
         // TE.log("File Texture %s", textureInput.getValue());

--- a/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/UniformNames.java
+++ b/te-app/src/main/java/titanicsend/pattern/yoffa/shader_engine/UniformNames.java
@@ -9,6 +9,6 @@ public class UniformNames {
   public static final String AUDIO_CHANNEL = CHANNEL + "0";
   public static final String LX_PARAMETER_SUFFIX = "_parameter";
   public static final String LX_MODEL_COORDS = "lxModelCoords";
-  public static final String LX_MODEL_INDEX = "lxModelIndex";
+  public static final String LX_MODEL_NEIGHBORHOOD = "lxModelIndex";
   public static final String BACK_BUFFER = "iBackbuffer";
 }


### PR DESCRIPTION
Did a refactor pass (name changes only) to clarify a few things:
- iChannel textures
- ModelCoords and ModelIndex textures

There were places where "coords" was used in reference to both model-derived textures, and places where "coords" was used only in reference to the first texture.  Attempting to create consistency I chose:
- "ModelTextures" refers to both lxmodel-derived textures
- "Coords" refers to the first texture and "Index" refers to the second texture.