### PR TITLE
Bug fix: suppress command engine with UIOffairParameter

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -110,6 +110,7 @@ import titanicsend.ndi.NDIOutShaderEffect;
 import titanicsend.ndi.NDIReceiverPattern;
 import titanicsend.osc.CrutchOSC;
 import titanicsend.oscremapper.OscRemapperPlugin;
+import titanicsend.parameter.UIOffairDiscreteParameter;
 import titanicsend.pattern.TEMidiFighter64DriverPattern;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.pattern.ben.Audio1;
@@ -839,6 +840,7 @@ public class TEApp extends LXStudio {
 
       LXStudio.Registry registry = (LXStudio.Registry) lx.registry;
       registry.addUIDeviceControls(UITEPerformancePattern.class);
+      registry.addUIParameterControl(UIOffairDiscreteParameter.class);
       registry.addUIParameterControl(UIUserPresetSelector.class);
       registry.addUIParameterControl(UITEColorControl.class);
 

--- a/te-app/src/main/java/titanicsend/parameter/OffairDiscreteParameter.java
+++ b/te-app/src/main/java/titanicsend/parameter/OffairDiscreteParameter.java
@@ -14,10 +14,9 @@ import titanicsend.model.justin.LXVirtualDiscreteParameter;
 /**
  * Wraps a discrete parameter and prevents the value from changing while the parent device is "live"
  */
-public class OffairDiscreteParameter<T extends DiscreteParameter>
-    extends LXVirtualDiscreteParameter<T> {
+public class OffairDiscreteParameter extends LXVirtualDiscreteParameter<DiscreteParameter> {
 
-  public OffairDiscreteParameter(String label, T parameter) {
+  public OffairDiscreteParameter(String label, DiscreteParameter parameter) {
     super(label, parameter);
   }
 

--- a/te-app/src/main/java/titanicsend/parameter/UIOffairDiscreteParameter.java
+++ b/te-app/src/main/java/titanicsend/parameter/UIOffairDiscreteParameter.java
@@ -1,0 +1,22 @@
+package titanicsend.parameter;
+
+import heronarts.glx.ui.UI;
+import heronarts.glx.ui.component.UIKnob;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.studio.ui.device.UIDeviceControls;
+
+public class UIOffairDiscreteParameter extends UIKnob
+    implements UIDeviceControls.ParameterControl<OffairDiscreteParameter> {
+
+  public UIOffairDiscreteParameter(UI ui, OffairDiscreteParameter parameter) {
+    this(ui, parameter, null);
+  }
+
+  public UIOffairDiscreteParameter(
+      UI ui, OffairDiscreteParameter parameter, LXParameter childParameter) {
+    super(0, 0, parameter);
+
+    // There's an issue when this wraps a preset selector. It needs to not use the command engine.
+    setUseCommandEngine(false);
+  }
+}

--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -8,7 +8,6 @@ import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
-import heronarts.lx.structure.view.LXViewEngine;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -18,7 +17,6 @@ import titanicsend.parameter.OffairDiscreteParameter;
 import titanicsend.pattern.jon.TEControl;
 import titanicsend.pattern.jon.TEControlTag;
 import titanicsend.pattern.jon._CommonControlGetter;
-import titanicsend.preset.UserPresetCollection;
 import titanicsend.util.MissingControlsManager;
 import titanicsend.util.TE;
 
@@ -39,8 +37,8 @@ public class TECommonControls {
   public TEColorParameter color;
 
   // Wrapped parameters that cannot be changed while live
-  private OffairDiscreteParameter<UserPresetCollection.Selector> presetSelectorOffair;
-  private OffairDiscreteParameter<LXViewEngine.Selector> viewOffair;
+  private OffairDiscreteParameter presetSelectorOffair;
+  private OffairDiscreteParameter viewOffair;
 
   // Panic control courtesy of JKB's Rubix codebase
   public final BooleanParameter panic =
@@ -360,11 +358,11 @@ public class TECommonControls {
     TEColorParameter colorParam = registerColorControl(colorPrefix);
 
     // Wrap the Preset parameter to prevent it from being changed while live
-    this.presetSelectorOffair = new OffairDiscreteParameter<>("Preset", pat.presetSelector);
+    this.presetSelectorOffair = new OffairDiscreteParameter("Preset", pat.presetSelector);
     this.pattern.addParam(KEY_PRESET_SELECTOR_OFFAIR, this.presetSelectorOffair);
 
     // Wrap the View parameter to prevent it from being changed while live
-    this.viewOffair = new OffairDiscreteParameter<>("View", pat.view);
+    this.viewOffair = new OffairDiscreteParameter("View", pat.view);
     this.pattern.addParam(KEY_VIEW_OFFAIR, this.viewOffair);
   }
 

--- a/te-app/src/main/java/titanicsend/ui/UIMFTControls.java
+++ b/te-app/src/main/java/titanicsend/ui/UIMFTControls.java
@@ -19,6 +19,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import titanicsend.color.TEColorParameter;
+import titanicsend.parameter.OffairDiscreteParameter;
+import titanicsend.parameter.UIOffairDiscreteParameter;
 import titanicsend.pattern.TEPerformancePattern;
 import titanicsend.preset.UIUserPresetSelector;
 import titanicsend.preset.UserPresetCollection;
@@ -148,6 +150,9 @@ public class UIMFTControls extends UI2dContainer implements LXParameterListener 
     } else if (param instanceof UserPresetCollection.Selector selector) {
       // Avoid command engine with userPreset selector, it bonks for unknown reasons
       return new UIUserPresetSelector(this.ui, selector);
+    } else if (param instanceof OffairDiscreteParameter offairParameter) {
+      // Avoid command engine with offair parameter, it could be a proxy to userPreset selector
+      return new UIOffairDiscreteParameter(ui, offairParameter);
     } else if (param instanceof BoundedParameter
         || param instanceof DiscreteParameter
         || param instanceof BoundedFunctionalParameter) {


### PR DESCRIPTION
We had suppressed the command engine for the `UserPreset` `Selector` by using a custom variation of a `UIKnob`.  This protection was lost when we wrapped it in an `OffairParameter`.

Added the same safety wrapper to `OffairParameter`, but had to make it non-generic to work with the `LXRegistry`.

You could encounter the bug by selecting a non-live pattern and changing the `UserPreset` selector.