### PR TITLE
Fix use of generic with Offair parameter in TECommonControls

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -165,7 +165,7 @@ public class TECommonControls {
     return controlList.get(tag);
   }
 
-  public OffairDiscreteParameter<UserPresetCollection.Selector> getPresetSelectorOffair() {
+  public OffairDiscreteParameter getPresetSelectorOffair() {
     return this.presetSelectorOffair;
   }
 


### PR DESCRIPTION
Fixes a current compile issue on main.  Somehow this file change missed the bus.