### PR TITLE
tiny bugfix: remove generic arg to OffairDiscreteParameter

### DIFF
--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -165,7 +165,7 @@ public class TECommonControls {
     return controlList.get(tag);
   }
 
-  public OffairDiscreteParameter<UserPresetCollection.Selector> getPresetSelectorOffair() {
+  public OffairDiscreteParameter getPresetSelectorOffair() {
     return this.presetSelectorOffair;
   }
 


### PR DESCRIPTION
looks like I missed this in a merge conflict resolution - should fix the problem now.