### PR TITLE
errorprone compiler warnings: instanceof pattern-matching

### DIFF
--- a/osc-remapper/src/main/java/titanicsend/oscremapper/config/ConfigLoader.java
+++ b/osc-remapper/src/main/java/titanicsend/oscremapper/config/ConfigLoader.java
@@ -234,12 +234,12 @@ public class ConfigLoader {
   /** Get integer value from map with default */
   private static int getInt(Map<String, Object> map, String key, int defaultValue) {
     Object value = map.get(key);
-    if (value instanceof Number) {
-      return ((Number) value).intValue();
+    if (value instanceof Number number) {
+      return number.intValue();
     }
-    if (value instanceof String) {
+    if (value instanceof String string) {
       try {
-        return Integer.parseInt((String) value);
+        return Integer.parseInt(string);
       } catch (NumberFormatException e) {
         LOG.error("Invalid integer value for %s: %s", key, value);
       }

--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -242,14 +242,14 @@ public class TECommonControls {
     double value = 0d;
     double v0 = 0d;
     double v1 = 0d;
-    if (oldControl instanceof CompoundParameter) {
+    if (oldControl instanceof CompoundParameter compoundParameter) {
       value = oldControl.getValue();
-      v0 = ((CompoundParameter) oldControl).range.v0;
-      v1 = ((CompoundParameter) oldControl).range.v1;
-    } else if (oldControl instanceof BoundedParameter) {
-      value = ((BoundedParameter) oldControl).getValue();
-      v0 = ((BoundedParameter) oldControl).range.v0;
-      v1 = ((BoundedParameter) oldControl).range.v1;
+      v0 = compoundParameter.range.v0;
+      v1 = compoundParameter.range.v1;
+    } else if (oldControl instanceof BoundedParameter boundedParameter) {
+      value = boundedParameter.getValue();
+      v0 = boundedParameter.range.v0;
+      v1 = boundedParameter.range.v1;
     }
     LXListenableNormalizedParameter newControl = updateParam(oldControl, newLabel, value, v0, v1);
     setControl(tag, newControl);
@@ -259,8 +259,8 @@ public class TECommonControls {
   public TECommonControls setNormalizationCurve(
       TEControlTag tag, BoundedParameter.NormalizationCurve curve) {
     LXListenableNormalizedParameter p = getLXControl(tag);
-    if (p instanceof BoundedParameter) {
-      ((BoundedParameter) p).setNormalizationCurve(curve);
+    if (p instanceof BoundedParameter boundedParameter) {
+      boundedParameter.setNormalizationCurve(curve);
     } else {
       TE.log("Warning: setNormalizationCurve() can not be called on parameter " + tag.toString());
     }

--- a/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
+++ b/te-app/src/main/java/titanicsend/pattern/TECommonControls.java
@@ -282,49 +282,41 @@ public class TECommonControls {
   }
 
   private static LXListenableNormalizedParameter updateParam(
-      LXListenableNormalizedParameter oldControl,
-      String label,
-      double value,
-      double v0,
-      double v1) {
-    LXListenableNormalizedParameter newControl;
-    if (oldControl instanceof CompoundParameter) {
-      newControl =
-          (CompoundParameter)
-              new CompoundParameter(label, value, v0, v1)
-                  .setNormalizationCurve(((CompoundParameter) oldControl).getNormalizationCurve())
-                  .setExponent(oldControl.getExponent())
-                  .setDescription(oldControl.getDescription())
-                  .setPolarity(oldControl.getPolarity())
-                  .setUnits(oldControl.getUnits());
-    } else if (oldControl instanceof BoundedParameter) {
-      newControl =
-          (BoundedParameter)
-              new BoundedParameter(label, value, v0, v1)
-                  .setNormalizationCurve(((BoundedParameter) oldControl).getNormalizationCurve())
-                  .setExponent(oldControl.getExponent())
-                  .setDescription(oldControl.getDescription())
-                  .setPolarity(oldControl.getPolarity())
-                  .setUnits(oldControl.getUnits());
-    } else if (oldControl instanceof BooleanParameter) {
-      newControl =
-          (BooleanParameter)
-              new BooleanParameter(label)
-                  .setMode(((BooleanParameter) oldControl).getMode())
-                  .setDescription(oldControl.getDescription())
-                  .setUnits(oldControl.getUnits());
-    } else if (oldControl instanceof DiscreteParameter) {
-      newControl =
-          (DiscreteParameter)
-              new DiscreteParameter(label, ((DiscreteParameter) oldControl).getOptions())
-                  .setIncrementMode(((DiscreteParameter) oldControl).getIncrementMode())
-                  .setDescription(oldControl.getDescription())
-                  .setUnits(oldControl.getUnits());
-    } else {
-      TE.error("Unrecognized control type in TE Common Control " + oldControl.getClass().getName());
-      return oldControl;
+      LXListenableNormalizedParameter old, String label, double value, double v0, double v1) {
+    switch (old) {
+      case CompoundParameter compound -> {
+        return new CompoundParameter(label, value, v0, v1)
+            .setNormalizationCurve(compound.getNormalizationCurve())
+            .setExponent(old.getExponent())
+            .setDescription(old.getDescription())
+            .setPolarity(old.getPolarity())
+            .setUnits(old.getUnits());
+      }
+      case BoundedParameter bounded -> {
+        return new BoundedParameter(label, value, v0, v1)
+            .setNormalizationCurve(bounded.getNormalizationCurve())
+            .setExponent(old.getExponent())
+            .setDescription(old.getDescription())
+            .setPolarity(old.getPolarity())
+            .setUnits(old.getUnits());
+      }
+      case BooleanParameter bool -> {
+        return new BooleanParameter(label)
+            .setMode(bool.getMode())
+            .setDescription(old.getDescription())
+            .setUnits(old.getUnits());
+      }
+      case DiscreteParameter discrete -> {
+        return new DiscreteParameter(label, discrete.getOptions())
+            .setIncrementMode(discrete.getIncrementMode())
+            .setDescription(old.getDescription())
+            .setUnits(old.getUnits());
+      }
+      default -> {
+        TE.error("Unrecognized control type in TE Common Control " + old.getClass().getName());
+        return old;
+      }
     }
-    return newControl;
   }
 
   /**

--- a/te-app/src/main/java/titanicsend/pattern/TEPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/TEPattern.java
@@ -254,10 +254,10 @@ public abstract class TEPattern extends DmxPattern {
   /** Set all current parameter values as the defaults for this pattern instance */
   public void captureDefaults() {
     for (LXParameter p : this.getParameters()) {
-      if (p instanceof LXListenableParameter
+      if (p instanceof LXListenableParameter lXListenableParameter
           && !isHiddenControl(p)
           && !p.getPath().equals(KEY_PRESET_SELECTOR)) {
-        captureDefault((LXListenableParameter) p);
+        captureDefault(lXListenableParameter);
       }
     }
   }
@@ -274,7 +274,9 @@ public abstract class TEPattern extends DmxPattern {
     } else {
       // Use base value for modulated parameters
       double value =
-          p instanceof CompoundParameter ? ((CompoundParameter) p).getBaseValue() : p.getValue();
+          p instanceof CompoundParameter compoundParameter
+              ? compoundParameter.getBaseValue()
+              : p.getValue();
       this.defaults.put(p.getPath(), value);
       ((LXListenableParameter) p).reset(value);
     }


### PR DESCRIPTION
Java `instanceof` now supports pattern-matching.

instead of:
```java
if (p instanceof LXListenableParameter) {
  captureDefault((LXListenableParameter) p);
}
```

now you can do:
```java
if (p instanceof LXListenableParameter listenableParam) {
  captureDefault(listenableParam);
}
```

basically you can add a variable name after `instanceof` ClassName , and that variable name will already be casted. Kinda handy / makes things a bit more readable!

Details here: https://docs.oracle.com/en/java/javase/18/language/pattern-matching-instanceof-operator.html