### PR TITLE
Add pattern for testing Mothership windows

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -161,6 +161,7 @@ import titanicsend.pattern.justin.GammaTestPattern;
 import titanicsend.pattern.justin.MothershipDrivingPattern;
 import titanicsend.pattern.justin.TEGradientPattern;
 import titanicsend.pattern.justin.TESolidPattern;
+import titanicsend.pattern.justin.TestMothershipWindow;
 import titanicsend.pattern.justin.TwoColorPattern;
 import titanicsend.pattern.look.PolySpiral;
 import titanicsend.pattern.look.SigmoidDanceAudioLevels;
@@ -505,6 +506,7 @@ public class TEApp extends LXStudio {
       lx.registry.addPattern(TwoColorPattern.class);
       lx.registry.addPattern(MothershipDrivingPattern.class);
       lx.registry.addPattern(GammaTestPattern.class);
+      lx.registry.addPattern(TestMothershipWindow.class);
 
       // Midi surface names for use with BomeBox
       lx.engine.midi.registerSurface(APC40Mk2.class);

--- a/te-app/src/main/java/titanicsend/color/TEColorParameter.java
+++ b/te-app/src/main/java/titanicsend/color/TEColorParameter.java
@@ -140,6 +140,16 @@ public class TEColorParameter extends ColorParameter implements GradientUtils.Gr
     return (TEColorParameter) super.setDescription(description);
   }
 
+  public TEColorParameter setColorSource(ColorSource colorSource) {
+    this.colorSource.setValue(colorSource);
+    return this;
+  }
+
+  public TEColorParameter setBlendMode(BlendMode blendMode) {
+    this.blendMode.setValue(blendMode);
+    return this;
+  }
+
   @Override
   public LXListenableNormalizedParameter getRemoteControl() {
     return this.offset;

--- a/te-app/src/main/java/titanicsend/pattern/justin/TestMothershipWindow.java
+++ b/te-app/src/main/java/titanicsend/pattern/justin/TestMothershipWindow.java
@@ -1,0 +1,134 @@
+package titanicsend.pattern.justin;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.LXComponentName;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.EnumParameter;
+import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.pattern.LXPattern;
+import java.util.ArrayList;
+import java.util.List;
+import titanicsend.color.TEColorParameter;
+
+/** A test pattern for lighting up specific Mothership windows and slices */
+@LXCategory(LXCategory.TEST)
+@LXComponentName("Test Mothership Window")
+public class TestMothershipWindow extends LXPattern {
+
+  public enum Side {
+    BOTH("both", "b"),
+    PORT("port", "p"),
+    STARBOARD("starboard", "s");
+
+    public final String label;
+    public final String firstLetter;
+
+    private Side(String label, String firstLetter) {
+      this.label = label;
+      this.firstLetter = firstLetter;
+    }
+  }
+
+  public final EnumParameter<Side> side =
+      new EnumParameter<>("Side", Side.BOTH)
+          .setIncrementMode(DiscreteParameter.IncrementMode.RELATIVE)
+          .setWrappable(false);
+
+  public final DiscreteParameter slice =
+      new DiscreteParameter("Slice", 0, 0, 24)
+          .setOptions(
+              new String[] {
+                "All", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14",
+                "15", "16", "17", "18", "19", "20", "21", "22", "23", "24"
+              })
+          .setIncrementMode(DiscreteParameter.IncrementMode.RELATIVE)
+          .setWrappable(false);
+
+  public final DiscreteParameter window =
+      new DiscreteParameter("Window", 0, 0, 9)
+          .setOptions(new String[] {"All", "W1", "W2", "W3", "W4", "W5", "W6", "W7", "W8", "W9"})
+          .setIncrementMode(DiscreteParameter.IncrementMode.RELATIVE)
+          .setWrappable(false);
+
+  public final TEColorParameter color =
+      (TEColorParameter)
+          new TEColorParameter("Color")
+              .setColorSource(TEColorParameter.ColorSource.STATIC)
+              .setColor(LXColor.RED);
+
+  private boolean needsRefresh = true;
+  private final List<LXModel> models = new ArrayList<>();
+
+  public TestMothershipWindow(LX lx) {
+    super(lx);
+
+    addParameter("side", this.side);
+    addParameter("slice", this.slice);
+    addParameter("window", this.window);
+    addParameter("color", this.color);
+  }
+
+  @Override
+  public void onParameterChanged(LXParameter p) {
+    if (p == this.side || p == this.slice || p == this.window) {
+      this.needsRefresh = true;
+    }
+  }
+
+  @Override
+  public void onModelChanged(LXModel model) {
+    super.onModelChanged(model);
+    this.needsRefresh = true;
+  }
+
+  private void refresh() {
+    this.models.clear();
+
+    final int slice = this.slice.getValuei();
+    final Side side = this.side.getEnum();
+    final int window = this.window.getValuei();
+
+    // Slice
+    String sliceString = "slice";
+    if (slice != 0) {
+      sliceString += String.format("%02d", slice);
+    }
+
+    // Optional port or starboard
+    if (side != Side.BOTH) {
+      if (slice == 0) {
+        sliceString = side.label;
+      } else {
+        sliceString += side.firstLetter;
+      }
+    }
+    final List<LXModel> slices = getModel().sub(sliceString);
+
+    // Window
+    if (window == 0) {
+      this.models.addAll(slices);
+    } else {
+      final String windowString = "w" + window;
+      for (LXModel s : slices) {
+        this.models.addAll(s.sub(windowString));
+      }
+    }
+  }
+
+  @Override
+  protected void run(double v) {
+    if (this.needsRefresh) {
+      this.needsRefresh = false;
+      refresh();
+    }
+
+    final int color = this.color.calcColor();
+
+    for (LXModel m : this.models) {
+      setColor(m, color);
+    }
+  }
+}


### PR DESCRIPTION
Simple test pattern for checking Mothership windows for config or physical issues.

Parameters include: slice number, window number, side, and color

<img width="437" height="596" alt="image" src="https://github.com/user-attachments/assets/7195a235-58ab-4c6c-9fe9-9522f4a18f1c" />
