### PR TITLE
errorprone compiler warnings: audio-stems module

### DIFF
--- a/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
+++ b/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
@@ -147,8 +147,9 @@ public class AudioStemModulator extends LXModulator
   }
 
   /*
-   * UIModulatorControls<>
+   * UIModulatorControls
    */
+  @Override
   public void buildModulatorControls(
       LXStudio.UI ui, UIModulator uiModulator, AudioStemModulator modulator) {
 

--- a/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
+++ b/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java
@@ -1,6 +1,5 @@
 package titanicsend.audio;
 
-import heronarts.glx.ui.UI2dComponent;
 import heronarts.glx.ui.UI2dContainer;
 import heronarts.glx.ui.UI2dContainer.Position;
 import heronarts.glx.ui.component.UIKnob;
@@ -163,23 +162,15 @@ public class AudioStemModulator extends LXModulator
     this.addColumn(
         controls,
         50.0f,
-        new UI2dComponent[] {
-          this.newDropMenu(this.stem), this.newKnob(this.outputMode).setPosition(0, 6)
-        });
-
+        this.newDropMenu(this.stem),
+        this.newKnob(this.outputMode).setPosition(0, 6));
+    this.addColumn(controls, UIKnob.WIDTH, this.newKnob(this.emaMs), this.newKnob(this.waveshape));
     this.addColumn(
-        controls,
-        UIKnob.WIDTH,
-        new UI2dComponent[] {this.newKnob(this.emaMs), this.newKnob(this.waveshape)});
-
-    this.addColumn(
-        controls,
-        UIKnob.WIDTH + 18,
-        new UI2dComponent[] {this.newKnob(this.slope), this.newKnob(this.accRate)});
+        controls, UIKnob.WIDTH + 18, this.newKnob(this.slope), this.newKnob(this.accRate));
 
     UIMeter meter = UIMeter.newVerticalMeter(ui, this, 12, 2 * UIKnob.HEIGHT);
 
-    this.addColumn(controls, UIKnob.WIDTH, new UI2dComponent[] {meter});
+    this.addColumn(controls, UIKnob.WIDTH, meter);
 
     controls.addToContainer(uiModulator, Position.LEFT);
   }

--- a/audio-stems/src/main/java/titanicsend/audio/AudioStems.java
+++ b/audio-stems/src/main/java/titanicsend/audio/AudioStems.java
@@ -1,5 +1,7 @@
 package titanicsend.audio;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -16,8 +18,8 @@ import heronarts.lx.parameter.ObjectParameter;
 import heronarts.lx.utils.LXUtils;
 import heronarts.lx.utils.ObservableList;
 import java.io.File;
-import java.io.FileReader;
 import java.io.InputStream;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,7 +125,7 @@ public class AudioStems extends LXComponent implements LXOscListener {
 
     // Load from file
     if (file.exists()) {
-      try (FileReader fr = new FileReader(file)) {
+      try (Reader fr = Files.newBufferedReader(file.toPath(), UTF_8)) {
         JsonObject obj = new Gson().fromJson(fr, JsonObject.class);
         if (obj.has(KEY_STEMS)) {
           JsonArray stemsArray = obj.getAsJsonArray(KEY_STEMS);

--- a/audio-stems/src/main/java/titanicsend/audio/AudioStemsPlugin.java
+++ b/audio-stems/src/main/java/titanicsend/audio/AudioStemsPlugin.java
@@ -18,7 +18,8 @@ public class AudioStemsPlugin implements LXStudio.Plugin {
 
   @Override
   public void initialize(LX lx) {
-    lx.engine.registerComponent("audioStems", this.audioStems = new AudioStems(lx));
+    this.audioStems = new AudioStems(lx);
+    lx.engine.registerComponent("audioStems", this.audioStems);
 
     // This will get picked up by the package import, no need to directly add.
     // lx.registry.addModulator(AudioStemModulator.class);


### PR DESCRIPTION
Fixed the following warnings:

```
[WARNING] /Users/alook/te/LXStudio-TE/audio-stems/src/main/java/titanicsend/audio/AudioStems.java:[126,28] [DefaultCharset] Implicit use of the platform default charset, which can result in differing behaviour between JVM executions or incorrect behavior if the encoding of the data source doesn't match expectations.
    (see https://errorprone.info/bugpattern/DefaultCharset)
  Did you mean 'try (Reader fr = Files.newBufferedReader(file.toPath(), UTF_8)) {' or 'try (Reader fr = Files.newBufferedReader(file.toPath(), Charset.defaultCharset())) {'?

[WARNING] /Users/alook/te/LXStudio-TE/audio-stems/src/main/java/titanicsend/audio/AudioStemsPlugin.java:[21,63] [AssignmentExpression] The use of an assignment expression can be surprising and hard to read; consider factoring out the assignment to a separate statement.
    (see https://errorprone.info/bugpattern/AssignmentExpression)

[WARNING] /Users/alook/te/LXStudio-TE/audio-stems/src/main/java/titanicsend/audio/AudioStemModulator.java:[153,15] [MissingOverride] buildModulatorControls implements method in UIModulatorControls; expected @Override
    (see https://errorprone.info/bugpattern/MissingOverride)
  Did you mean '@Override public void buildModulatorControls('?
```